### PR TITLE
Update links pointing to sample generated output configs

### DIFF
--- a/dev-docs/dev.md
+++ b/dev-docs/dev.md
@@ -158,14 +158,14 @@ $ tree $CONFIG_OUT
 ```
 
 *   Sample generated
-    [golden fluent bit main conf](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/testdata/valid/linux/default_config/golden_fluent_bit_main.conf)
+    [golden fluent bit main conf](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/testdata/goldens/builtin/golden/linux/fluent_bit_main.conf)
     at `$CONFIG_OUT/fluent_bit_main.conf`.
 *   Sample generated
-    [golden fluent bit parser conf](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/testdata/valid/linux/default_config/golden_fluent_bit_parser.conf)
+    [golden fluent bit parser conf](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/testdata/goldens/builtin/golden/linux/fluent_bit_parser.conf)
     at `$CONFIG_OUT/fluent_bit_parser.conf`.
 *   Sample generated
-    [golden otel conf](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/testdata/valid/linux/default_config/golden_otel.conf)
-    at `$CONFIG_OUT/otel.conf`.
+    [golden otel yaml](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml)
+    at `$CONFIG_OUT/otel.yaml`.
 
 ## Build and test manually on GCE VMs
 


### PR DESCRIPTION
## Description
Updating links to sample generated outputs from built in config in the dev Docs.

## Related issue
#1835 

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

