### PR TITLE
[Draft] confgenerator : Improve detection of unsupported OTel Logging Receivers and Processors.

### DIFF
--- a/apps/active_directory_ds.go
+++ b/apps/active_directory_ds.go
@@ -62,6 +62,10 @@ func (r LoggingReceiverActiveDirectoryDS) Type() string {
 	return "active_directory_ds"
 }
 
+func (r LoggingReceiverActiveDirectoryDS) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverActiveDirectoryDS) Components(ctx context.Context, tag string) []fluentbit.Component {
 	l := confgenerator.LoggingReceiverWindowsEventLog{
 		Channels: []string{"Directory Service", "Active Directory Web Services"},

--- a/apps/apache.go
+++ b/apps/apache.go
@@ -78,6 +78,10 @@ func (LoggingProcessorApacheError) Type() string {
 	return "apache_error"
 }
 
+func (p LoggingProcessorApacheError) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorApacheError) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseRegex{
 		// Documentation: https://httpd.apache.org/docs/current/logs.html#errorlog
@@ -135,6 +139,10 @@ type LoggingProcessorApacheAccess struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 }
 
+func (p LoggingProcessorApacheAccess) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorApacheAccess) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	return genericAccessLogParser(ctx, p.Type(), tag, uid)
 }
@@ -146,6 +154,10 @@ func (LoggingProcessorApacheAccess) Type() string {
 type LoggingReceiverApacheAccess struct {
 	LoggingProcessorApacheAccess            `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverApacheAccess) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverApacheAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
@@ -167,6 +179,10 @@ func (r LoggingReceiverApacheAccess) Components(ctx context.Context, tag string)
 type LoggingReceiverApacheError struct {
 	LoggingProcessorApacheError             `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverApacheError) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverApacheError) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -65,6 +65,10 @@ func (LoggingProcessorCassandraSystem) Type() string {
 	return "cassandra_system"
 }
 
+func (p LoggingProcessorCassandraSystem) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorCassandraSystem) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	return javaLogParsingComponents(ctx, p.Type(), tag, uid)
 }
@@ -75,6 +79,10 @@ type LoggingProcessorCassandraDebug struct {
 
 func (LoggingProcessorCassandraDebug) Type() string {
 	return "cassandra_debug"
+}
+
+func (p LoggingProcessorCassandraDebug) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
 }
 
 func (p LoggingProcessorCassandraDebug) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
@@ -149,6 +157,10 @@ type LoggingProcessorCassandraGC struct {
 
 func (LoggingProcessorCassandraGC) Type() string {
 	return "cassandra_gc"
+}
+
+func (p LoggingProcessorCassandraGC) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
 }
 
 func (p LoggingProcessorCassandraGC) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
@@ -239,6 +251,10 @@ type LoggingReceiverCassandraSystem struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverCassandraSystem) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverCassandraSystem) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
@@ -257,6 +273,10 @@ type LoggingReceiverCassandraDebug struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverCassandraDebug) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverCassandraDebug) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
@@ -273,6 +293,10 @@ func (r LoggingReceiverCassandraDebug) Components(ctx context.Context, tag strin
 type LoggingReceiverCassandraGC struct {
 	LoggingProcessorCassandraGC             `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverCassandraGC) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverCassandraGC) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/couchdb.go
+++ b/apps/couchdb.go
@@ -76,6 +76,10 @@ func (LoggingProcessorCouchdb) Type() string {
 	return "couchdb"
 }
 
+func (p LoggingProcessorCouchdb) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorCouchdb) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -156,6 +160,10 @@ func (p LoggingProcessorCouchdb) Components(ctx context.Context, tag string, uid
 type LoggingReceiverCouchdb struct {
 	LoggingProcessorCouchdb                 `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverCouchdb) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverCouchdb) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -154,6 +154,10 @@ func (LoggingProcessorElasticsearchJson) Type() string {
 	return "elasticsearch_json"
 }
 
+func (p LoggingProcessorElasticsearchJson) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorElasticsearchJson) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	c := []fluentbit.Component{}
 
