### PR TITLE
confgenerator : Fix otel logging config supported detection by setting `ReceiverMixin` as property

### DIFF
--- a/apps/apache.go
+++ b/apps/apache.go
@@ -144,13 +144,13 @@ func (LoggingProcessorApacheAccess) Type() string {
 }
 
 type LoggingReceiverApacheAccess struct {
-	LoggingProcessorApacheAccess            `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorApacheAccess `yaml:",inline"`
+	ReceiverMixin                confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverApacheAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log file path on Debian / Ubuntu
 			"/var/log/apache2/access.log",
 			// Default log file path RHEL / CentOS
@@ -159,19 +159,19 @@ func (r LoggingReceiverApacheAccess) Components(ctx context.Context, tag string)
 			"/var/log/httpd/access_log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorApacheAccess.Components(ctx, tag, "apache_access")...)
 	return c
 }
 
 type LoggingReceiverApacheError struct {
-	LoggingProcessorApacheError             `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorApacheError `yaml:",inline"`
+	ReceiverMixin               confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverApacheError) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log file path on Debian / Ubuntu
 			"/var/log/apache2/error.log",
 			// Default log file path RHEL / CentOS
@@ -180,7 +180,7 @@ func (r LoggingReceiverApacheError) Components(ctx context.Context, tag string) 
 			"/var/log/httpd/error_log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorApacheError.Components(ctx, tag, "apache_error")...)
 	return c
 }

