### PR TITLE
Adding plugin .tar file to artifact.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,9 +173,6 @@ COPY --from=centos8-build-diagnostics /work/cache /work/cache
 COPY --from=centos8-build-wrapper /work/cache /work/cache
 RUN ./pkg/rpm/build.sh
 
-
-FROM centos8-build AS centos8-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -185,7 +182,7 @@ RUN ./pkg/plugin/build.sh /work/cache centos8
 FROM scratch AS centos8
 COPY --from=centos8-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-centos-8.tgz
 COPY --from=centos8-build /google-cloud-ops-agent*.rpm /
-COPY --from=centos8-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=centos8-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for rockylinux-9
@@ -289,9 +286,6 @@ COPY --from=rockylinux9-build-diagnostics /work/cache /work/cache
 COPY --from=rockylinux9-build-wrapper /work/cache /work/cache
 RUN ./pkg/rpm/build.sh
 
-
-FROM rockylinux9-build AS rockylinux9-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -301,7 +295,7 @@ RUN ./pkg/plugin/build.sh /work/cache rockylinux9
 FROM scratch AS rockylinux9
 COPY --from=rockylinux9-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-rockylinux-9.tgz
 COPY --from=rockylinux9-build /google-cloud-ops-agent*.rpm /
-COPY --from=rockylinux9-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=rockylinux9-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for debian-bookworm
@@ -400,9 +394,6 @@ COPY --from=bookworm-build-diagnostics /work/cache /work/cache
 COPY --from=bookworm-build-wrapper /work/cache /work/cache
 RUN ./pkg/deb/build.sh
 
-
-FROM bookworm-build AS bookworm-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -412,7 +403,7 @@ RUN ./pkg/plugin/build.sh /work/cache bookworm
 FROM scratch AS bookworm
 COPY --from=bookworm-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-bookworm.tgz
 COPY --from=bookworm-build /google-cloud-ops-agent*.deb /
-COPY --from=bookworm-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=bookworm-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for debian-bullseye
@@ -511,9 +502,6 @@ COPY --from=bullseye-build-diagnostics /work/cache /work/cache
 COPY --from=bullseye-build-wrapper /work/cache /work/cache
 RUN ./pkg/deb/build.sh
 
-
-FROM bullseye-build AS bullseye-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -523,7 +511,7 @@ RUN ./pkg/plugin/build.sh /work/cache bullseye
 FROM scratch AS bullseye
 COPY --from=bullseye-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-debian-bullseye.tgz
 COPY --from=bullseye-build /google-cloud-ops-agent*.deb /
-COPY --from=bullseye-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=bullseye-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for sles-12
@@ -641,9 +629,6 @@ COPY --from=sles12-build-diagnostics /work/cache /work/cache
 COPY --from=sles12-build-wrapper /work/cache /work/cache
 RUN ./pkg/rpm/build.sh
 
-
-FROM sles12-build AS sles12-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -653,7 +638,7 @@ RUN ./pkg/plugin/build.sh /work/cache sles12
 FROM scratch AS sles12
 COPY --from=sles12-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-sles-12.tgz
 COPY --from=sles12-build /google-cloud-ops-agent*.rpm /
-COPY --from=sles12-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=sles12-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for sles-15
@@ -757,9 +742,6 @@ COPY --from=sles15-build-diagnostics /work/cache /work/cache
 COPY --from=sles15-build-wrapper /work/cache /work/cache
 RUN ./pkg/rpm/build.sh
 
-
-FROM sles15-build AS sles15-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -769,7 +751,7 @@ RUN ./pkg/plugin/build.sh /work/cache sles15
 FROM scratch AS sles15
 COPY --from=sles15-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-sles-15.tgz
 COPY --from=sles15-build /google-cloud-ops-agent*.rpm /
-COPY --from=sles15-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=sles15-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for ubuntu-focal
@@ -868,9 +850,6 @@ COPY --from=focal-build-diagnostics /work/cache /work/cache
 COPY --from=focal-build-wrapper /work/cache /work/cache
 RUN ./pkg/deb/build.sh
 
-
-FROM focal-build AS focal-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -880,7 +859,7 @@ RUN ./pkg/plugin/build.sh /work/cache focal
 FROM scratch AS focal
 COPY --from=focal-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-focal.tgz
 COPY --from=focal-build /google-cloud-ops-agent*.deb /
-COPY --from=focal-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=focal-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for ubuntu-jammy
@@ -979,9 +958,6 @@ COPY --from=jammy-build-diagnostics /work/cache /work/cache
 COPY --from=jammy-build-wrapper /work/cache /work/cache
 RUN ./pkg/deb/build.sh
 
-
-FROM jammy-build AS jammy-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -991,7 +967,7 @@ RUN ./pkg/plugin/build.sh /work/cache jammy
 FROM scratch AS jammy
 COPY --from=jammy-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-jammy.tgz
 COPY --from=jammy-build /google-cloud-ops-agent*.deb /
-COPY --from=jammy-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=jammy-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for ubuntu-noble
@@ -1090,9 +1066,6 @@ COPY --from=noble-build-diagnostics /work/cache /work/cache
 COPY --from=noble-build-wrapper /work/cache /work/cache
 RUN ./pkg/deb/build.sh
 
