### PR TITLE
Add actions for stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 14 days.'
+          close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+          stale-issue-message: 'This issue was marked stale due to lack of activity. It will be closed in 14 days.'
+          close-issue-message: 'Closed as inacive. Feel free to reopen if this issue is still relevant.'
+          days-before-close: 14


### PR DESCRIPTION
## Description
Add actions for stale issues/PRs. Uses https://github.com/actions/stale. This will mark issues/PRs as stale after the default period with no activity (60 days), and then close them another 14 days after that if they're still stale.

## Related issue
N/A

## How has this been tested?
🚀

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
