### PR TITLE
Reduced Go binary size by passing `-ldflags -s -w` during the build process.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ fi
 BUILD_INFO_IMPORT_PATH="github.com/GoogleCloudPlatform/ops-agent/internal/version"
 BUILD_X1="-X ${BUILD_INFO_IMPORT_PATH}.BuildDistro=${BUILD_DISTRO}"
 BUILD_X2="-X ${BUILD_INFO_IMPORT_PATH}.Version=${PKG_VERSION}"
-LD_FLAGS="${BUILD_X1} ${BUILD_X2}"
+LD_FLAGS="-s -w ${BUILD_X1} ${BUILD_X2}"
 set -x -e
 
 export PATH=/usr/local/go/bin:$PATH

--- a/builds/agent_wrapper.sh
+++ b/builds/agent_wrapper.sh
@@ -16,5 +16,5 @@
 set -x -e
 DESTDIR=$1
 mkdir -p "$DESTDIR/opt/google-cloud-ops-agent/libexec"
-go build -buildvcs=false -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_wrapper" \
+go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_wrapper" \
   github.com/GoogleCloudPlatform/ops-agent/cmd/agent_wrapper

--- a/builds/ops_agent_diagnostics.sh
+++ b/builds/ops_agent_diagnostics.sh
@@ -16,5 +16,5 @@
 set -x -e
 DESTDIR=$1
 mkdir -p "$DESTDIR/opt/google-cloud-ops-agent/libexec"
-go build -buildvcs=false -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_diagnostics" \
+go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_diagnostics" \
   github.com/GoogleCloudPlatform/ops-agent/cmd/google_cloud_ops_agent_diagnostics

--- a/builds/ops_agent_plugin.sh
+++ b/builds/ops_agent_plugin.sh
@@ -16,5 +16,5 @@
 set -x -e
 DESTDIR=$1
 mkdir -p "$DESTDIR/opt/google-cloud-ops-agent/libexec"
-go build -buildvcs=false -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_uap_plugin" \
+go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_uap_plugin" \
   github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin

--- a/builds/otel.sh
+++ b/builds/otel.sh
@@ -48,4 +48,4 @@ if [ "$SKIP_OTEL_JAVA" != "true" ]; then
 fi
 
 cd submodules/opentelemetry-operations-collector
-go build -tags=gpu -buildvcs=false -o "$DESTDIR/otelopscol" -ldflags "$LDFLAGS" ./cmd/otelopscol
+go build -tags=gpu -buildvcs=false -o "$DESTDIR/otelopscol" -ldflags "$LDFLAGS -s -w" ./cmd/otelopscol


### PR DESCRIPTION
## Description
Reduced Go binary size by passing `-ldflags -s -w` during the build process.

## Related issue

## How has this been tested?
Everything should build and execute as normal. The Ops Agent logic is not changed; all existing tests should pass for the PR.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