@@ -241,6 +245,10 @@ func (LoggingProcessorElasticsearchGC) Type() string {
 	return "elasticsearch_gc"
 }
 
+func (p LoggingProcessorElasticsearchGC) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorElasticsearchGC) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	c := []fluentbit.Component{}
 
@@ -271,6 +279,10 @@ func (p LoggingProcessorElasticsearchGC) Components(ctx context.Context, tag, ui
 type LoggingReceiverElasticsearchJson struct {
 	LoggingProcessorElasticsearchJson       `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+}
+
+func (r LoggingReceiverElasticsearchJson) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverElasticsearchJson) Components(ctx context.Context, tag string) []fluentbit.Component {
@@ -314,6 +326,10 @@ func (r LoggingReceiverElasticsearchJson) Components(ctx context.Context, tag st
 type LoggingReceiverElasticsearchGC struct {
 	LoggingProcessorElasticsearchGC         `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+}
+
+func (r LoggingReceiverElasticsearchGC) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverElasticsearchGC) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/flink.go
+++ b/apps/flink.go
@@ -80,6 +80,10 @@ func (LoggingProcessorFlink) Type() string {
 	return "flink"
 }
 
+func (p LoggingProcessorFlink) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorFlink) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -144,6 +148,10 @@ func (p LoggingProcessorFlink) Components(ctx context.Context, tag string, uid s
 type LoggingReceiverFlink struct {
 	LoggingProcessorFlink                   `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverFlink) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverFlink) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/hadoop.go
+++ b/apps/hadoop.go
@@ -67,6 +67,10 @@ func (LoggingProcessorHadoop) Type() string {
 	return "hadoop"
 }
 
+func (p LoggingProcessorHadoop) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorHadoop) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	// Sample log line:
 	// 2022-02-01 18:09:47,136 INFO org.apache.hadoop.hdfs.server.namenode.FSEditLog: Edit logging is async:true
@@ -108,6 +112,10 @@ func (p LoggingProcessorHadoop) Components(ctx context.Context, tag, uid string)
 type LoggingReceiverHadoop struct {
 	LoggingProcessorHadoop                  `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+}
+
+func (r LoggingReceiverHadoop) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverHadoop) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/hbase.go
+++ b/apps/hbase.go
@@ -70,6 +70,10 @@ func (LoggingProcessorHbaseSystem) Type() string {
 	return "hbase_system"
 }
 
+func (p LoggingProcessorHbaseSystem) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorHbaseSystem) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -128,6 +132,10 @@ func (p LoggingProcessorHbaseSystem) Components(ctx context.Context, tag string,
 type SystemLoggingReceiverHbase struct {
 	LoggingProcessorHbaseSystem             `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r SystemLoggingReceiverHbase) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r SystemLoggingReceiverHbase) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/iis.go
+++ b/apps/iis.go
@@ -253,6 +253,10 @@ type LoggingReceiverIisAccess struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverIisAccess) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverIisAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{

--- a/apps/jetty.go
+++ b/apps/jetty.go
@@ -63,6 +63,10 @@ type LoggingProcessorJettyAccess struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 }
 
+func (p LoggingProcessorJettyAccess) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorJettyAccess) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	return genericAccessLogParser(ctx, p.Type(), tag, uid)
 }
@@ -74,6 +78,10 @@ func (LoggingProcessorJettyAccess) Type() string {
 type LoggingReceiverJettyAccess struct {
 	LoggingProcessorJettyAccess             `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverJettyAccess) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverJettyAccess) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/kafka.go
+++ b/apps/kafka.go
@@ -80,6 +80,10 @@ func (LoggingProcessorKafka) Type() string {
 	return "kafka"
 }
 
