### PR TITLE
adding windows 2025 I think

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -181,11 +181,12 @@ targets:
         test_distros:
           representative:
           - windows-cloud:windows-2016-core
-          - windows-cloud:windows-2022
+          - windows-cloud:windows-2025
           - windows-sql-cloud:sql-std-2019-win-2019
-          - windows-sql-cloud:sql-std-2022-win-2022  
+          - windows-sql-cloud:sql-std-2022-win-2022
           exhaustive:
           - windows-cloud:windows-2016
           - windows-cloud:windows-2019
           - windows-cloud:windows-2019-core
           - windows-cloud:windows-2022-core
+          - windows-cloud:windows-2025-core

--- a/project.yaml
+++ b/project.yaml
@@ -183,7 +183,7 @@ targets:
           - windows-cloud:windows-2016-core
           - windows-cloud:windows-2025
           - windows-sql-cloud:sql-std-2019-win-2019
-          - windows-sql-cloud:sql-std-2022-win-2022
+          - windows-sql-cloud:sql-std-2022-win-2025
           exhaustive:
           - windows-cloud:windows-2016
           - windows-cloud:windows-2019
@@ -191,3 +191,4 @@ targets:
           - windows-cloud:windows-2019-core
           - windows-cloud:windows-2022-core
           - windows-cloud:windows-2025-core
+          - windows-sql-cloud:sql-std-2022-win-2022

--- a/project.yaml
+++ b/project.yaml
@@ -187,6 +187,7 @@ targets:
           exhaustive:
           - windows-cloud:windows-2016
           - windows-cloud:windows-2019
+          - windows-cloud:windows-2022
           - windows-cloud:windows-2019-core
           - windows-cloud:windows-2022-core
           - windows-cloud:windows-2025-core


### PR DESCRIPTION
## Description
This PR adds the Windows 2025 images now available in GCP to `project.yaml`.

## Related issue
b/384012234

## How has this been tested?
GitHub Actions :smiley: 

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
