### PR TITLE
project.yaml: update opensuse-leap image in tests

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -161,16 +161,16 @@ targets:
           exhaustive:
           - suse-sap-cloud:sles-15-sp6-sap
           - opensuse-cloud:opensuse-leap
-          - opensuse-cloud=opensuse-leap-15-5-v20240516-x86-64
-          - opensuse-cloud=opensuse-leap-15-6-v20250105-x86-64
+          - opensuse-cloud=opensuse-leap-15-5-v20250110-x86-64
+          - opensuse-cloud=opensuse-leap-15-6-v20250130-x86-64
       aarch64:
         test_distros:
           representative:
           - suse-cloud:sles-15-arm64
           exhaustive:
           - opensuse-cloud:opensuse-leap-arm64
-          - opensuse-cloud=opensuse-leap-15-5-v20240516-arm64
-          - opensuse-cloud=opensuse-leap-15-6-v20250105-arm64
+          - opensuse-cloud=opensuse-leap-15-5-v20250110-arm64
+          - opensuse-cloud=opensuse-leap-15-6-v20250130-arm64
   windows:
     package_extension:
       goo


### PR DESCRIPTION
## Description
Updated tests to use the latest Open SUSE images

```
gcloud compute images list --project opensuse-cloud --no-standard-images
NAME                                 PROJECT         FAMILY               DEPRECATED  STATUS
opensuse-leap-15-5-v20250110-arm64   opensuse-cloud  opensuse-leap-arm64              READY
opensuse-leap-15-5-v20250110-x86-64  opensuse-cloud  opensuse-leap                    READY
opensuse-leap-15-6-v20250130-arm64   opensuse-cloud  opensuse-leap-arm64              READY
opensuse-leap-15-6-v20250130-x86-64  opensuse-cloud  opensuse-leap                    READY
```

## Related issue
b/395613842

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
