### PR TITLE
confgenerator: add NFS path detection

### DIFF
--- a/confgenerator/logging_receivers_test.go
+++ b/confgenerator/logging_receivers_test.go
@@ -1,0 +1,94 @@
+package confgenerator
+
+import (
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// See https://man7.org/linux/man-pages/man2/statfs.2.html
+const EXT4_SUPER_MAGIC = 0xef53
+
+func TestDetectNFSPaths(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("This unit test only runs on Linux")
+	}
+
+	testCases := []struct {
+		name            string
+		includePaths    []string
+		nfsPaths        []string
+		shouldDetectNFS bool
+	}{
+		{
+			name: "direct path",
+			includePaths: []string{
+				"/a/b/x.log",
+			},
+			nfsPaths: []string{
+				"/a/b",
+			},
+			shouldDetectNFS: true,
+		},
+		{
+			name: "wildcard file",
+			includePaths: []string{
+				"/a/b/*.log",
+			},
+			nfsPaths: []string{
+				"/a/b",
+			},
+			shouldDetectNFS: true,
+		},
+		{
+			name: "wildcard in folder",
+			includePaths: []string{
+				"/a/b/c*/*.log",
+			},
+			nfsPaths: []string{
+				"/a/b",
+			},
+			shouldDetectNFS: true,
+		},
+		// If the NFS folder is part of a wildcard, we will not be able to
+		// detect it.
+		{
+			name: "wildcard in NFS folder",
+			includePaths: []string{
+				"/a/*/*.log",
+			},
+			nfsPaths: []string{
+				"/a/b",
+			},
+			shouldDetectNFS: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := LoggingReceiverFiles{
+				IncludePaths: tc.includePaths,
+			}
+			m := r.mixin()
+			m.syscallStatfs = pretendStatfs(tc.nfsPaths)
+			nfsFound := m.detectNFSPaths()
+			if nfsFound != tc.shouldDetectNFS {
+				t.Fatalf("expected detectNFSPaths to return %t but returned %t", tc.shouldDetectNFS, nfsFound)
+			}
+		})
+	}
+}
+
+func pretendStatfs(paths []string) statfsFunc {
+	return func(path string, buf *syscall.Statfs_t) error {
+		for _, testPath := range paths {
+			if strings.HasPrefix(path, testPath) {
+				buf.Type = NFS_SUPER_MAGIC
+				return nil
+			}
+		}
+		buf.Type = EXT4_SUPER_MAGIC
+		return nil
+	}
+}

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -2809,7 +2809,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
             module: [default]
           static_configs:
             - targets:
-              - http://localhost:8000/data.json 
+              - http://localhost:8000/data.json
           relabel_configs:
             - source_labels: [__address__]
               target_label: __param_target
@@ -2818,7 +2818,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
               target_label: instance
               replacement: '$1'
             - target_label: __address__
-              replacement: localhost:7979 
+              replacement: localhost:7979
   service:
     pipelines:
       prom_pipeline:

--- a/integration_test/third_party_apps_test/applications/nfs/README.md
+++ b/integration_test/third_party_apps_test/applications/nfs/README.md
@@ -1,0 +1,12 @@
+# NFS
+
+This third party app test differs from the rest. The third party app test framework is used because it is somewhat similar (there is need to install and exercise a third party application before the test can work) but it does not directly map to a third party application receiver. A `files` receiver reads a log file from the shared NFS directory, and the expectations are:
+* The logs are read and sent to Cloud Logging
+* The tailed log file getting deleted from the directory is registered by the Ops Agent, and the `.nfsxxxxx` files are deleted as well
+
+## Shared values
+
+There is no official way to share values among these scripts so certain values are assumed across scripts:
+* NFS Share directory: `/mnt/nfssrv`
+* NFS Mount directory: `/var/nfsmnt`
+* Name of log file in NFS share directory: `example.log`

--- a/integration_test/third_party_apps_test/applications/nfs/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nfs/centos_rhel/install
@@ -1,0 +1,16 @@
+function setup_nfs_share {
+    NFS_SERVER_SERVICE_NAME=$1
+    NFS_SERVE_DIR=/mnt/nfssrv
+    NFS_MOUNT_DIR=/var/nfsmnt
+    sudo mkdir -p $NFS_SERVE_DIR
+    sudo chown nobody:nogroup $NFS_SERVE_DIR
+    sudo chmod 777 $NFS_SERVE_DIR
+    echo "$NFS_SERVE_DIR localhost(rw,sync,no_subtree_check)"
+    sudo exportfs -a
+    sudo systemctl restart $NFS_SERVER_SERVICE_NAME
+    sudo mkdir -p $NFS_MOUNT_DIR
+    sudo mount -t nfs localhost:$NFS_SERVE_DIR $NFS_MOUNT_DIR
+}
+
+sudo yum -y install nfs-utils
+setup_nfs_share nfs-server