--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -235,49 +235,49 @@ func (p LoggingProcessorCassandraGC) Components(ctx context.Context, tag string,
 }
 
 type LoggingReceiverCassandraSystem struct {
-	LoggingProcessorCassandraSystem         `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorCassandraSystem `yaml:",inline"`
+	ReceiverMixin                   confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverCassandraSystem) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log file path on Debian / Ubuntu / RHEL / CentOS
 			"/var/log/cassandra/system*.log",
 			// No default install position / log path for SLES
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorCassandraSystem.Components(ctx, tag, "cassandra_system")...)
 	return c
 }
 
 type LoggingReceiverCassandraDebug struct {
-	LoggingProcessorCassandraDebug          `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorCassandraDebug `yaml:",inline"`
+	ReceiverMixin                  confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverCassandraDebug) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log file path on Debian / Ubuntu / RHEL / CentOS
 			"/var/log/cassandra/debug*.log",
 			// No default install position / log path for SLES
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorCassandraDebug.Components(ctx, tag, "cassandra_debug")...)
 	return c
 }
 
 type LoggingReceiverCassandraGC struct {
-	LoggingProcessorCassandraGC             `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorCassandraGC `yaml:",inline"`
+	ReceiverMixin               confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverCassandraGC) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log file path on Debian / Ubuntu / RHEL / CentOS for JDK 8
 			"/var/log/cassandra/gc.log.*.current",
 			// Default log file path on Debian / Ubuntu / RHEL / CentOS for JDK 11
@@ -285,7 +285,7 @@ func (r LoggingReceiverCassandraGC) Components(ctx context.Context, tag string) 
 			// No default install position / log path for SLES
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorCassandraGC.Components(ctx, tag, "cassandra_gc")...)
 	return c
 }

--- a/apps/couchbase.go
+++ b/apps/couchbase.go
@@ -236,8 +236,8 @@ func init() {
 
 // LoggingReceiverCouchbase is a struct used for generating the fluentbit component for couchbase logs
 type LoggingReceiverCouchbase struct {
-	confgenerator.ConfigComponent           `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	confgenerator.ConfigComponent `yaml:",inline"`
+	ReceiverMixin                 confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 // Type returns the string identifier for the general couchbase logs
@@ -247,8 +247,8 @@ func (lr LoggingReceiverCouchbase) Type() string {
 
 // Components returns the logging components of the couchbase access logs
 func (lr LoggingReceiverCouchbase) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(lr.IncludePaths) == 0 {
-		lr.IncludePaths = []string{
+	if len(lr.ReceiverMixin.IncludePaths) == 0 {
+		lr.ReceiverMixin.IncludePaths = []string{
 			"/opt/couchbase/var/lib/couchbase/logs/couchdb.log",
 			"/opt/couchbase/var/lib/couchbase/logs/info.log",
 			"/opt/couchbase/var/lib/couchbase/logs/debug.log",
@@ -256,7 +256,7 @@ func (lr LoggingReceiverCouchbase) Components(ctx context.Context, tag string) [
 			"/opt/couchbase/var/lib/couchbase/logs/babysitter.log",
 		}
 	}
-	components := lr.LoggingReceiverFilesMixin.Components(ctx, tag)
+	components := lr.ReceiverMixin.Components(ctx, tag)
 	components = append(components, confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
 			Parsers: []confgenerator.RegexParser{
@@ -304,8 +304,8 @@ func (lr LoggingReceiverCouchbase) Components(ctx context.Context, tag string) [
 
 // LoggingProcessorCouchbaseHTTPAccess is a struct that will generate the fluentbit components for the http access logs
 type LoggingProcessorCouchbaseHTTPAccess struct {
-	confgenerator.ConfigComponent           `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	confgenerator.ConfigComponent `yaml:",inline"`
+	ReceiverMixin                 confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 // Type returns the string for the couchbase http access logs
@@ -315,13 +315,13 @@ func (lp LoggingProcessorCouchbaseHTTPAccess) Type() string {
 
 // Components returns the fluentbit components for the http access logs of couchbase
 func (lp LoggingProcessorCouchbaseHTTPAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(lp.IncludePaths) == 0 {
-		lp.IncludePaths = []string{
+	if len(lp.ReceiverMixin.IncludePaths) == 0 {
+		lp.ReceiverMixin.IncludePaths = []string{
 			"/opt/couchbase/var/lib/couchbase/logs/http_access.log",
 			"/opt/couchbase/var/lib/couchbase/logs/http_access_internal.log",
 		}
 	}
-	c := lp.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := lp.ReceiverMixin.Components(ctx, tag)
 	// TODO: Harden the genericAccessLogParser so it can be used. It didn't work here since there are some minor differences with the
 	// referer fields and there are additional fields after the user agent here but not in the other apps.
 	c = append(c,
@@ -368,8 +368,8 @@ func (lp LoggingProcessorCouchbaseHTTPAccess) Components(ctx context.Context, ta
 
 // LoggingProcessorCouchbaseGOXDCR is a struct that iwll generate the fluentbit components for the goxdcr logs
 type LoggingProcessorCouchbaseGOXDCR struct {
-	confgenerator.ConfigComponent           `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	confgenerator.ConfigComponent `yaml:",inline"`
+	ReceiverMixin                 confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 // Type returns the type string for the cross datacenter logs of couchbase
@@ -379,13 +379,13 @@ func (lg LoggingProcessorCouchbaseGOXDCR) Type() string {
 
 // Components returns the fluentbit components for the couchbase goxdcr logs
 func (lg LoggingProcessorCouchbaseGOXDCR) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(lg.IncludePaths) == 0 {
-		lg.IncludePaths = []string{
+	if len(lg.ReceiverMixin.IncludePaths) == 0 {
+		lg.ReceiverMixin.IncludePaths = []string{
 			"/opt/couchbase/var/lib/couchbase/logs/goxdcr.log",
 		}
 	}
 
-	c := lg.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := lg.ReceiverMixin.Components(ctx, tag)
 	c = append(c, confgenerator.LoggingProcessorParseMultilineRegex{
 		LoggingProcessorParseRegexComplex: confgenerator.LoggingProcessorParseRegexComplex{
 			Parsers: []confgenerator.RegexParser{

--- a/apps/couchdb.go
+++ b/apps/couchdb.go
@@ -154,18 +154,18 @@ func (p LoggingProcessorCouchdb) Components(ctx context.Context, tag string, uid
 }
 
 type LoggingReceiverCouchdb struct {
-	LoggingProcessorCouchdb                 `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorCouchdb `yaml:",inline"`
+	ReceiverMixin           confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverCouchdb) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log file
 			"/var/log/couchdb/couchdb.log",
 		}
 	}
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -178,7 +178,7 @@ func (r LoggingReceiverCouchdb) Components(ctx context.Context, tag string) []fl
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorCouchdb.Components(ctx, tag, "couchdb")...)
 	return c
 }

--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -269,14 +269,14 @@ func (p LoggingProcessorElasticsearchGC) Components(ctx context.Context, tag, ui
 }
 
 type LoggingReceiverElasticsearchJson struct {
-	LoggingProcessorElasticsearchJson       `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+	LoggingProcessorElasticsearchJson `yaml:",inline"`
+	ReceiverMixin                     confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
 }
 
 func (r LoggingReceiverElasticsearchJson) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
 		// Default JSON logs for Elasticsearch
-		r.IncludePaths = []string{
+		r.ReceiverMixin.IncludePaths = []string{
 			"/var/log/elasticsearch/*_server.json",
 			"/var/log/elasticsearch/*_deprecation.json",
 			"/var/log/elasticsearch/*_index_search_slowlog.json",
@@ -294,7 +294,7 @@ func (r LoggingReceiverElasticsearchJson) Components(ctx context.Context, tag st
 	// "at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:166) ~[elasticsearch-7.16.2.jar:7.16.2]",
 	// "... 6 more"] }
 
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -307,24 +307,24 @@ func (r LoggingReceiverElasticsearchJson) Components(ctx context.Context, tag st
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	return append(c, r.LoggingProcessorElasticsearchJson.Components(ctx, tag, "elasticsearch_json")...)
 }
 
 type LoggingReceiverElasticsearchGC struct {
-	LoggingProcessorElasticsearchGC         `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+	LoggingProcessorElasticsearchGC `yaml:",inline"`
+	ReceiverMixin                   confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
 }
 
 func (r LoggingReceiverElasticsearchGC) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
 		// Default GC log for Elasticsearch
-		r.IncludePaths = []string{
+		r.ReceiverMixin.IncludePaths = []string{
 			"/var/log/elasticsearch/gc.log",
 		}
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	return append(c, r.LoggingProcessorElasticsearchGC.Components(ctx, tag, "elasticsearch_gc")...)
 }
 

--- a/apps/flink.go
+++ b/apps/flink.go
@@ -142,19 +142,19 @@ func (p LoggingProcessorFlink) Components(ctx context.Context, tag string, uid s
 }
 
 type LoggingReceiverFlink struct {
-	LoggingProcessorFlink                   `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorFlink `yaml:",inline"`
+	ReceiverMixin         confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverFlink) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/flink/log/flink-*-standalonesession-*.log",
 			"/opt/flink/log/flink-*-taskexecutor-*.log",
 			"/opt/flink/log/flink-*-client-*.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorFlink.Components(ctx, tag, "flink")...)
 	return c
 }

--- a/apps/hadoop.go
+++ b/apps/hadoop.go
@@ -106,20 +106,20 @@ func (p LoggingProcessorHadoop) Components(ctx context.Context, tag, uid string)
 }
 
 type LoggingReceiverHadoop struct {
-	LoggingProcessorHadoop                  `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+	LoggingProcessorHadoop `yaml:",inline"`
+	ReceiverMixin          confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
 }
 
 func (r LoggingReceiverHadoop) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
 		// Default logs for hadoop
-		r.IncludePaths = []string{
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/hadoop/logs/hadoop-*.log",
 			"/opt/hadoop/logs/yarn-*.log",
 		}
 	}
 
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -132,7 +132,7 @@ func (r LoggingReceiverHadoop) Components(ctx context.Context, tag string) []flu
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 
 	return append(c, r.LoggingProcessorHadoop.Components(ctx, tag, "hadoop")...)
 }

--- a/apps/hbase.go
+++ b/apps/hbase.go
@@ -126,18 +126,18 @@ func (p LoggingProcessorHbaseSystem) Components(ctx context.Context, tag string,
 }
 
 type SystemLoggingReceiverHbase struct {
-	LoggingProcessorHbaseSystem             `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorHbaseSystem `yaml:",inline"`
+	ReceiverMixin               confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r SystemLoggingReceiverHbase) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/hbase/logs/hbase-*-regionserver-*.log",
 			"/opt/hbase/logs/hbase-*-master-*.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorHbaseSystem.Components(ctx, tag, "hbase_system")...)
 	return c
 }

--- a/apps/iis.go
+++ b/apps/iis.go
@@ -249,17 +249,17 @@ func (p *LoggingProcessorIisAccess) Components(ctx context.Context, tag, uid str
 }
 
 type LoggingReceiverIisAccess struct {
-	LoggingProcessorIisAccess               `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorIisAccess `yaml:",inline"`
+	ReceiverMixin             confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverIisAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			`C:\inetpub\logs\LogFiles\W3SVC1\u_ex*`,
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorIisAccess.Components(ctx, tag, "iis_access")...)
 	return c
 }

--- a/apps/jetty.go
+++ b/apps/jetty.go
@@ -72,17 +72,17 @@ func (LoggingProcessorJettyAccess) Type() string {
 }
 
 type LoggingReceiverJettyAccess struct {
-	LoggingProcessorJettyAccess             `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorJettyAccess `yaml:",inline"`
+	ReceiverMixin               confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverJettyAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/logs/*.request.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorJettyAccess.Components(ctx, tag, "jetty_access")...)
 	return c
 }

--- a/apps/kafka.go
+++ b/apps/kafka.go
@@ -144,20 +144,20 @@ func (p LoggingProcessorKafka) Components(ctx context.Context, tag string, uid s
 }
 
 type LoggingReceiverKafka struct {
-	LoggingProcessorKafka                   `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorKafka `yaml:",inline"`
+	ReceiverMixin         confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverKafka) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// No default package installers, these are common log paths from installs online
 			"/var/log/kafka/*.log",
 			"/opt/kafka/logs/server.log",
 			"/opt/kafka/logs/controller.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorKafka.Components(ctx, tag, "kafka")...)
 	return c
 }

--- a/apps/mongodb.go
+++ b/apps/mongodb.go
@@ -320,18 +320,18 @@ func (p *LoggingProcessorMongodb) RegexLogComponents(tag, uid string) []fluentbi
 }
 
 type LoggingReceiverMongodb struct {
-	LoggingProcessorMongodb                 `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorMongodb `yaml:",inline"`
+	ReceiverMixin           confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r *LoggingReceiverMongodb) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// default logging location
 			"/var/log/mongodb/mongod.log*",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorMongodb.Components(ctx, tag, "mongodb")...)
 	return c
 }

--- a/apps/mysql.go
+++ b/apps/mysql.go
@@ -568,47 +568,47 @@ func (p LoggingProcessorMysqlSlow) Components(ctx context.Context, tag string, u
 }
 
 type LoggingReceiverMysqlGeneral struct {
-	LoggingProcessorMysqlGeneral            `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorMysqlGeneral `yaml:",inline"`
+	ReceiverMixin                confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverMysqlGeneral) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log path for CentOS / RHEL / SLES / Debain / Ubuntu
 			"/var/lib/mysql/${HOSTNAME}.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorMysqlGeneral.Components(ctx, tag, "mysql_general")...)
 	return c
 }
 
 type LoggingReceiverMysqlSlow struct {
-	LoggingProcessorMysqlSlow               `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorMysqlSlow `yaml:",inline"`
+	ReceiverMixin             confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverMysqlSlow) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log path for CentOS / RHEL / SLES / Debain / Ubuntu
 			"/var/lib/mysql/${HOSTNAME}-slow.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorMysqlSlow.Components(ctx, tag, "mysql_slow")...)
 	return c
 }
 
 type LoggingReceiverMysqlError struct {
-	LoggingProcessorMysqlError              `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorMysqlError `yaml:",inline"`
+	ReceiverMixin              confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverMysqlError) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log path for CentOS / RHEL
 			"/var/log/mysqld.log",
 			// Default log path for SLES
@@ -622,7 +622,7 @@ func (r LoggingReceiverMysqlError) Components(ctx context.Context, tag string) [
 			"/var/lib/mysql/${HOSTNAME}.err",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorMysqlError.Components(ctx, tag, "mysql_error")...)
 	return c
 }

--- a/apps/nginx.go
+++ b/apps/nginx.go
@@ -126,29 +126,29 @@ func (p LoggingProcessorNginxError) Components(ctx context.Context, tag string, 
 }
 
 type LoggingReceiverNginxAccess struct {
-	LoggingProcessorNginxAccess             `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorNginxAccess `yaml:",inline"`
+	ReceiverMixin               confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverNginxAccess) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{"/var/log/nginx/access.log"}
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{"/var/log/nginx/access.log"}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorNginxAccess.Components(ctx, tag, "nginx_access")...)
 	return c
 }
 
 type LoggingReceiverNginxError struct {
-	LoggingProcessorNginxError              `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorNginxError `yaml:",inline"`
+	ReceiverMixin              confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverNginxError) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{"/var/log/nginx/error.log"}
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{"/var/log/nginx/error.log"}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorNginxError.Components(ctx, tag, "nginx_error")...)
 	return c
 }

--- a/apps/oracledb.go
+++ b/apps/oracledb.go
@@ -812,10 +812,10 @@ func (lr LoggingProcessorOracleDBAlert) Components(ctx context.Context, tag stri
 }
 
 type LoggingReceiverOracleDBAlert struct {
-	LoggingProcessorOracleDBAlert           `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
-	OracleHome                              string   `yaml:"oracle_home,omitempty" validate:"required_without=IncludePaths,excluded_with=IncludePaths"`
-	IncludePaths                            []string `yaml:"include_paths,omitempty" validate:"required_without=OracleHome,excluded_with=OracleHome"`
+	LoggingProcessorOracleDBAlert `yaml:",inline"`
+	ReceiverMixin                 confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	OracleHome                    string                                  `yaml:"oracle_home,omitempty" validate:"required_without=IncludePaths,excluded_with=IncludePaths"`
+	IncludePaths                  []string                                `yaml:"include_paths,omitempty" validate:"required_without=OracleHome,excluded_with=OracleHome"`
 }
 
 func (lr LoggingReceiverOracleDBAlert) Components(ctx context.Context, tag string) []fluentbit.Component {
@@ -825,9 +825,9 @@ func (lr LoggingReceiverOracleDBAlert) Components(ctx context.Context, tag strin
 		}
 	}
 
-	lr.LoggingReceiverFilesMixin.IncludePaths = lr.IncludePaths
+	lr.ReceiverMixin.IncludePaths = lr.IncludePaths
 
-	c := lr.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := lr.ReceiverMixin.Components(ctx, tag)
 	c = append(c, lr.LoggingProcessorOracleDBAlert.Components(ctx, tag, lr.Type())...)
 	return c
 }
@@ -920,10 +920,10 @@ func (lr LoggingProcessorOracleDBAudit) Components(ctx context.Context, tag stri
 }
 
 type LoggingReceiverOracleDBAudit struct {
-	LoggingProcessorOracleDBAudit           `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
-	OracleHome                              string   `yaml:"oracle_home,omitempty" validate:"required_without=IncludePaths,excluded_with=IncludePaths"`
-	IncludePaths                            []string `yaml:"include_paths,omitempty" validate:"required_without=OracleHome,excluded_with=OracleHome"`
+	LoggingProcessorOracleDBAudit `yaml:",inline"`
+	ReceiverMixin                 confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	OracleHome                    string                                  `yaml:"oracle_home,omitempty" validate:"required_without=IncludePaths,excluded_with=IncludePaths"`
+	IncludePaths                  []string                                `yaml:"include_paths,omitempty" validate:"required_without=OracleHome,excluded_with=OracleHome"`
 }
 
 func (lr LoggingReceiverOracleDBAudit) Components(ctx context.Context, tag string) []fluentbit.Component {
@@ -933,9 +933,9 @@ func (lr LoggingReceiverOracleDBAudit) Components(ctx context.Context, tag strin
 		}
 	}
 
-	lr.LoggingReceiverFilesMixin.IncludePaths = lr.IncludePaths
+	lr.ReceiverMixin.IncludePaths = lr.IncludePaths
 
-	c := lr.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := lr.ReceiverMixin.Components(ctx, tag)
 	c = append(c, lr.LoggingProcessorOracleDBAudit.Components(ctx, tag, lr.Type())...)
 	return c
 }

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -202,13 +202,13 @@ func (p LoggingProcessorPostgresql) Components(ctx context.Context, tag string, 
 }
 
 type LoggingReceiverPostgresql struct {
-	LoggingProcessorPostgresql              `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorPostgresql `yaml:",inline"`
+	ReceiverMixin              confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverPostgresql) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log paths for Debian / Ubuntu
 			"/var/log/postgresql/postgresql*.log",
 			// Default log paths for SLES
@@ -217,7 +217,7 @@ func (r LoggingReceiverPostgresql) Components(ctx context.Context, tag string) [
 			"/var/lib/pgsql/*/data/log/postgresql*.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorPostgresql.Components(ctx, tag, "postgresql")...)
 	return c
 }

--- a/apps/rabbitmq.go
+++ b/apps/rabbitmq.go
@@ -79,13 +79,13 @@ func (p *LoggingProcessorRabbitmq) Components(ctx context.Context, tag, uid stri
 }
 
 type LoggingReceiverRabbitmq struct {
-	LoggingProcessorRabbitmq                `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorRabbitmq `yaml:",inline"`
+	ReceiverMixin            confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverRabbitmq) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/var/log/rabbitmq/rabbit*.log",
 		}
 	}
@@ -96,7 +96,7 @@ func (r LoggingReceiverRabbitmq) Components(ctx context.Context, tag string) []f
 	// ===========
 	// ERROR: could not bind to distribution port 25672, it is in use by another node: rabbit@keith-testing-rabbitmq
 	//
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -108,7 +108,7 @@ func (r LoggingReceiverRabbitmq) Components(ctx context.Context, tag string) []f
 			Regex:     `^(?!\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+)`,
 		},
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorRabbitmq.Components(ctx, tag, "rabbitmq")...)
 	return c
 }

--- a/apps/redis.go
+++ b/apps/redis.go
@@ -140,13 +140,13 @@ func (p LoggingProcessorRedis) Components(ctx context.Context, tag string, uid s
 }
 
 type LoggingReceiverRedis struct {
-	LoggingProcessorRedis                   `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorRedis `yaml:",inline"`
+	ReceiverMixin         confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverRedis) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// Default log path on Ubuntu / Debian
 			"/var/log/redis/redis-server.log",
 			// Default log path built from src (6379 is the default redis port)
@@ -159,7 +159,7 @@ func (r LoggingReceiverRedis) Components(ctx context.Context, tag string) []flue
 			"/var/log/redis/redis_6379.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorRedis.Components(ctx, tag, "redis")...)
 	return c
 }

--- a/apps/saphana.go
+++ b/apps/saphana.go
@@ -96,25 +96,25 @@ func (p LoggingProcessorSapHanaTrace) Components(ctx context.Context, tag string
 }
 
 type LoggingReceiverSapHanaTrace struct {
-	LoggingProcessorSapHanaTrace            `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorSapHanaTrace `yaml:",inline"`
+	ReceiverMixin                confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverSapHanaTrace) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/usr/sap/*/HDB*/${HOSTNAME}/trace/*.trc",
 		}
 	}
-	if len(r.ExcludePaths) == 0 {
-		r.ExcludePaths = []string{
+	if len(r.ReceiverMixin.ExcludePaths) == 0 {
+		r.ReceiverMixin.ExcludePaths = []string{
 			"/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver_history*.trc",
 			"/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*loads*.trc",
 			"/usr/sap/*/HDB*/${HOSTNAME}/trace/nameserver*executed_statements*.trc",
 		}
 	}
 
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -127,7 +127,7 @@ func (r LoggingReceiverSapHanaTrace) Components(ctx context.Context, tag string)
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorSapHanaTrace.Components(ctx, tag, r.Type())...)
 	return c
 }

--- a/apps/solr.go
+++ b/apps/solr.go
@@ -115,17 +115,17 @@ func (p LoggingProcessorSolrSystem) Components(ctx context.Context, tag string, 
 }
 
 type LoggingReceiverSolrSystem struct {
-	LoggingProcessorSolrSystem              `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorSolrSystem `yaml:",inline"`
+	ReceiverMixin              confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverSolrSystem) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/var/solr/logs/solr.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorSolrSystem.Components(ctx, tag, "solr_system")...)
 	return c
 }

--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -126,19 +126,19 @@ func (p LoggingProcessorTomcatSystem) Components(ctx context.Context, tag string
 }
 
 type SystemLoggingReceiverTomcat struct {
-	LoggingProcessorTomcatSystem            `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorTomcatSystem `yaml:",inline"`
+	ReceiverMixin                confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r SystemLoggingReceiverTomcat) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/tomcat/logs/catalina.out",
 			"/var/log/tomcat*/catalina.out",
 			"/var/log/tomcat*/catalina.*.log",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorTomcatSystem.Components(ctx, tag, "tomcat_system")...)
 	return c
 }
@@ -156,18 +156,18 @@ func (LoggingProcessorTomcatAccess) Type() string {
 }
 
 type AccessSystemLoggingReceiverTomcat struct {
-	LoggingProcessorTomcatAccess            `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorTomcatAccess `yaml:",inline"`
+	ReceiverMixin                confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r AccessSystemLoggingReceiverTomcat) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/tomcat/logs/localhost_access_log*.txt",
 			"/var/log/tomcat*/localhost_access_log*.txt",
 		}
 	}
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorTomcatAccess.Components(ctx, tag, "tomcat_access")...)
 	return c
 }

--- a/apps/varnish.go
+++ b/apps/varnish.go
@@ -72,16 +72,16 @@ func (p LoggingProcessorVarnish) Components(ctx context.Context, tag string, uid
 }
 
 type LoggingReceiverVarnish struct {
-	LoggingProcessorVarnish                 `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorVarnish `yaml:",inline"`
+	ReceiverMixin           confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverVarnish) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{"/var/log/varnish/varnishncsa.log"}
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{"/var/log/varnish/varnishncsa.log"}
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorVarnish.Components(ctx, tag, "varnish")...)
 	return c
 }

--- a/apps/vault.go
+++ b/apps/vault.go
@@ -339,15 +339,15 @@ func (p LoggingProcessorVaultJson) Components(ctx context.Context, tag, uid stri
 }
 
 type LoggingReceiverVaultAuditJson struct {
-	LoggingProcessorVaultJson               `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
-	IncludePaths                            []string `yaml:"include_paths,omitempty" validate:"required"`
+	LoggingProcessorVaultJson `yaml:",inline"`
+	ReceiverMixin             confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+	IncludePaths              []string                                `yaml:"include_paths,omitempty" validate:"required"`
 }
 
 func (r LoggingReceiverVaultAuditJson) Components(ctx context.Context, tag string) []fluentbit.Component {
-	r.LoggingReceiverFilesMixin.IncludePaths = r.IncludePaths
+	r.ReceiverMixin.IncludePaths = r.IncludePaths
 
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -360,7 +360,7 @@ func (r LoggingReceiverVaultAuditJson) Components(ctx context.Context, tag strin
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	return append(c, r.LoggingProcessorVaultJson.Components(ctx, tag, r.LoggingProcessorVaultJson.Type())...)
 }
 

--- a/apps/wildfly.go
+++ b/apps/wildfly.go
@@ -112,13 +112,13 @@ func (p LoggingProcessorWildflySystem) Components(ctx context.Context, tag strin
 }
 
 type LoggingReceiverWildflySystem struct {
-	LoggingProcessorWildflySystem           `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
+	LoggingProcessorWildflySystem `yaml:",inline"`
+	ReceiverMixin                 confgenerator.LoggingReceiverFilesMixin `yaml:",inline" validate:"structonly"`
 }
 
 func (r LoggingReceiverWildflySystem) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
-		r.IncludePaths = []string{
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
+		r.ReceiverMixin.IncludePaths = []string{
 			// no package installers, default installation usually provides the following
 			// Standalone server log
 			"/opt/wildfly/standalone/log/server.log",
@@ -129,7 +129,7 @@ func (r LoggingReceiverWildflySystem) Components(ctx context.Context, tag string
 		}
 	}
 
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -142,7 +142,7 @@ func (r LoggingReceiverWildflySystem) Components(ctx context.Context, tag string
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	c = append(c, r.LoggingProcessorWildflySystem.Components(ctx, tag, "wildfly_system")...)
 	return c
 }

--- a/apps/zookeeper.go
+++ b/apps/zookeeper.go
@@ -129,20 +129,20 @@ func (p LoggingProcessorZookeeperGeneral) Components(ctx context.Context, tag, u
 }
 
 type LoggingReceiverZookeeperGeneral struct {
-	LoggingProcessorZookeeperGeneral        `yaml:",inline"`
-	confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
+	LoggingProcessorZookeeperGeneral `yaml:",inline"`
+	ReceiverMixin                    confgenerator.LoggingReceiverFilesMixin `yaml:",inline"`
 }
 
 func (r LoggingReceiverZookeeperGeneral) Components(ctx context.Context, tag string) []fluentbit.Component {
-	if len(r.IncludePaths) == 0 {
+	if len(r.ReceiverMixin.IncludePaths) == 0 {
 		// Default log for Zookeeper.
-		r.IncludePaths = []string{
+		r.ReceiverMixin.IncludePaths = []string{
 			"/opt/zookeeper/logs/zookeeper-*.out",
 			"/var/log/zookeeper/zookeeper.log",
 		}
 	}
 
-	r.MultilineRules = []confgenerator.MultilineRule{
+	r.ReceiverMixin.MultilineRules = []confgenerator.MultilineRule{
 		{
 			StateName: "start_state",
 			NextState: "cont",
@@ -155,7 +155,7 @@ func (r LoggingReceiverZookeeperGeneral) Components(ctx context.Context, tag str
 		},
 	}
 
-	c := r.LoggingReceiverFilesMixin.Components(ctx, tag)
+	c := r.ReceiverMixin.Components(ctx, tag)
 	return append(c, r.LoggingProcessorZookeeperGeneral.Components(ctx, tag, "zookeeper_general")...)
 }
 

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:apache_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:cassandra_debug
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchbase_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchbase_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchbase_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchbase_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:couchdb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:elasticsearch_gc
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:flink
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hadoop
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:hbase_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:jetty_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:kafka
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mongodb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mongodb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mongodb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mongodb
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:mysql_error
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:nginx_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:oracledb_alert
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:oracledb_alert
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:oracledb_alert
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:oracledb_alert
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:postgresql_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:rabbitmq
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:redis
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:saphana
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:solr_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:tomcat_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:varnish
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:vault_audit
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:wildfly_system
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:zookeeper_general
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:iis_access
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: receivers:iis_access
   key: "[0].enabled"


### PR DESCRIPTION
## Description
The current verification to know if a [LoggingReceiver](https://github.com/GoogleCloudPlatform/ops-agent/blob/2.54.0/confgenerator/config.go#L512-L515) receiver is supported by OTel Logging consists on determining if the receiver implements the [OTelReceiver](https://github.com/GoogleCloudPlatform/ops-agent/blob/2.54.0/confgenerator/config.go#L582-L585) interface or not. This means the logging receiver should have an (OTel) `Pipelines` method to be an `OTelReceiver`.

Currently most 3rd party app receivers are not supported by otel logging, but they use [LoggingReceiverFilesMixin](https://github.com/GoogleCloudPlatform/ops-agent/blob/2.54.0/confgenerator/logging_receivers.go#L66-L77) as an embedded struct (which is indeed supported by otel logging) which means 3P app receivers get an implementation `Pipelines` method as a `promoted method`.

## Solution
Setting `LoggingReceiverFilesMixin` as a property with name `ReceiverMixin` avoids the struct to be `embedded`, which avoids their methods to be promoted (`Pipelines` won't be considered a parent method anymore).

## Followup
More sophisticated and longterm solutions have been explored in https://github.com/GoogleCloudPlatform/ops-agent/pull/1896 & https://github.com/GoogleCloudPlatform/ops-agent/compare/master...quentin-generic-receivers, but there are still details to address.

## Related issue
b/390671495

## How has this been tested?
All unit tests and integration tests pass. No `LoggingReceiver` functionality was changed. Unit test goldens where updated with the `otel_logging_supported_config` new values.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
