### PR TITLE
Updated postgresql version pinning to 16

### DIFF
--- a/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
@@ -4,7 +4,7 @@ sudo apt-get -y install gnupg wget
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 sudo wget --no-verbose --output-document=/etc/apt/trusted.gpg.d/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
 sudo apt-get -y update
-sudo apt-get install -y postgresql-14
+sudo apt-get install -y postgresql
 
 sudo service postgresql restart
 sudo su postgres -c "psql postgres -c \"ALTER ROLE postgres WITH PASSWORD 'abc123';\""

--- a/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
@@ -4,7 +4,7 @@ sudo apt-get -y install gnupg wget
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 sudo wget --no-verbose --output-document=/etc/apt/trusted.gpg.d/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
 sudo apt-get -y update
-sudo apt-get install -y postgresql
+sudo apt-get install -y postgresql-16
 
 sudo service postgresql restart
 sudo su postgres -c "psql postgres -c \"ALTER ROLE postgres WITH PASSWORD 'abc123';\""
@@ -30,7 +30,7 @@ sudo tee -a ${CFG_ROOT}/main/pg_hba.conf << EOF
 host  replication   replica_user  localhost  md5
 EOF
 
-sudo systemctl restart postgresql-16
+sudo systemctl restart postgresql
 
 # backup from primary to repl directory and configure replication
 sudo tee ${DATA_ROOT}/.pgpass << EOF

--- a/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
@@ -10,8 +10,8 @@ sudo service postgresql restart
 sudo su postgres -c "psql postgres -c \"ALTER ROLE postgres WITH PASSWORD 'abc123';\""
 sudo su postgres -c "psql postgres -c \"CREATE ROLE replica_user WITH REPLICATION LOGIN PASSWORD 'abc123';\""
 
-DATA_ROOT=/var/lib/postgresql/14
-CFG_ROOT=/etc/postgresql/14
+DATA_ROOT=/var/lib/postgresql/16
+CFG_ROOT=/etc/postgresql/16
 
 ### Everything following this comment is designed to set up a paused replica to get replication metrics
 sudo tee -a ${CFG_ROOT}/main/postgresql.conf << EOF
@@ -30,7 +30,7 @@ sudo tee -a ${CFG_ROOT}/main/pg_hba.conf << EOF
 host  replication   replica_user  localhost  md5
 EOF
 
-sudo systemctl restart postgresql
+sudo systemctl restart postgresql-16
 
 # backup from primary to repl directory and configure replication
 sudo tee ${DATA_ROOT}/.pgpass << EOF
@@ -63,7 +63,7 @@ EOF
 sudo chown -R postgres:postgres ${DATA_ROOT}/repl
 
 # start the replica in the background
-nohup sudo su postgres -c "/usr/lib/postgresql/14/bin/postgres -D ${DATA_ROOT}/repl" 2>/dev/null >/dev/null </dev/null &
+nohup sudo su postgres -c "/usr/lib/postgresql/16/bin/postgres -D ${DATA_ROOT}/repl" 2>/dev/null >/dev/null </dev/null &
 # give it time to start, since we put it in the background
 sleep 5
 # pause the replication so we see delay metrics populated


### PR DESCRIPTION
## Description
Updated Postgresql version pinning to 16 as postgresql 14 is not available in ubuntu 24.10 ARM.

## Related issue
b/378951907

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
