### PR TITLE
couchdb test improvements

### DIFF
--- a/integration_test/third_party_apps_test/applications/couchdb/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/couchdb/centos_rhel/install
@@ -28,7 +28,10 @@ EOF
     ;;
 esac
 
-sudo yum install -y couchdb
+# TODO(b/370026125): the logging receiver doesn't work on RPM-based
+# distros without manually configuring couchdb to log to a file.
+# This took effect in 3.4.0, so pin to 3.3.3 for the tests.
+sudo yum install -y couchdb-3.3.3
 
 cat << EOF > local.ini
 [couchdb]

--- a/integration_test/third_party_apps_test/applications/couchdb/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/couchdb/centos_rhel/install
@@ -47,3 +47,24 @@ sudo chmod 0755 /opt/couchdb/etc/local.ini
 
 sudo systemctl enable couchdb 
 sudo systemctl restart couchdb
+
+timeout 60s bash <<EOF
+wait_for_couchdb() {
+    until curl http://admin:otelp@localhost:5984 > /dev/null 2>&1
+    do
+        echo "Waiting for couchdb to start. . ."
+        sleep "1"
+    done
+}
+
+wait_for_couchdb
+
+sleep 5
+
+echo "couchdb started"
+EOF
+
+# https://docs.couchdb.org/en/stable/setup/single-node.html
+curl -X PUT http://admin:otelp@localhost:5984/_users
+curl -X PUT http://admin:otelp@localhost:5984/_replicator
+curl -X PUT http://admin:otelp@localhost:5984/_global_changes

--- a/integration_test/third_party_apps_test/applications/couchdb/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/couchdb/debian_ubuntu/install
@@ -40,5 +40,25 @@ sudo chown couchdb:couchdb /opt/couchdb/etc/local.ini
 sudo chmod 0755 /opt/couchdb/etc/local.ini
 
 sudo systemctl enable couchdb
-
 sudo systemctl restart couchdb
+
+timeout 60s bash <<EOF
+wait_for_couchdb() {
+    until curl http://admin:otelp@localhost:5984 > /dev/null 2>&1
+    do
+        echo "Waiting for couchdb to start. . ."
+        sleep "1"
+    done
+}
+
+wait_for_couchdb
+
+sleep 5
+
+echo "couchdb started"
+EOF
+
+# https://docs.couchdb.org/en/stable/setup/single-node.html
+curl -X PUT http://admin:otelp@localhost:5984/_users
+curl -X PUT http://admin:otelp@localhost:5984/_replicator
+curl -X PUT http://admin:otelp@localhost:5984/_global_changes

--- a/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
@@ -23,6 +23,35 @@ description: |-
   database metrics, such as how many are open and the number of operations. The
   integration collects general CouchDB and access logs and parses them into a JSON
   payload. The result includes fields for user, host, level, and message.
+configure_integration: |-
+  This integration does not require any additional configuration with
+  CouchDB versions prior to 3.4.0, or on Debian-based distributions.
+
+  As of version 3.4.0, CouchDB behaves differently on RPM-based
+  distributions (like RHEL or Rocky Linux). To make CouchDB work with
+  this logging receiver's default configuration on such systems, you must
+  configure Apache CouchDB to write to `/var/log/couchdb/couchdb.log`
+  instead of journald.
+
+  To write logs to `/var/log/couchdb/couchdb.log`, complete the
+  following steps:
+
+  1. Create the file `/opt/couchdb/etc/local.d/ops-agent-filelog.ini`.
+
+  1. Add the following lines to the file:
+
+     ```none
+     [log]
+     writer = file
+     file = /var/log/couchdb/couchdb.log
+     level = info
+     ```
+
+  1. Restart Apache CouchDB:
+
+     ```
+     sudo systemctl restart couchdb
+     ```
 minimum_supported_agent_version:
   metrics: 2.10.0
   logging: 2.11.0


### PR DESCRIPTION
## Description
`_users`, `_replicator` and `_global_changes` need to be created manually for single-node deployments. (This eliminates a bunch of log spam during the test.)

Explicitly configure file logging until https://github.com/apache/couchdb/issues/5261 is resolved.

## Related issue
[b/370026125](http://b/370026125)

## How has this been tested?
Local test passed, will let presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
