### PR TITLE
Pin goopack version

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -90,7 +90,10 @@ RUN Start-Process msiexec.exe `
 # Run these in a directory with a go.mod file so that "go get" doesn't need
 # a working Git installation.
 WORKDIR /goget
-RUN go install github.com/google/googet/v2/goopack@latest;
+
+# @latest has an issue with path separators, so pin to an older version for now.
+# https://github.com/google/googet/issues/83#issuecomment-2536975624
+RUN go install github.com/google/googet/v2/goopack@v2.18.4;
 
 ###############################################################################
 # Build fluent-bit


### PR DESCRIPTION
## Description
The latest version of goopack (v2.20.0) has an issue with path separators, so pin to the newest working version instead (v2.18.4).

See https://github.com/google/googet/issues/83#issuecomment-2536975624.

## Related issue
https://github.com/google/googet/issues/83#issuecomment-2536975624
[b/383588824](http://b/383588824)

## How has this been tested?
Verified manually.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
