### PR TITLE
[Testing] Remove sles-15-sp-sqp iamge from the list of test images

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -129,7 +129,6 @@ targets:
           representative:
           - suse-cloud:sles-15
           exhaustive:
-          - suse-sap-cloud:sles-15-sp2-sap
           - suse-sap-cloud:sles-15-sp6-sap
           - opensuse-cloud:opensuse-leap
           - opensuse-cloud=opensuse-leap-15-5-v20240516-x86-64


### PR DESCRIPTION
## Description
SLES 15 SP2 for SAP will reach EOL [Dec 2024](https://cloud.google.com/compute/docs/images/os-details#suse_linux_enterprise_server_sles). 

## Related issue
[b/374757288](http://b/374757288)

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
