### PR TITLE
Ops Agent Plugin - Subagents Startup Logic

### DIFF
--- a/builds/ops_agent_plugin.sh
+++ b/builds/ops_agent_plugin.sh
@@ -16,5 +16,5 @@
 set -x -e
 DESTDIR=$1
 mkdir -p "$DESTDIR/opt/google-cloud-ops-agent"
-go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/plugin" \
+go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/ops-agent-uap-plugin" \
   github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin

--- a/builds/ops_agent_plugin.sh
+++ b/builds/ops_agent_plugin.sh
@@ -16,5 +16,5 @@
 set -x -e
 DESTDIR=$1
 mkdir -p "$DESTDIR/opt/google-cloud-ops-agent"
-go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/ops-agent-uap-plugin" \
+go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/plugin" \
   github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin

--- a/builds/ops_agent_plugin.sh
+++ b/builds/ops_agent_plugin.sh
@@ -15,6 +15,6 @@
 
 set -x -e
 DESTDIR=$1
-mkdir -p "$DESTDIR/opt/google-cloud-ops-agent/libexec"
-go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_uap_plugin" \
+mkdir -p "$DESTDIR/opt/google-cloud-ops-agent"
+go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/plugin" \
   github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin

--- a/cmd/ops_agent_uap_plugin/plugin.go
+++ b/cmd/ops_agent_uap_plugin/plugin.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 
 	pb "github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin/google_guest_agent/plugin"
 )
