### PR TITLE
Fixed a Race Condition in the UAP Plugin Implementation

### DIFF
--- a/cmd/ops_agent_uap_plugin/plugin.go
+++ b/cmd/ops_agent_uap_plugin/plugin.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -46,8 +47,12 @@ type RunCommandFunc func(cmd *exec.Cmd) (string, error)
 // PluginServer implements the plugin RPC server interface.
 type OpsAgentPluginServer struct {
 	pb.UnimplementedGuestAgentPluginServer
-	server     *grpc.Server
-	cancel     context.CancelFunc
+	server *grpc.Server
+
+	// mu protects the cancel field.
+	mu     sync.Mutex
+	cancel context.CancelFunc
+
 	runCommand RunCommandFunc
 }
 

--- a/cmd/ops_agent_uap_plugin/service_linux.go
+++ b/cmd/ops_agent_uap_plugin/service_linux.go
@@ -72,14 +72,17 @@ func (ps *OpsAgentPluginServer) Apply(ctx context.Context, msg *pb.ApplyRequest)
 // Until plugin receives Start request plugin is expected to be not functioning
 // and just listening on the address handed off waiting for the request.
 func (ps *OpsAgentPluginServer) Start(ctx context.Context, msg *pb.StartRequest) (*pb.StartResponse, error) {
+	ps.mu.Lock()
 	if ps.cancel != nil {
 		log.Printf("The Ops Agent plugin is started already, skipping the current request")
+		ps.mu.Unlock()
 		return &pb.StartResponse{}, nil
 	}
 	log.Printf("Received a Start request: %s. Starting the Ops Agent", msg)
 
 	pContext, cancel := context.WithCancel(context.Background())
 	ps.cancel = cancel
+	ps.mu.Unlock()
 
 	pluginInstallPath, err := os.Executable()
 	if err != nil {
@@ -101,8 +104,7 @@ func (ps *OpsAgentPluginServer) Start(ctx context.Context, msg *pb.StartRequest)
 	// Find existing ops agent installation, and conflicting legacy agent installation.
 	foundConflictingInstallations, err := findPreExistentAgents(pContext, ps.runCommand, AgentSystemdServiceNames)
 	if foundConflictingInstallations || err != nil {
-		ps.cancel()
-		ps.cancel = nil
+		ps.Stop(ctx, &pb.StopRequest{Cleanup: false})
 		log.Printf("Start() failed: %s", err)
 		return nil, status.Error(1, err.Error())
 	}
@@ -110,15 +112,13 @@ func (ps *OpsAgentPluginServer) Start(ctx context.Context, msg *pb.StartRequest)
 	// Ops Agent config validation
 	if err := validateOpsAgentConfig(pContext, pluginInstallDir, ps.runCommand); err != nil {
 		log.Printf("Start() failed: %s", err)
-		ps.cancel()
-		ps.cancel = nil
+		ps.Stop(ctx, &pb.StopRequest{Cleanup: false})
 		return nil, status.Errorf(1, "failed to validate Ops Agent config: %s", err)
 	}
 	// Subagent config generation
 	if err := generateSubagentConfigs(pContext, ps.runCommand, pluginInstallDir, pluginStateDir); err != nil {
 		log.Printf("Start() failed: %s", err)
-		ps.cancel()
-		ps.cancel = nil
+		ps.Stop(ctx, &pb.StopRequest{Cleanup: false})
 		return nil, status.Errorf(1, "failed to generate subagent configs: %s", err)
 	}
 
@@ -135,6 +135,8 @@ func (ps *OpsAgentPluginServer) Start(ctx context.Context, msg *pb.StartRequest)
 // For e.g. if plugins want to stop some task it was performing or remove some
 // state before exiting it can be done on this request.
 func (ps *OpsAgentPluginServer) Stop(ctx context.Context, msg *pb.StopRequest) (*pb.StopResponse, error) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
 	if ps.cancel == nil {
 		log.Printf("The Ops Agent plugin is stopped already, skipping the current request")
 		return &pb.StopResponse{}, nil
@@ -152,6 +154,8 @@ func (ps *OpsAgentPluginServer) Stop(ctx context.Context, msg *pb.StopRequest) (
 // it can reported in status which is sent back to the service by agent.
 func (ps *OpsAgentPluginServer) GetStatus(ctx context.Context, msg *pb.GetStatusRequest) (*pb.Status, error) {
 	log.Println("Received a GetStatus request")
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
 	if ps.cancel == nil {
 		log.Println("The Ops Agent plugin is not running")
 		return &pb.Status{Code: 1, Results: []string{"The Ops Agent Plugin is not running."}}, nil


### PR DESCRIPTION
## Description
This PR identifies and fixes a race condition in the Ops Agent UAP plugin implementation. The setting (read) and resetting (write) of the `cancel` function in the `Start()` and `Stop()` methods should be atomic and protected by a mutex, which has been added in this PR.

## Related issue
b/380277488
## How has this been tested?
`go test -mod=mod -coverpkg="./..." -coverprofile=covprofile ./...` command triggered in the presubmit flakes due to this race condition.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