+func (p LoggingProcessorKafka) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorKafka) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -146,6 +150,10 @@ func (p LoggingProcessorKafka) Components(ctx context.Context, tag string, uid s
 type LoggingReceiverKafka struct {
 	LoggingProcessorKafka                   `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverKafka) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverKafka) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/mysql.go
+++ b/apps/mysql.go
@@ -150,6 +150,10 @@ func (LoggingProcessorMysqlError) Type() string {
 	return "mysql_error"
 }
 
+func (p LoggingProcessorMysqlError) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorMysqlError) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseRegexComplex{
 		Parsers: []confgenerator.RegexParser{
@@ -233,6 +237,10 @@ func (LoggingProcessorMysqlGeneral) Type() string {
 	return "mysql_general"
 }
 
+func (p LoggingProcessorMysqlGeneral) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorMysqlGeneral) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -312,6 +320,10 @@ type LoggingProcessorMysqlSlow struct {
 
 func (LoggingProcessorMysqlSlow) Type() string {
 	return "mysql_slow"
+}
+
+func (p LoggingProcessorMysqlSlow) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
 }
 
 func (p LoggingProcessorMysqlSlow) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
@@ -572,6 +584,10 @@ type LoggingReceiverMysqlGeneral struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverMysqlGeneral) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverMysqlGeneral) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
@@ -589,6 +605,10 @@ type LoggingReceiverMysqlSlow struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverMysqlSlow) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverMysqlSlow) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
@@ -604,6 +624,10 @@ func (r LoggingReceiverMysqlSlow) Components(ctx context.Context, tag string) []
 type LoggingReceiverMysqlError struct {
 	LoggingProcessorMysqlError              `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverMysqlError) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverMysqlError) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/nginx.go
+++ b/apps/nginx.go
@@ -70,6 +70,10 @@ func (LoggingProcessorNginxAccess) Type() string {
 	return "nginx_access"
 }
 
+func (p LoggingProcessorNginxAccess) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorNginxAccess) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	return genericAccessLogParser(ctx, p.Type(), tag, uid)
 }
@@ -80,6 +84,10 @@ type LoggingProcessorNginxError struct {
 
 func (LoggingProcessorNginxError) Type() string {
 	return "nginx_error"
+}
+
+func (p LoggingProcessorNginxError) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
 }
 
 func (p LoggingProcessorNginxError) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
@@ -130,6 +138,10 @@ type LoggingReceiverNginxAccess struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverNginxAccess) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverNginxAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{"/var/log/nginx/access.log"}
@@ -142,6 +154,10 @@ func (r LoggingReceiverNginxAccess) Components(ctx context.Context, tag string) 
 type LoggingReceiverNginxError struct {
 	LoggingProcessorNginxError              `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverNginxError) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverNginxError) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -116,6 +116,10 @@ func (LoggingProcessorPostgresql) Type() string {
 	return "postgresql_general"
 }
 
+func (p LoggingProcessorPostgresql) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -204,6 +208,10 @@ func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, 
 type LoggingReceiverPostgresql struct {
 	LoggingProcessorPostgresql              `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverPostgresql) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverPostgresql) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/rabbitmq.go