@@ -84,11 +85,7 @@ func main() {
 	// offered mean Guest Agent was successful in installing/launching the plugin
 	// & will manage the lifecycle (start, stop, or revision change) here onwards.
 	pb.RegisterGuestAgentPluginServer(server, ps)
-
-	ctx := context.Background()
-	ps.GetStatus(ctx, &pb.GetStatusRequest{})
-	ps.Start(ctx, &pb.StartRequest{})
-
+	reflection.Register(server)
 	if err := server.Serve(listener); err != nil {
 		fmt.Fprintf(os.Stderr, "Exiting, cannot continue serving: %v\n", err)
 		os.Exit(1)

--- a/cmd/ops_agent_uap_plugin/service_linux.go
+++ b/cmd/ops_agent_uap_plugin/service_linux.go
@@ -81,17 +81,17 @@ func (ps *OpsAgentPluginServer) Start(ctx context.Context, msg *pb.StartRequest)
 	pContext, cancel := context.WithCancel(context.Background())
 	ps.cancel = cancel
 
-	pluginInstallaPath, err := os.Executable()
+	pluginInstallPath, err := os.Executable()
 	if err != nil {
 		log.Printf("Start() failed, because it cannot determine the plugin install location: %s", err)
 		return nil, status.Error(1, err.Error())
 	}
-	pluginInstallaPath, err = filepath.EvalSymlinks(pluginInstallaPath)
+	pluginInstallPath, err = filepath.EvalSymlinks(pluginInstallPath)
 	if err != nil {
 		log.Printf("Start() failed, because it cannot determine the plugin install location: %s", err)
 		status.Error(1, err.Error())
 	}
-	pluginInstallDir := filepath.Dir(pluginInstallaPath)
+	pluginInstallDir := filepath.Dir(pluginInstallPath)
 
 	pluginStateDir := msg.GetConfig().GetStateDirectoryPath()
 	if pluginStateDir == "" {

--- a/cmd/ops_agent_uap_plugin/service_linux_test.go
+++ b/cmd/ops_agent_uap_plugin/service_linux_test.go
@@ -295,7 +295,7 @@ func Test_restartCommand_CancelContextWhenNoAttemptLeft(t *testing.T) {
 	}
 	restartCommand(ctx, cancel, cmd, mockRunCommandFunc, 0, 10, &wg)
 	if ctx.Err() == nil {
-		t.Error("restartCommand() did not cancel context")
+		t.Error("restartCommand() did not cancel context but should")
 	}
 }
 
@@ -316,11 +316,11 @@ func Test_restartCommand_DoNotCancelContextWhenCmdTerminatedBySignals(t *testing
 	}
 	restartCommand(ctx, cancel, cmd, mockRunCommandFunc, 1, 10, &wg)
 	if ctx.Err() != nil {
-		t.Error("restartCommand() canceled context")
+		t.Error("restartCommand() canceled the context but shouldn't")
 	}
 }
 
-func Test_runSubagents_terminatesWhenSpawnedGoRoutinesReturn(t *testing.T) {
+func Test_runSubagents_TerminatesWhenSpawnedGoRoutinesReturn(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	mockCmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess")
 	mockCmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
@@ -333,7 +333,7 @@ func Test_runSubagents_terminatesWhenSpawnedGoRoutinesReturn(t *testing.T) {
 	mockRestartCommandFunc := func(ctx context.Context, cancel context.CancelFunc, _ *exec.Cmd, runCommand RunCommandFunc, _ int, totalRetry int, wg *sync.WaitGroup) {
 		restartCommand(ctx, cancel, mockCmd, runCommand, 0, totalRetry, wg)
 	}
-	// the test fails if runSubagents never returns
+	// the test times out and fails if runSubagents does not returns
 	runSubagents(ctx, cancel, "", mockRestartCommandFunc, mockRunCommandFunc)
 }
 

--- a/cmd/ops_agent_uap_plugin/service_linux_test.go
+++ b/cmd/ops_agent_uap_plugin/service_linux_test.go
@@ -115,7 +115,7 @@ func Test_validateOpsAgentConfig(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := validateOpsAgentConfig(ctx, mockRunCommand, "")
+			err := validateOpsAgentConfig(ctx, "", mockRunCommand)
 			gotSuccess := (err == nil)
 			if gotSuccess != tc.wantSuccess {
 				t.Errorf("%s: validateOpsAgentConfig() failed to valide Ops Agent config: %v, want successful config validation: %v, error:%v", tc.name, gotSuccess, tc.wantSuccess, err)
@@ -153,7 +153,7 @@ func Test_generateSubagentConfigs(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := generateSubagentConfigs(ctx, mockRunCommand, "")
+			err := generateSubagentConfigs(ctx, mockRunCommand, "", "")
 			gotSuccess := (err == nil)
 			if gotSuccess != tc.wantSuccess {
 				t.Errorf("%s: generateSubagentConfigs() failed to generate subagents configs: %v, want successful config validation: %v, error:%v", tc.name, gotSuccess, tc.wantSuccess, err)
@@ -329,7 +329,7 @@ func Test_runSubagents_TerminatesWhenSpawnedGoRoutinesReturn(t *testing.T) {
 	}
 	cancel() // child go routines return immediately, because the parent context has been cancelled.
 	// the test times out and fails if runSubagents does not returns
-	runSubagents(ctx, cancel, "", mockRestartCommandFunc, runCommand)
+	runSubagents(ctx, cancel, "", "", mockRestartCommandFunc, runCommand)
 }
 
 // TestHelperProcess isn't a real test. It's used as a helper process to mock

--- a/cmd/ops_agent_uap_plugin/service_windows.go
+++ b/cmd/ops_agent_uap_plugin/service_windows.go
@@ -29,7 +29,7 @@ import (
 // between Plugin and the server itself. For e.g. service might want to update
 // plugin config to enable/disable feature here plugins can react to such requests.
 func (ps *OpsAgentPluginServer) Apply(ctx context.Context, msg *pb.ApplyRequest) (*pb.ApplyResponse, error) {
-	return &pb.ApplyResponse{}, nil
+	panic("Apply method is not implemented on Windows yet")
 }
 
 // Start starts the plugin and initiates the plugin functionality.


### PR DESCRIPTION
## Description
This PR enhanced the `Start()` method by adding functionality to start up subagents and the diagnostics service.

## Related issue
[b/380277488](https://b.corp.google.com/issues/380277488)

## How has this been tested?
Unit tests are added.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
