### PR TITLE
Fix unpopulated TARGET/ARCH when running under Louhi

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -100,9 +100,6 @@ function set_image_specs() {
   export IMAGE_SPECS
 }
 
-export_to_sponge_config "TARGET" "${TARGET:-}"
-export_to_sponge_config "ARCH" "${ARCH:-}"
-
 # Note: if we ever need to change regions, we will need to set up a new
 # Cloud Router and Cloud NAT gateway for that region. This is because
 # we use --no-address on Kokoro, because of b/169084857.
@@ -148,6 +145,9 @@ fi
 
 set_image_specs
 set_zones
+
+export_to_sponge_config "TARGET" "${TARGET:-}"
+export_to_sponge_config "ARCH" "${ARCH:-}"
 
 # If a built agent was passed in from Kokoro directly, use that.
 if compgen -G "${KOKORO_GFILE_DIR}/result/google-cloud-ops-agent*" > /dev/null; then


### PR DESCRIPTION
## Description
When running under Louhi, TARGET and ARCH are set inside of `set_image_specs`, so `export_to_sponge_config` should come afterwards instead of beforehand.

## Related issue
N/A

## How has this been tested?
Presubmits and nightlies

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
