### PR TITLE
Rocky Linux 9 NVIDIA driver: pin to an earlier version of driver

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
@@ -100,18 +100,11 @@ try_install() {
     return 1
 }
 
-handle_rhel7() {
+handle_rhel9() {
     install_driver_package() {
-        # Ref: https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html#centos7
-        # For Centos - we can expect the repo to have the matching version of
-        # kernel packages, and the driver package needs those kernel packages
-        sudo yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
-        sudo yum -y install nvidia-driver-latest-dkms
-    }
-
-    remove_driver_package() {
-        # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
-        sudo yum -y remove "*nvidia*"
+        # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
+        # TODO(b/396163322): Remove the version pin once the repo is fixed
+        sudo yum -y module install nvidia-driver:565-dkms
     }
 }
 
@@ -120,16 +113,15 @@ handle_common() {
         # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
         sudo yum -y module install nvidia-driver
     }
+}
 
-    remove_driver_package() {
-        # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
-        sudo yum -y module remove --all nvidia-driver
-    }
-
+remove_driver_package() {
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
+    sudo yum -y module remove --all nvidia-driver
 }
 
 case "$MAJOR_VERSION_ID" in
-    7) handle_rhel7;;
+    9) handle_rhel9;;
     *) handle_common;;
 esac
 try_install install_cuda_from_package_manager install_cuda_from_runfile

--- a/integration_test/third_party_apps_test/applications/dcgmv1/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgmv1/centos_rhel/install
@@ -100,18 +100,11 @@ try_install() {
     return 1
 }
 
-handle_rhel7() {
+handle_rhel9() {
     install_driver_package() {
-        # Ref: https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html#centos7
-        # For Centos - we can expect the repo to have the matching version of
-        # kernel packages, and the driver package needs those kernel packages
-        sudo yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
-        sudo yum -y install nvidia-driver-latest-dkms
-    }
-
-    remove_driver_package() {
-        # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
-        sudo yum -y remove "*nvidia*"
+        # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
+        # TODO(b/396163322): Remove the version pin once the repo is fixed
+        sudo yum -y module install nvidia-driver:565-dkms
     }
 }
 
@@ -120,16 +113,15 @@ handle_common() {
         # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
         sudo yum -y module install nvidia-driver
     }
+}
 
-    remove_driver_package() {
-        # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
-        sudo yum -y module remove --all nvidia-driver
-    }
-
+remove_driver_package() {
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
+    sudo yum -y module remove --all nvidia-driver
 }
 
 case "$MAJOR_VERSION_ID" in
-    7) handle_rhel7;;
+    9) handle_rhel9;;
     *) handle_common;;
 esac
 try_install install_cuda_from_package_manager install_cuda_from_runfile

--- a/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
@@ -90,18 +90,11 @@ try_install() {
     return 1
 }
 
-handle_rhel7() {
+handle_rhel9() {
     install_driver_package() {
-        # Ref: https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html#centos7
-        # For Centos - we can expect the repo to have the matching version of
-        # kernel packages, and the driver package needs those kernel packages
-        sudo yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
-        sudo yum -y install nvidia-driver-latest-dkms
-    }
-
-    remove_driver_package() {
-        # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
-        sudo yum -y remove "*nvidia*"
+        # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
+        # TODO(b/396163322): Remove the version pin once the repo is fixed
+        sudo yum -y module install nvidia-driver:565-dkms
     }
 }
 
@@ -110,16 +103,15 @@ handle_common() {
         # Ref: https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
         sudo yum -y module install nvidia-driver
     }
+}
 
-    remove_driver_package() {
-        # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
-        sudo yum -y module remove --all nvidia-driver
-    }
-
+remove_driver_package() {
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#removing-cuda-toolkit-and-driver
+    sudo yum -y module remove --all nvidia-driver
 }
 
 case "$MAJOR_VERSION_ID" in
-    7) handle_rhel7;;
+    9) handle_rhel9;;
     *) handle_common;;
 esac
 try_install install_cuda_from_package_manager install_cuda_from_runfile


### PR DESCRIPTION
## Description
Rocky Linux 9 can't install the latest version of NVIDIA driver (v570) from the package manager, as the latest version has dependencies on kernel module that is newer than that image. Installing newer kernel module requires rebooting. Therefore, temporarily install a previous version 565 for RL9. 

Also removed the logic for RHEL 7 since we are no longer testing on it.  

## Related issue
[b/395868198](http://b/395868198)

## How has this been tested?
Integration tests passing. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