+++ b/apps/rabbitmq.go
@@ -83,6 +83,10 @@ type LoggingReceiverRabbitmq struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r LoggingReceiverRabbitmq) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverRabbitmq) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{

--- a/apps/redis.go
+++ b/apps/redis.go
@@ -91,6 +91,10 @@ func (LoggingProcessorRedis) Type() string {
 	return "redis"
 }
 
+func (p LoggingProcessorRedis) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorRedis) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseRegex{
 		// Documentation: https://github.com/redis/redis/blob/6.2/src/server.c#L1122
@@ -142,6 +146,10 @@ func (p LoggingProcessorRedis) Components(ctx context.Context, tag string, uid s
 type LoggingReceiverRedis struct {
 	LoggingProcessorRedis                   `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverRedis) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverRedis) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/saphana.go
+++ b/apps/saphana.go
@@ -31,6 +31,10 @@ func (LoggingProcessorSapHanaTrace) Type() string {
 	return "saphana"
 }
 
+func (p LoggingProcessorSapHanaTrace) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorSapHanaTrace) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseRegex{
 		// Undocumented Format: [thread_id]{connection_id}[transaction_id/update_transaction_id] timestamp severity_flag component source_file : message
@@ -98,6 +102,10 @@ func (p LoggingProcessorSapHanaTrace) Components(ctx context.Context, tag string
 type LoggingReceiverSapHanaTrace struct {
 	LoggingProcessorSapHanaTrace            `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverSapHanaTrace) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverSapHanaTrace) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/solr.go
+++ b/apps/solr.go
@@ -63,6 +63,10 @@ func (LoggingProcessorSolrSystem) Type() string {
 	return "solr_system"
 }
 
+func (p LoggingProcessorSolrSystem) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorSolrSystem) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -117,6 +121,10 @@ func (p LoggingProcessorSolrSystem) Components(ctx context.Context, tag string, 
 type LoggingReceiverSolrSystem struct {
 	LoggingProcessorSolrSystem              `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverSolrSystem) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverSolrSystem) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -65,6 +65,10 @@ func (LoggingProcessorTomcatSystem) Type() string {
 	return "tomcat_system"
 }
 
+func (p LoggingProcessorTomcatSystem) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorTomcatSystem) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
@@ -130,6 +134,10 @@ type SystemLoggingReceiverTomcat struct {
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
+func (r SystemLoggingReceiverTomcat) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
+}
+
 func (r SystemLoggingReceiverTomcat) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if len(r.IncludePaths) == 0 {
 		r.IncludePaths = []string{
@@ -147,6 +155,10 @@ type LoggingProcessorTomcatAccess struct {
 	confgenerator.ConfigComponent `yaml:",inline"`
 }
 
+func (p LoggingProcessorTomcatAccess) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorTomcatAccess) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	return genericAccessLogParser(ctx, p.Type(), tag, uid)
 }
@@ -158,6 +170,10 @@ func (LoggingProcessorTomcatAccess) Type() string {
 type AccessSystemLoggingReceiverTomcat struct {
 	LoggingProcessorTomcatAccess            `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r AccessSystemLoggingReceiverTomcat) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r AccessSystemLoggingReceiverTomcat) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/varnish.go
+++ b/apps/varnish.go
@@ -65,6 +65,10 @@ func (LoggingProcessorVarnish) Type() string {
 	return "varnish"
 }
 
+func (p LoggingProcessorVarnish) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorVarnish) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	// Logging documentation: https://github.com/varnishcache/varnish-cache/blob/04455d6c3d8b2d810007239cb1cb2b740d7ec8ab/doc/sphinx/reference/varnishncsa.rst#format
 	// Sample line: 127.0.0.1 - - [02/Mar/2022:15:55:05 +0000] "GET http://localhost:8080/test HTTP/1.1" 404 273 "-" "curl/7.64.0"
@@ -74,6 +78,10 @@ func (p LoggingProcessorVarnish) Components(ctx context.Context, tag string, uid
 type LoggingReceiverVarnish struct {
 	LoggingProcessorVarnish                 `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverVarnish) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverVarnish) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/vault.go
+++ b/apps/vault.go
@@ -315,6 +315,10 @@ func (LoggingProcessorVaultJson) Type() string {
 	return "vault_audit"
 }
 
+func (p LoggingProcessorVaultJson) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorVaultJson) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	c := []fluentbit.Component{}
 
@@ -342,6 +346,10 @@ type LoggingReceiverVaultAuditJson struct {
 	LoggingProcessorVaultJson               `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
 	IncludePaths                            []string `yaml:"include_paths,omitempty" validate:"required"`
+}
+
+func (r LoggingReceiverVaultAuditJson) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverVaultAuditJson) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/wildfly.go
+++ b/apps/wildfly.go
@@ -69,6 +69,10 @@ func (LoggingProcessorWildflySystem) Type() string {
 	return "wildfly_system"
 }
 
