### PR TITLE
Add whitespace ignore to distro detector script

### DIFF
--- a/cloudbuild/new-distro-detector/run.sh
+++ b/cloudbuild/new-distro-detector/run.sh
@@ -54,7 +54,7 @@ gsutil -q cp "${LAST_KNOWN_LIST}" - \
   | tee known_families.txt
 
 # If there is a difference, print the diff, and...
-if ! diff known_families.txt current_families.txt; then
+if ! diff --ignore-all-space --ignore-blank-lines known_families.txt current_families.txt; then
   # Print instructions for handling the error.
   # Set +x temporarily so that the banner is only printed once.
   set +x


### PR DESCRIPTION
## Description
Last night the distro detector failed on an empty line in the diff. I'm not sure how that happened, and running the script over and over can't reproduce it. Regardless, we don't ever want to fail on something like that since it alerts on-call unnecessarily. This PR adds flags to the diff command to ignore blank lines and whitespace.

## Related issue
b/384688415

## How has this been tested?
I ran it the first time to test it, and reproduced the problem backwards (the one produced by the command didn't have the newline anymore). Of course this corrected it, because the no-empty-line version was then uploaded to the bucket. So I commented out the beginning of the script and manually edited the local copy of `current_families.txt` I had and added the opening newline, and testing it with and without the new flags to ensure that this scenario would be caught in the future.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
