### PR TITLE
Autogenerated support for oracular x86_64 and aarch64

### DIFF
--- a/kokoro/config/build/presubmit/oracular_aarch64.gcl
+++ b/kokoro/config/build/presubmit/oracular_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'oracular'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/oracular_x86_64.gcl
+++ b/kokoro/config/build/presubmit/oracular_x86_64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'oracular'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/oracular_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/oracular_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/oracular_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/oracular_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/oracular_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/oracular_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/oracular_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/oracular_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/presubmit/oracular_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/presubmit/oracular_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/presubmit/oracular_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/presubmit/oracular_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/oracular_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/oracular_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/oracular_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/release/oracular_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'oracular'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/project.yaml
+++ b/project.yaml
@@ -9,6 +9,12 @@ targets:
           - ubuntu-os-cloud:ubuntu-2410-amd64
           exhaustive:
           - ubuntu-os-cloud:ubuntu-minimal-2410-amd64
+      aarch64:
+        test_distros:
+          representative:
+          - ubuntu-os-cloud:ubuntu-2410-arm64
+          exhaustive:
+          - ubuntu-os-cloud:ubuntu-minimal-2410-arm64
   bookworm:
     package_extension:
       deb

--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,14 @@
 targets:
+  oracular:
+    package_extension:
+      deb
+    architectures:
+      x86_64:
+        test_distros:
+          representative:
+          - ubuntu-os-cloud:ubuntu-2410-amd64
+          exhaustive:
+          - ubuntu-os-cloud:ubuntu-minimal-2410-amd64
   bookworm:
     package_extension:
       deb


### PR DESCRIPTION
## Description
Add Kokoro build configs for new distro ubuntu 24.10 oracular x86_64 and aarch64

## Related issue
b/375011241

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