+func (p LoggingProcessorWildflySystem) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorWildflySystem) Components(ctx context.Context, tag string, uid string) []fluentbit.Component {
 	c := confgenerator.LoggingProcessorParseRegex{
 		// Logging documentation: https://docs.wildfly.org/26/Admin_Guide.html#Logging
@@ -114,6 +118,10 @@ func (p LoggingProcessorWildflySystem) Components(ctx context.Context, tag strin
 type LoggingReceiverWildflySystem struct {
 	LoggingProcessorWildflySystem           `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+}
+
+func (r LoggingReceiverWildflySystem) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverWildflySystem) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/apps/zookeeper.go
+++ b/apps/zookeeper.go
@@ -71,6 +71,10 @@ func (LoggingProcessorZookeeperGeneral) Type() string {
 	return "zookeeper_general"
 }
 
+func (p LoggingProcessorZookeeperGeneral) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorZookeeperGeneral) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	c := []fluentbit.Component{}
 
@@ -131,6 +135,10 @@ func (p LoggingProcessorZookeeperGeneral) Components(ctx context.Context, tag, u
 type LoggingReceiverZookeeperGeneral struct {
 	LoggingProcessorZookeeperGeneral        `yaml:",inline"`
 	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+}
+
+func (r LoggingReceiverZookeeperGeneral) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, confgenerator.GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverZookeeperGeneral) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -72,6 +72,14 @@ func googleManagedPrometheusExporter(userAgent string) otel.Component {
 	}
 }
 
+func GetUnsupportedOtelLogReceiverError() error {
+	return fmt.Errorf("This receiver is not supported by otel logging.")
+}
+
+func GetUnsupportedOtelLogProcessorError() error {
+	return fmt.Errorf("This processor is not supported by otel logging.")
+}
+
 func (uc *UnifiedConfig) getOTelLogLevel() string {
 	logLevel := "info"
 	if uc.Metrics != nil && uc.Metrics.Service != nil && uc.Metrics.Service.LogLevel != "" {

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -249,7 +249,7 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 		}
 	}()
 
-	uc, err := confgenerator.MergeConfFiles(
+	mergedUc, err := confgenerator.MergeConfFiles(
 		ctx,
 		filepath.Join("testdata", testDir, inputFileName),
 		apps.BuiltInConfStructs,
@@ -260,7 +260,7 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 	got[builtinConfigFileName] = apps.BuiltInConfStructs[pc.platform.Name()].String()
 
 	// Fluent Bit configs
-	flbGeneratedConfigs, err := uc.GenerateFluentBitConfigs(ctx,
+	flbGeneratedConfigs, err := mergedUc.GenerateFluentBitConfigs(ctx,
 		pc.defaultLogsDir,
 		pc.defaultStateDir,
 	)
@@ -272,7 +272,7 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 	}
 
 	// Otel configs
-	otelGeneratedConfig, err := uc.GenerateOtelConfig(ctx)
+	otelGeneratedConfig, err := mergedUc.GenerateOtelConfig(ctx)
 	if err != nil {
 		return
 	}
@@ -280,13 +280,13 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 
 	inputBytes, err := os.ReadFile(filepath.Join("testdata", testDir, inputFileName))
 
-	userConf, err := confgenerator.UnmarshalYamlToUnifiedConfig(ctx, inputBytes)
+	userUc, err := confgenerator.UnmarshalYamlToUnifiedConfig(ctx, inputBytes)
 	if err != nil {
 		return
 	}
 
 	// Feature Tracking
-	extractedFeatures, err := confgenerator.ExtractFeatures(ctx, userConf)
+	extractedFeatures, err := confgenerator.ExtractFeatures(ctx, userUc, mergedUc)
 	if err != nil {
 		return
 	}

--- a/confgenerator/feature_tracking.go
+++ b/confgenerator/feature_tracking.go
@@ -72,43 +72,43 @@ type CustomFeatures interface {
 // ExtractFeatures fields that containing a tracking tag will be tracked.
 // Automatic collection of bool or int fields. Any value that exists on tracking
 // tag will be used instead of value from UnifiedConfig.
-func ExtractFeatures(ctx context.Context, uc *UnifiedConfig) ([]Feature, error) {
-	allFeatures := getOverriddenDefaultPipelines(uc)
-	allFeatures = append(allFeatures, getSelfLogCollection(uc))
-	allFeatures = append(allFeatures, getOTelLoggingSupportedConfig(ctx, uc))
+func ExtractFeatures(ctx context.Context, userUc, mergedUc *UnifiedConfig) ([]Feature, error) {
+	allFeatures := getOverriddenDefaultPipelines(userUc)
+	allFeatures = append(allFeatures, getSelfLogCollection(userUc))
+	allFeatures = append(allFeatures, getOTelLoggingSupportedConfig(ctx, mergedUc))
 
 	var err error
 	var tempTrackedFeatures []Feature
-	if uc.HasMetrics() {
-		tempTrackedFeatures, err = trackedMappedComponents("metrics", "receivers", uc.Metrics.Receivers)
+	if userUc.HasMetrics() {
+		tempTrackedFeatures, err = trackedMappedComponents("metrics", "receivers", userUc.Metrics.Receivers)
 		if err != nil {
 			return nil, err
 		}
 		allFeatures = append(allFeatures, tempTrackedFeatures...)
 
-		tempTrackedFeatures, err = trackedMappedComponents("metrics", "processors", uc.Metrics.Processors)
-		if err != nil {
-			return nil, err
-		}
-		allFeatures = append(allFeatures, tempTrackedFeatures...)
-	}
-
-	if uc.HasLogging() {
-		tempTrackedFeatures, err = trackedMappedComponents("logging", "receivers", uc.Logging.Receivers)
-		if err != nil {
-			return nil, err
-		}
-		allFeatures = append(allFeatures, tempTrackedFeatures...)
-
-		tempTrackedFeatures, err = trackedMappedComponents("logging", "processors", uc.Logging.Processors)
+		tempTrackedFeatures, err = trackedMappedComponents("metrics", "processors", userUc.Metrics.Processors)
 		if err != nil {
 			return nil, err
 		}
 		allFeatures = append(allFeatures, tempTrackedFeatures...)
 	}
 
-	if uc.HasCombined() {
-		tempTrackedFeatures, err = trackedMappedComponents("combined", "receivers", uc.Combined.Receivers)
+	if userUc.HasLogging() {
+		tempTrackedFeatures, err = trackedMappedComponents("logging", "receivers", userUc.Logging.Receivers)
+		if err != nil {
+			return nil, err
+		}
+		allFeatures = append(allFeatures, tempTrackedFeatures...)
+
+		tempTrackedFeatures, err = trackedMappedComponents("logging", "processors", userUc.Logging.Processors)
+		if err != nil {
+			return nil, err
+		}
+		allFeatures = append(allFeatures, tempTrackedFeatures...)
+	}
+
+	if userUc.HasCombined() {
+		tempTrackedFeatures, err = trackedMappedComponents("combined", "receivers", userUc.Combined.Receivers)
 		if err != nil {
 			return nil, err
 		}

--- a/confgenerator/feature_tracking_test.go
+++ b/confgenerator/feature_tracking_test.go
@@ -140,7 +140,7 @@ var expectedTestFeatureBase = []confgenerator.Feature{
 }
 
 func TestEmptyConfig(t *testing.T) {
-	features, err := confgenerator.ExtractFeatures(context.Background(), &emptyUc)
+	features, err := confgenerator.ExtractFeatures(context.Background(), &emptyUc, &emptyUc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -615,7 +615,7 @@ func TestBed(t *testing.T) {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
-			actual, err := confgenerator.ExtractFeatures(context.Background(), test.Config)
+			actual, err := confgenerator.ExtractFeatures(context.Background(), test.Config, test.Config)
 
 			if test.ExpectedError != nil {
 				if test.Expected != nil {
@@ -696,7 +696,7 @@ func TestOverrideDefaultPipeline(t *testing.T) {
 		},
 	}
 
-	features, err := confgenerator.ExtractFeatures(context.Background(), &uc)
+	features, err := confgenerator.ExtractFeatures(context.Background(), &uc, &uc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +770,7 @@ func TestPrometheusFeatureMetrics(t *testing.T) {
 		Receivers: receivers,
 	}
 
-	features, err := confgenerator.ExtractFeatures(context.Background(), &uc)
+	features, err := confgenerator.ExtractFeatures(context.Background(), &uc, &uc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -989,7 +989,7 @@ func TestNestedStructs(t *testing.T) {
 	uc.Metrics = &confgenerator.Metrics{
 		Receivers: receivers,
 	}
-	features, err := confgenerator.ExtractFeatures(context.Background(), &uc)
+	features, err := confgenerator.ExtractFeatures(context.Background(), &uc, &uc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -70,6 +70,10 @@ var multilineRulesLanguageMap = map[string][]string{
 		`"go_frame_2" "/^\s/" "go_frame_1"`},
 }
 
+func (p ParseMultiline) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, GetUnsupportedOtelLogProcessorError()
+}
+
 func (p ParseMultiline) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	var components []fluentbit.Component
 	// Fluent Bit multiline parser currently can't export using `message` as key.
@@ -278,6 +282,10 @@ func (r LoggingProcessorParseRegex) Type() string {
 	return "parse_regex"
 }
 
+func (p LoggingProcessorParseRegex) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorParseRegex) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	parser, parserName := p.ParserShared.Component(tag, uid)
 	parser.Config["Format"] = "regex"
@@ -298,6 +306,10 @@ type RegexParser struct {
 type LoggingProcessorParseRegexComplex struct {
 	Field   string
 	Parsers []RegexParser
+}
+
+func (p LoggingProcessorParseRegexComplex) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, GetUnsupportedOtelLogProcessorError()
 }
 
 func (p LoggingProcessorParseRegexComplex) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
@@ -347,6 +359,10 @@ type LoggingProcessorParseMultilineRegex struct {
 	Rules []MultilineRule
 }
 
+func (p LoggingProcessorParseMultilineRegex) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, GetUnsupportedOtelLogProcessorError()
+}
+
 func (p LoggingProcessorParseMultilineRegex) Components(ctx context.Context, tag, uid string) []fluentbit.Component {
 	multilineParserName := fmt.Sprintf("%s.%s.multiline", tag, uid)
 	rules := [][2]string{}
@@ -388,6 +404,10 @@ type LoggingProcessorNestWildcard struct {
 	Wildcard     string
 	NestUnder    string
 	RemovePrefix string
+}
+
+func (p LoggingProcessorNestWildcard) Processors(ctx context.Context) ([]otel.Component, error) {
+	return nil, GetUnsupportedOtelLogProcessorError()
 }
 
 func (p LoggingProcessorNestWildcard) Components(ctx context.Context, tag, uid string) []fluentbit.Component {

--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -235,6 +235,10 @@ func (r LoggingReceiverSyslog) GetListenPort() uint16 {
 	return r.ListenPort
 }
 
+func (r LoggingReceiverSyslog) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverSyslog) Components(ctx context.Context, tag string) []fluentbit.Component {
 	return []fluentbit.Component{{
 		Kind: "INPUT",
@@ -292,6 +296,10 @@ func (r LoggingReceiverTCP) GetListenPort() uint16 {
 	return r.ListenPort
 }
 
+func (r LoggingReceiverTCP) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, GetUnsupportedOtelLogReceiverError()
+}
+
 func (r LoggingReceiverTCP) Components(ctx context.Context, tag string) []fluentbit.Component {
 	if r.ListenHost == "" {
 		r.ListenHost = "127.0.0.1"
@@ -345,6 +353,10 @@ func (r LoggingReceiverFluentForward) GetListenPort() uint16 {
 		r.ListenPort = 24224
 	}
 	return r.ListenPort
+}
+
+func (r LoggingReceiverFluentForward) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverFluentForward) Components(ctx context.Context, tag string) []fluentbit.Component {
@@ -617,6 +629,10 @@ type LoggingReceiverSystemd struct {
 
 func (r LoggingReceiverSystemd) Type() string {
 	return "systemd_journald"
+}
+
+func (r LoggingReceiverSystemd) Pipelines(context.Context) ([]otel.ReceiverPipeline, error) {
+	return nil, GetUnsupportedOtelLogReceiverError()
 }
 
 func (r LoggingReceiverSystemd) Components(ctx context.Context, tag string) []fluentbit.Component {

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/linux-gpu/error
+++ b/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/linux-gpu/error
@@ -1,1 +1,1 @@
-processor "apache" not supported in pipeline "p1"
+processor "apache" has invalid configuration: This processor is not supported by otel logging.

--- a/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/linux/error
+++ b/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/linux/error
@@ -1,1 +1,1 @@
-processor "apache" not supported in pipeline "p1"
+processor "apache" has invalid configuration: This processor is not supported by otel logging.

--- a/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/windows-2012/error
+++ b/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/windows-2012/error
@@ -1,1 +1,1 @@
-processor "apache" not supported in pipeline "p1"
+processor "apache" has invalid configuration: This processor is not supported by otel logging.

--- a/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/windows/error
+++ b/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/golden/windows/error
@@ -1,1 +1,1 @@
-processor "apache" not supported in pipeline "p1"
+processor "apache" has invalid configuration: This processor is not supported by otel logging.

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:iis_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:iis_access
   key: "[0].enabled"

--- a/internal/self_metrics/self_metrics.go
+++ b/internal/self_metrics/self_metrics.go
@@ -98,8 +98,8 @@ func InstrumentEnabledReceiversMetric(ctx context.Context, uc *confgenerator.Uni
 	return nil
 }
 
-func InstrumentFeatureTrackingMetric(ctx context.Context, uc *confgenerator.UnifiedConfig, meter metricapi.Meter) error {
-	features, err := confgenerator.ExtractFeatures(ctx, uc)
+func InstrumentFeatureTrackingMetric(ctx context.Context, userUc, mergedUc *confgenerator.UnifiedConfig, meter metricapi.Meter) error {
+	features, err := confgenerator.ExtractFeatures(ctx, userUc, mergedUc)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func CollectOpsAgentSelfMetrics(ctx context.Context, userUc, mergedUc *confgener
 	}
 
 	featureTrackingProvider := CreateFeatureTrackingMeterProvider(exporter, res)
-	err = InstrumentFeatureTrackingMetric(ctx, userUc, featureTrackingProvider.Meter("ops_agent/feature_tracking"))
+	err = InstrumentFeatureTrackingMetric(ctx, userUc, mergedUc, featureTrackingProvider.Meter("ops_agent/feature_tracking"))
 	if err != nil {
 		return fmt.Errorf("failed to instrument feature tracking: %w", err)
 	}


### PR DESCRIPTION
## Description
A proposed solution to improve detection of unsupported OTel Logging Receivers and Processors. 

### Explanation
Currently the detection of supported `Receivers` and `Processors` relies on [determining if an instantiated struct implements](https://github.com/GoogleCloudPlatform/ops-agent/blob/5770e42ca0ae90a2d9f8084dcd0e668084ecc478/confgenerator/confgenerator.go#L204) the [OTelReceiver](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/config.go#L582) or [OTelProcessor](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/confgenerator/config.go#L775) interfaces. This is based on the assumption that OTel Logging unsupported `Receivers` and `Processors` don't implement the `Pipelines` and `Processors` methods. 

This assumption fails, for example, when a Receiver (or Processor) has a (nested) `embedded struct` which does implement a method (e.g. Pipeline), but it is not directly implemented in the "parent" struct. See [LoggingReceiverFlink](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/apps/flink.go#L144C1-L147C2), in this example the `flink` receiver relies on a `parse_regex` processor which is unsupported, but our current detection logic can't determine this because the embedded `files` receiver does implement the interface.

One solution could be to use the `reflect` golang package and "determine" if the implemented `Pipeline` method is `promoted` from the embedded struct or directly implemented in the (parent) struct (e.g. comparing method pointers). This could be very fragile and does seem unintended comparing with the Go language definitions ( https://github.com/golang/go/issues/21162 ).

### Proposed Solution
Add a the missing `Pipelines` and `Processors` methods to all Logging Receiver and Processors with a clear `error` message when a Receiver or Processor is not supported. This indeed breaks the previous more elegant solution/approach of detection of support by checking missing methods (does or doesn't implement interface) into a fully descriptive approach (every method determines if its supported).

### Details
- Add `Pipelines` and `Processors` methods to all Logging Receiver and Processors. Return error when not supported by OTel Logging.
- Detect otel logging support from Feature Tracking using the Merged config instead of the User config. This was causing issues in the detection when detecting unsupported processors in the `default_pipeline`.

## Related issue
b/390671495

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
