### PR TITLE
fix: remove artemis support from list of supported platforms of activemq

### DIFF
--- a/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/activemq/metadata.yaml
@@ -29,7 +29,7 @@ minimum_supported_agent_version:
   metrics: 2.11.0
   logging: 2.15.0
 supported_operating_systems: linux
-supported_app_version: ["Classic 5.8.x through 5.16.x", "Artemis 2.x"]
+supported_app_version: ["Classic 5.8.x through 5.16.x"]
 expected_metrics:
   - type: workload.googleapis.com/activemq.connection.count
     value_type: INT64


### PR DESCRIPTION
## Description
The MBean targets are different between base ActiveMQ and Artemis ActiveMQ <see screenshots>

ActiveMQ MBeans
![image](https://github.com/user-attachments/assets/ded43519-1600-4f0e-9176-74c7b4775284)

Artemis Process MBeans
![image](https://github.com/user-attachments/assets/9dbb6c85-90ee-4c6b-b6ae-63b7ad5c9900)


The target system of activemq is not going to be looking for artemis metrics

## Related issue

Resolves #1857

Potentially #1856

## How has this been tested?

This is a documentation change as the listed support should not have been added in the first place.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
