### PR TITLE
Fix bug when checking if PLUGIN test is enabled

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -1042,6 +1042,6 @@ func GetOtelConfigPath(imageSpec string) string {
 
 func IsOpsAgentUAPPlugin() bool {
 	// ok is true when the env variable is preset in the environment.
-	_, ok := os.LookupEnv("IS_OPS_AGENT_UAP_PLUGIN")
-	return ok
+	value, ok := os.LookupEnv("IS_OPS_AGENT_UAP_PLUGIN")
+	return ok && value != ""
 }


### PR DESCRIPTION
## Description
Current implementation doesn't work properly if the env variable is exported as an empty string.


## Related issue
b/396679776
## How has this been tested?
Created a go test sample to verify the behavior

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
