### PR TITLE
Set DPkg lock timeout to 400.

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1360,7 +1360,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	// TODO(b/369656678): We see frequent errors like "Waiting for cache lock:
 	//   Could not get lock /var/lib/dpkg/lock-frontend", so add a generous timeout.
 	if IsDebianBased(vm.ImageSpec) {
-		if _, err := RunRemotely(ctx, logger, vm, "echo 'DPkg::Lock::Timeout=300' | sudo tee /etc/dpkg/dpkg.cfg.d/cache-lock-timeout.cfg"); err != nil {
+		if _, err := RunRemotely(ctx, logger, vm, "echo 'DPkg::Lock::Timeout=400' | sudo tee /etc/dpkg/dpkg.cfg.d/cache-lock-timeout.cfg"); err != nil {
 			return nil, fmt.Errorf("setting increased dpkg cache lock timeout failed: %w", err)
 		}
 	}

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1360,7 +1360,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	// TODO(b/369656678): We see frequent errors like "Waiting for cache lock:
 	//   Could not get lock /var/lib/dpkg/lock-frontend", so add a generous timeout.
 	if IsDebianBased(vm.ImageSpec) {
-		if _, err := RunRemotely(ctx, logger, vm, "echo 'DPkg::Lock::Timeout=400' | sudo tee /etc/dpkg/dpkg.cfg.d/cache-lock-timeout.cfg"); err != nil {
+		if _, err := RunRemotely(ctx, logger, vm, "echo 'DPkg::Lock::Timeout=600' | sudo tee /etc/dpkg/dpkg.cfg.d/cache-lock-timeout.cfg"); err != nil {
 			return nil, fmt.Errorf("setting increased dpkg cache lock timeout failed: %w", err)
 		}
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
