### PR TITLE
UAP - Redirected Health Check logs to the UAP plugin state directory & Added otel jar file to the Plugin tarball

### DIFF
--- a/cmd/ops_agent_uap_plugin/service_linux.go
+++ b/cmd/ops_agent_uap_plugin/service_linux.go
@@ -110,7 +110,7 @@ func (ps *OpsAgentPluginServer) Start(ctx context.Context, msg *pb.StartRequest)
 	}
 
 	// Ops Agent config validation
-	if err := validateOpsAgentConfig(pContext, pluginInstallDir, ps.runCommand); err != nil {
+	if err := validateOpsAgentConfig(pContext, pluginInstallDir, pluginStateDir, ps.runCommand); err != nil {
 		log.Printf("Start() failed: %s", err)
 		ps.Stop(ctx, &pb.StopRequest{Cleanup: false})
 		return nil, status.Errorf(1, "failed to validate Ops Agent config: %s", err)
@@ -268,10 +268,11 @@ func runCommand(cmd *exec.Cmd) (string, error) {
 	return string(out), err
 }
 
-func validateOpsAgentConfig(ctx context.Context, pluginInstallDirectory string, runCommand RunCommandFunc) error {
+func validateOpsAgentConfig(ctx context.Context, pluginInstallDirectory string, pluginStateDirectory string, runCommand RunCommandFunc) error {
 	configValidationCmd := exec.CommandContext(ctx,
 		path.Join(pluginInstallDirectory, ConfGeneratorBinary),
 		"-in", OpsAgentConfigLocationLinux,
+		"-logs", path.Join(pluginStateDirectory, LogsDirectory),
 	)
 	if output, err := runCommand(configValidationCmd); err != nil {
 		return fmt.Errorf("failed to validate the Ops Agent config:\ncommand output: %s\ncommand error: %s", output, err)

--- a/cmd/ops_agent_uap_plugin/service_linux_test.go
+++ b/cmd/ops_agent_uap_plugin/service_linux_test.go
@@ -115,7 +115,7 @@ func Test_validateOpsAgentConfig(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := validateOpsAgentConfig(ctx, "", mockRunCommand)
+			err := validateOpsAgentConfig(ctx, "", "", mockRunCommand)
 			gotSuccess := (err == nil)
 			if gotSuccess != tc.wantSuccess {
 				t.Errorf("%s: validateOpsAgentConfig() failed to valide Ops Agent config: %v, want successful config validation: %v, error:%v", tc.name, gotSuccess, tc.wantSuccess, err)

--- a/pkg/plugin/build.sh
+++ b/pkg/plugin/build.sh
@@ -36,6 +36,7 @@ cp $WS/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_wrapper ${PLUGI
 cp $WS/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_diagnostics ${PLUGIN_DIR}/libexec/google_cloud_ops_agent_diagnostics
 
 cp $WS/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol ${PLUGIN_DIR}/subagents/opentelemetry-collector/otelopscol
+cp $WS/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar ${PLUGIN_DIR}/subagents/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar
 cp $WS/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit ${PLUGIN_DIR}/subagents/fluent-bit/bin/fluent-bit
 
 tar -cvzf /google-cloud-ops-agent-plugin_${PKG_VERSION}-${TARGET_NAME}-$TARGETARCH.tar.gz -C $PLUGIN_DIR/ .


### PR DESCRIPTION
## Description
1. This PR slightly updated the Ops Agent plugin, redirecting health checks logs to the UAP-specified state directory. 
2. Added the otel jar file to the Ops Agent UAP tarball bundle. A lot of integration tests failed because of the missing jar file. 
## Related issue
b/394696872

## How has this been tested?
Unit tests.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
