### PR TITLE
MySQL test changes on SLES

### DIFF
--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -35,7 +35,9 @@ platforms_to_skip:
   # MySQL is not currently supported on various distros.
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
+  - suse-cloud:sles-12
   - suse-cloud:sles-15-arm64
+  - suse-sap-cloud:sles-12-sp5-sap
 supported_app_version: ["5.7", "8.0"]
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages

--- a/integration_test/third_party_apps_test/applications/mysql/sles/install
+++ b/integration_test/third_party_apps_test/applications/mysql/sles/install
@@ -21,7 +21,13 @@ else
   # Installation followed in: https://dev.mysql.com/doc/mysql-sles-repo-quick-guide/en/
   sudo rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
   sudo rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
-  sudo zypper -n install https://dev.mysql.com/get/${mysql_repo_pkg_name}
+  wget --output-document mysql-repos.rpm https://dev.mysql.com/get/${mysql_repo_pkg_name}
+  sudo rpm -Uvh mysql-repos.rpm
+  sudo zypper modifyrepo --disable mysql-8.4-lts-community
+  sudo zypper modifyrepo --disable mysql-connectors-community
+  sudo zypper modifyrepo --disable mysql-tools-8.4-lts-community
+  sudo zypper modifyrepo --enable mysql80-community
+  sudo zypper refresh
   sudo zypper -n install mysql-community-server
 fi
 

--- a/integration_test/third_party_apps_test/applications/mysql/sles/install
+++ b/integration_test/third_party_apps_test/applications/mysql/sles/install
@@ -14,10 +14,8 @@ if [[ "${ID}" == opensuse-leap && "${VERSION_ID}" == 15.[01] ]]; then
   sudo zypper -n install mariadb
 else
   mysql_repo_pkg_name=''
-  if [[ "${SUSE_VERSION}" == 12 ]]; then
-    mysql_repo_pkg_name=mysql80-community-release-sles12.rpm
-  elif [[ "${SUSE_VERSION}" == 15 ]]; then
-    mysql_repo_pkg_name=mysql80-community-release-sl15.rpm
+  if [[ "${SUSE_VERSION}" == 15 ]]; then
+    mysql_repo_pkg_name=mysql84-community-release-sl15-1.noarch.rpm
   fi
 
   # Installation followed in: https://dev.mysql.com/doc/mysql-sles-repo-quick-guide/en/
@@ -27,9 +25,7 @@ else
   sudo zypper -n install mysql-community-server
 fi
 
-if [[ "${SUSE_VERSION}" == 12 ]]; then
-  sudo zypper -n install libmysqlclient18
-elif [[ "${SUSE_VERSION}" == 15 ]]; then
+if [[ "${SUSE_VERSION}" == 15 ]]; then
   sudo zypper -n install libmariadb3
 fi
 

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -37,8 +37,10 @@ minimum_supported_agent_version:
 supported_operating_systems: linux
 platforms_to_skip:
   # MySQL5.7 is not supported on various distros.
+  - suse-cloud:sles-12
   - suse-cloud:sles-15
   - suse-cloud:sles-15-arm64
+  - suse-sap-cloud:sles-12-sp5-sap
   - rocky-linux-cloud:rocky-linux-8
   - rocky-linux-cloud:rocky-linux-8-optimized-gcp
   - rocky-linux-cloud:rocky-linux-8-optimized-gcp-arm64


### PR DESCRIPTION
## Description
MySQL is no longer supported on SLES 12, which went EOL in Oct 2024 -- removing it from the tests.

SLES 15 has updated installation instructions which is also fixed in this PR.

## Related issue
http://b/392091183

## How has this been tested?
Presubmits

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