--- a/integration_test/third_party_apps_test/applications/nfs/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nfs/debian_ubuntu/install
@@ -1,0 +1,16 @@
+function setup_nfs_share {
+    NFS_SERVER_SERVICE_NAME=$1
+    NFS_SERVE_DIR=/mnt/nfssrv
+    NFS_MOUNT_DIR=/var/nfsmnt
+    sudo mkdir -p $NFS_SERVE_DIR
+    sudo chown nobody:nogroup $NFS_SERVE_DIR
+    sudo chmod 777 $NFS_SERVE_DIR
+    echo "$NFS_SERVE_DIR localhost(rw,sync,no_subtree_check)"
+    sudo exportfs -a
+    sudo systemctl restart $NFS_SERVER_SERVICE_NAME
+    sudo mkdir -p $NFS_MOUNT_DIR
+    sudo mount -t nfs localhost:$NFS_SERVE_DIR $NFS_MOUNT_DIR
+}
+
+sudo apt install nfs-kernel-server
+setup_nfs_share nfs-kernel-server

--- a/integration_test/third_party_apps_test/applications/nfs/enable
+++ b/integration_test/third_party_apps_test/applications/nfs/enable
@@ -1,0 +1,23 @@
+# Configures Ops Agent to collect telemetry from the app and restart Ops Agent.
+
+set -e
+
+# Create a back up of the existing file so existing configurations are not lost.
+sudo cp /etc/google-cloud-ops-agent/config.yaml /etc/google-cloud-ops-agent/config.yaml.bak
+
+# Configure the Ops Agent.
+sudo tee /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
+logging:
+  receivers:
+    nfs_file:
+      type: files
+      include_paths: ["/var/nfsmnt/example.log"]
+  service:
+    pipelines:
+      files:
+        receivers:
+        - nfs_file
+EOF
+
+sudo service google-cloud-ops-agent restart
+sleep 60

--- a/integration_test/third_party_apps_test/applications/nfs/exercise
+++ b/integration_test/third_party_apps_test/applications/nfs/exercise
@@ -1,0 +1,10 @@
+NFS_SHARE_DIRECTORY=/mnt/nfssrv
+NFS_LOG_FILE=$NFS_SHARE_DIRECTORY/example.log
+
+sudo tee $NFS_LOG_FILE > /dev/null << EOF
+Example log line 1
+Example log line 2
+Example log line 3
+Example log line 4
+Example log line 5
+EOF

--- a/integration_test/third_party_apps_test/applications/nfs/sles/install
+++ b/integration_test/third_party_apps_test/applications/nfs/sles/install
@@ -1,0 +1,16 @@
+function setup_nfs_share {
+    NFS_SERVER_SERVICE_NAME=$1
+    NFS_SERVE_DIR=/mnt/nfssrv
+    NFS_MOUNT_DIR=/var/nfsmnt
+    sudo mkdir -p $NFS_SERVE_DIR
+    sudo chown nobody:nogroup $NFS_SERVE_DIR
+    sudo chmod 777 $NFS_SERVE_DIR
+    echo "$NFS_SERVE_DIR localhost(rw,sync,no_subtree_check)"
+    sudo exportfs -a
+    sudo systemctl restart $NFS_SERVER_SERVICE_NAME
+    sudo mkdir -p $NFS_MOUNT_DIR
+    sudo mount -t nfs localhost:$NFS_SERVE_DIR $NFS_MOUNT_DIR
+}
+
+sudo zypper install nfs-kernel-server
+setup_nfs_share nfs-kernel-server


### PR DESCRIPTION
## Description
This draft PR shows adding detection to the Ops Agent for NFS include paths in the file receiver. Since NFS does not support `inotify`, the Ops Agent would detect the include paths from the config and if one of the include paths for that receiver is an NFS directory, it switches that tail plugin to use the `fstat` backend instead of `inotify`.

## Related issue
[b/369376689](http://b/369376689)

## How has this been tested?
All testing of this was done manually on a system with an NFS mounted directory. TODO: add an integration test that automates the environment I was using to test this manually.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