-
-FROM noble-build AS noble-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -1102,7 +1075,7 @@ RUN ./pkg/plugin/build.sh /work/cache noble
 FROM scratch AS noble
 COPY --from=noble-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-noble.tgz
 COPY --from=noble-build /google-cloud-ops-agent*.deb /
-COPY --from=noble-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=noble-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
 # Build Ops Agent for ubuntu-oracular
@@ -1201,9 +1174,6 @@ COPY --from=oracular-build-diagnostics /work/cache /work/cache
 COPY --from=oracular-build-wrapper /work/cache /work/cache
 RUN ./pkg/deb/build.sh
 
-
-FROM oracular-build AS oracular-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -1213,7 +1183,7 @@ RUN ./pkg/plugin/build.sh /work/cache oracular
 FROM scratch AS oracular
 COPY --from=oracular-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-oracular.tgz
 COPY --from=oracular-build /google-cloud-ops-agent*.deb /
-COPY --from=oracular-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from=oracular-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 FROM scratch
 COPY --from=centos8 /* /

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -91,9 +91,6 @@ COPY --from={target_name}-build-diagnostics /work/cache /work/cache
 COPY --from={target_name}-build-wrapper /work/cache /work/cache
 {package_build}
 
-
-FROM {target_name}-build AS {target_name}-build-plugin
-WORKDIR /work
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
@@ -103,4 +100,4 @@ RUN ./pkg/plugin/build.sh /work/cache {target_name}
 FROM scratch AS {target_name}
 COPY --from={target_name}-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-{tar_distro_name}.tgz
 COPY --from={target_name}-build /google-cloud-ops-agent*.{package_extension} /
-COPY --from={target_name}-build-plugin /google-cloud-ops-agent-plugin*.tar.gz /
+COPY --from={target_name}-build /google-cloud-ops-agent-plugin*.tar.gz /

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -883,7 +883,7 @@ func InstallPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 	if gce.IsWindows(vm.ImageSpec) {
 		return installWindowsPackageFromGCS(ctx, logger, vm, gcsPath)
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, "mkdir -p /tmp/agentUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "mkdir -p /tmp/agentUpload /tmp/agentPlugin"); err != nil {
 		return err
 	}
 	if err := gce.InstallGsutilIfNeeded(ctx, logger, vm); err != nil {
@@ -897,6 +897,9 @@ func InstallPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 		return err
 	}
 	if _, err := gce.RunRemotely(ctx, logger, vm, "rm /tmp/agentUpload/*dbgsym* || echo nothing to delete"); err != nil {
+		return err
+	}
+	if _, err := gce.RunRemotely(ctx, logger, vm, "mv /tmp/agentUpload/*.tar.gz /tmp/agentPlugin || echo nothing to move"); err != nil {
 		return err
 	}
 	if IsRPMBased(vm.ImageSpec) {

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -79,8 +79,6 @@ docker run \
   build_image \
   bash <<EOF
     cp /google-cloud-ops-agent*.${PKGFORMAT} /artifacts
-    ls -l /
-    ls  -l *
     cp /google-cloud-ops-agent-plugin*.tar.gz /artifacts
 
     if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -64,8 +64,7 @@ docker buildx build . \
   -t build_image \
   --load \
   "${build_params[@]}"
-echo "Current dir: "
-pwd
+
 SIGNING_DIR="$(pwd)/kokoro/scripts/build/signing"
 if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
   RPM_SIGNING_KEY="${KOKORO_KEYSTORE_DIR}/71565_rpm-signing-key"

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -78,6 +78,7 @@ docker run \
   build_image \
   bash <<EOF
     cp /google-cloud-ops-agent*.${PKGFORMAT} /artifacts
+    cp /google-cloud-ops-agent-plugin*.tar.gz /artifacts
 
     if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
       bash /signing/sign.sh /artifacts/*.rpm

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -64,7 +64,8 @@ docker buildx build . \
   -t build_image \
   --load \
   "${build_params[@]}"
-
+echo "Current dir: "
+pwd
 SIGNING_DIR="$(pwd)/kokoro/scripts/build/signing"
 if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then
   RPM_SIGNING_KEY="${KOKORO_KEYSTORE_DIR}/71565_rpm-signing-key"
@@ -78,6 +79,8 @@ docker run \
   build_image \
   bash <<EOF
     cp /google-cloud-ops-agent*.${PKGFORMAT} /artifacts
+    ls -l /
+    ls  -l *
     cp /google-cloud-ops-agent-plugin*.tar.gz /artifacts
 
     if [[ "${PKGFORMAT}" == "rpm" && "${SKIP_SIGNING}" != "true" ]]; then


### PR DESCRIPTION
## Description
Making so that the github hook also generate the plugin tar.
Adding the newly generated plugin .tar.gz to the build artifacts so it can be accessed during the integration tests.

## Related issue
b/394644858

## How has this been tested?
Manually tested and verified that the .tar.gz will appear on the correct bucket.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
