### PR TITLE
Dockerfile support for Ubuntu 24.10 Oracular + Updated Instructions for running ops agent integration tests against the new distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1024,7 +1024,7 @@ ARG OPENJDK_MAJOR_VERSION
 RUN set -x; apt-get update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
 		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential cmake bison flex file libsystemd-dev \
+		build-essential cmake bison flex file systemd-dev debhelper libsystemd-dev \
 		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip
 
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1014,6 +1014,107 @@ FROM scratch AS noble
 COPY --from=noble-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-noble.tgz
 COPY --from=noble-build /google-cloud-ops-agent*.deb /
 
+# ======================================
+# Build Ops Agent for ubuntu-oracular
+# ======================================
+
+FROM ubuntu:oracular AS oracular-build-base
+ARG OPENJDK_MAJOR_VERSION
+
+RUN set -x; apt-get update && \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
+		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
+		build-essential cmake bison flex file libsystemd-dev \
+		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip
+
+SHELL ["/bin/bash", "-c"]
+
+# Install golang
+ARG TARGETARCH
+ARG GO_VERSION
+ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+
+FROM oracular-build-base AS oracular-build-otel
+WORKDIR /work
+# Download golang deps
+COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
+RUN cd submodules/opentelemetry-operations-collector && go mod download
+
+COPY ./submodules/opentelemetry-java-contrib submodules/opentelemetry-java-contrib
+# Install gradle. The first invocation of gradlew does this
+RUN cd submodules/opentelemetry-java-contrib && ./gradlew --no-daemon -Djdk.lang.Process.launchMechanism=vfork tasks
+COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
+COPY ./builds/otel.sh .
+RUN \
+    unset OTEL_TRACES_EXPORTER && \
+    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
+    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
+    ./otel.sh /work/cache/
+
+FROM oracular-build-base AS oracular-build-fluent-bit
+WORKDIR /work
+COPY ./submodules/fluent-bit submodules/fluent-bit
+COPY ./builds/fluent_bit.sh .
+RUN ./fluent_bit.sh /work/cache/
+
+
+FROM oracular-build-base AS oracular-build-systemd
+WORKDIR /work
+COPY ./systemd systemd
+COPY ./builds/systemd.sh .
+RUN ./systemd.sh /work/cache/
+
+
+FROM oracular-build-base AS oracular-build-golang-base
+WORKDIR /work
+COPY go.mod go.sum ./
+# Fetch dependencies
+RUN go mod download
+COPY confgenerator confgenerator
+COPY apps apps
+COPY internal internal
+
+
+FROM oracular-build-golang-base AS oracular-build-diagnostics
+WORKDIR /work
+COPY cmd/google_cloud_ops_agent_diagnostics cmd/google_cloud_ops_agent_diagnostics
+COPY ./builds/ops_agent_diagnostics.sh .
+RUN ./ops_agent_diagnostics.sh /work/cache/
+
+
+FROM oracular-build-golang-base AS oracular-build-wrapper
+WORKDIR /work
+COPY cmd/agent_wrapper cmd/agent_wrapper
+COPY ./builds/agent_wrapper.sh .
+RUN ./agent_wrapper.sh /work/cache/
+
+
+FROM oracular-build-golang-base AS oracular-build
+WORKDIR /work
+COPY . /work
+
+# Run the build script once to build the ops agent engine to a cache
+RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
+WORKDIR /tmp/cache_run/golang
+RUN ./pkg/deb/build.sh || true &> /dev/null
+WORKDIR /work
+
+COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
+COPY --from=oracular-build-otel /work/cache /work/cache
+COPY --from=oracular-build-fluent-bit /work/cache /work/cache
+COPY --from=oracular-build-systemd /work/cache /work/cache
+COPY --from=oracular-build-diagnostics /work/cache /work/cache
+COPY --from=oracular-build-wrapper /work/cache /work/cache
+RUN ./pkg/deb/build.sh
+
+FROM scratch AS oracular
+COPY --from=oracular-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-oracular.tgz
+COPY --from=oracular-build /google-cloud-ops-agent*.deb /
+
 FROM scratch
 COPY --from=centos8 /* /
 COPY --from=rockylinux9 /* /
@@ -1024,3 +1125,4 @@ COPY --from=sles15 /* /
 COPY --from=focal /* /
 COPY --from=jammy /* /
 COPY --from=noble /* /
+COPY --from=oracular /* /

--- a/dev-docs/new-distro.md
+++ b/dev-docs/new-distro.md
@@ -41,14 +41,21 @@ manifest as runtime errors that won't show up until tests are run.
     your new distro. For example, in
     [kokoro/config/build/presubmit/bullseye_x86_64.gcl](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/kokoro/config/build/presubmit/bullseye_x86_64.gcl)
     or [kokoro/config/build/presubmit/bullseye_aarch64.gcl](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/kokoro/config/build/presubmit/bullseye_aarch64.gcl),
-    replace `bullseye` with `$DISTRO_SHORT` and change `deb` to `rpm` if
-    needed. Then in
+
     [kokoro/config/test/ops_agent/presubmit/bullseye_x86_64.gcl](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/kokoro/config/test/ops_agent/presubmit/bullseye_x86_64.gcl)
     or [kokoro/config/test/ops_agent/presubmit/bullseye_aarch64.gcl](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/kokoro/config/test/ops_agent/presubmit/bullseye_aarch64.gcl),
-    replace `image_lists.bullseye_x86_64.presubmit` with
-    `$DISTRO_FAMILY` (in a single-element list, like `['suse-cloud:sles-15']`).
-    This will cause the bullseye Kokoro build to build and test your
-    distro instead.
+   
+    [kokoro/config/test/third_party_apps/presubmit/bullseye_x86_64.gcl](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/kokoro/config/test/third_party_apps/presubmit/bullseye_x86_64.gcl)
+    or [kokoro/config/test/third_party_apps/presubmit/bullseye_aarch64.gcl](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/kokoro/config/test/third_party_apps/presubmit/bullseye_aarch64.gcl)
+
+    replace `bullseye` with `$DISTRO_SHORT` and change `deb` to `rpm` if
+    needed.
+
+    Example PR: https://github.com/GoogleCloudPlatform/ops-agent/pull/1705/files
+
+1. Include a entry for the new distro in [project.yaml](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/project.yaml).
+
+   Example PR: https://github.com/GoogleCloudPlatform/ops-agent/pull/1705/files#diff-d18ef7c38e4b3b4766026d7a2334c5e47e635d0a62638653186c2faabb105a46
 
 1.  Make a PR at this point if you haven't already. GitHub will kick off
     unit tests and integration tests for your PR. **Ignore any

--- a/dev-docs/new-distro.md
+++ b/dev-docs/new-distro.md
@@ -53,7 +53,7 @@ manifest as runtime errors that won't show up until tests are run.
 
     Example PR: https://github.com/GoogleCloudPlatform/ops-agent/pull/1705/files
 
-1. Include a entry for the new distro in [project.yaml](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/project.yaml).
+1. Temporarily include an entry for the new distro in [project.yaml](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/project.yaml).
 
    Example PR: https://github.com/GoogleCloudPlatform/ops-agent/pull/1705/files#diff-d18ef7c38e4b3b4766026d7a2334c5e47e635d0a62638653186c2faabb105a46
 
@@ -65,8 +65,8 @@ manifest as runtime errors that won't show up until tests are run.
     for details.)
 
 1.  Once builds and "Ops Agent integration test" (AKA `ops_agent_test`) are
-    passing, Revert the temporary changes to the Kokoro configs (the two
-    `bullseye_$arch.gcl` files in the earlier step). Get your PR reviewed and
+    passing, revert the temporary changes to the Kokoro configs (the
+    `bullseye_$arch.gcl` files in the earlier step) and to the `project.yaml`. Get your PR reviewed and
     merge it to `master`.
 
 ### Running `third_party_apps_test` against the new distro

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -207,7 +207,7 @@ RUN ln -fs /usr/lib/systemd /lib/systemd` + installJava + installCMake,
 		install_packages: `RUN set -x; apt-get update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
 		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential cmake bison flex file libsystemd-dev \
+		build-essential cmake bison flex file systemd-dev debhelper libsystemd-dev \
 		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "ubuntu-oracular",

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -201,6 +201,18 @@ RUN ln -fs /usr/lib/systemd /lib/systemd` + installJava + installCMake,
 		tar_distro_name:   "ubuntu-noble",
 		package_extension: "deb",
 	},
+	{
+		from_image:  "ubuntu:oracular",
+		target_name: "oracular",
+		install_packages: `RUN set -x; apt-get update && \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
+		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
+		build-essential cmake bison flex file libsystemd-dev \
+		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip`,
+		package_build:     "RUN ./pkg/deb/build.sh",
+		tar_distro_name:   "ubuntu-oracular",
+		package_extension: "deb",
+	},
 }
 
 func getDockerfileFooter() string {


### PR DESCRIPTION
## Description
1. Dockerfile support for Ubuntu 24.10 Oracular 
2. Updated instructions for running `ops_agent_test` integration tests against the new distro.

## Related issue
b/375011241

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
