### PR TITLE
Use more specific network check URLs

### DIFF
--- a/internal/healthchecks/network_check.go
+++ b/internal/healthchecks/network_check.go
@@ -48,16 +48,18 @@ var (
 			successMessage:   "Request to the Monitoring API was successful.",
 			healthCheckError: MonApiConnErr,
 		},
-		// TODO(b/321220138): restore this once there's a more reliable endpoint.
-		// {
-		// 	name:             "Packages API",
-		// 	url:              "https://packages.cloud.google.com",
-		// 	successMessage:   "Request to packages.cloud.google.com was successful.",
-		// 	healthCheckError: PacApiConnErr,
-		// },
+		{
+			name: "Packages API",
+			// We don't really care that the thing being fetched is an RPM key, just
+			// that we *can* fetch it at all, regardless of what distro we're running
+			// under.
+			url:              "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
+			successMessage:   "Request to packages.cloud.google.com was successful.",
+			healthCheckError: PacApiConnErr,
+		},
 		{
 			name:             "dl.google.com",
-			url:              "https://dl.google.com",
+			url:              "https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
 			successMessage:   "Request to dl.google.com was successful.",
 			healthCheckError: DLApiConnErr,
 		},


### PR DESCRIPTION
## Description
This reduces the likelihood of a redirect which can cause superficial errors in network-constrained environments.

## Related issue
[b/369437667](http://b/369437667), [b/321220138](http://b/321220138)

## How has this been tested?
Will let presubmits run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
