### PR TITLE
feature_tracking : Update `ExtractFeatures` to receive both `userUc` and `mergedUc` for `getOTelLoggingSupportedConfig`.

### DIFF
--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -255,7 +255,7 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 		}
 	}()
 
-	uc, err := confgenerator.MergeConfFiles(
+	mergedUc, err := confgenerator.MergeConfFiles(
 		ctx,
 		filepath.Join("testdata", testDir, inputFileName),
 		apps.BuiltInConfStructs,
@@ -266,7 +266,7 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 	got[builtinConfigFileName] = apps.BuiltInConfStructs[pc.platform.Name()].String()
 
 	// Fluent Bit configs
-	flbGeneratedConfigs, err := uc.GenerateFluentBitConfigs(ctx,
+	flbGeneratedConfigs, err := mergedUc.GenerateFluentBitConfigs(ctx,
 		pc.defaultLogsDir,
 		pc.defaultStateDir,
 	)
@@ -278,7 +278,7 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 	}
 
 	// Otel configs
-	otelGeneratedConfig, err := uc.GenerateOtelConfig(ctx)
+	otelGeneratedConfig, err := mergedUc.GenerateOtelConfig(ctx)
 	if err != nil {
 		return
 	}
@@ -286,13 +286,13 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 
 	inputBytes, err := os.ReadFile(filepath.Join("testdata", testDir, inputFileName))
 
-	userConf, err := confgenerator.UnmarshalYamlToUnifiedConfig(ctx, inputBytes)
+	userUc, err := confgenerator.UnmarshalYamlToUnifiedConfig(ctx, inputBytes)
 	if err != nil {
 		return
 	}
 
 	// Feature Tracking
-	extractedFeatures, err := confgenerator.ExtractFeatures(ctx, userConf)
+	extractedFeatures, err := confgenerator.ExtractFeatures(ctx, userUc, mergedUc)
 	if err != nil {
 		return
 	}

--- a/confgenerator/feature_tracking.go
+++ b/confgenerator/feature_tracking.go
@@ -439,6 +439,7 @@ func getMetadata(field reflect.StructField) metadata {
 	}
 }
 
+// TODO: b/399354366 - Cleanup when OTel Logging Support is fully released.
 func getOTelLoggingSupportedConfig(ctx context.Context, mergedUc *UnifiedConfig) Feature {
 	feature := Feature{
 		Module: "logging",

--- a/confgenerator/feature_tracking.go
+++ b/confgenerator/feature_tracking.go
@@ -72,43 +72,43 @@ type CustomFeatures interface {
 // ExtractFeatures fields that containing a tracking tag will be tracked.
 // Automatic collection of bool or int fields. Any value that exists on tracking
 // tag will be used instead of value from UnifiedConfig.
-func ExtractFeatures(ctx context.Context, uc *UnifiedConfig) ([]Feature, error) {
-	allFeatures := getOverriddenDefaultPipelines(uc)
-	allFeatures = append(allFeatures, getSelfLogCollection(uc))
-	allFeatures = append(allFeatures, getOTelLoggingSupportedConfig(ctx, uc))
+func ExtractFeatures(ctx context.Context, userUc, mergedUc *UnifiedConfig) ([]Feature, error) {
+	allFeatures := getOverriddenDefaultPipelines(userUc)
+	allFeatures = append(allFeatures, getSelfLogCollection(userUc))
+	allFeatures = append(allFeatures, getOTelLoggingSupportedConfig(ctx, mergedUc))
 
 	var err error
 	var tempTrackedFeatures []Feature
-	if uc.HasMetrics() {
-		tempTrackedFeatures, err = trackedMappedComponents("metrics", "receivers", uc.Metrics.Receivers)
+	if userUc.HasMetrics() {
+		tempTrackedFeatures, err = trackedMappedComponents("metrics", "receivers", userUc.Metrics.Receivers)
 		if err != nil {
 			return nil, err
 		}
 		allFeatures = append(allFeatures, tempTrackedFeatures...)
 
-		tempTrackedFeatures, err = trackedMappedComponents("metrics", "processors", uc.Metrics.Processors)
-		if err != nil {
-			return nil, err
-		}
-		allFeatures = append(allFeatures, tempTrackedFeatures...)
-	}
-
-	if uc.HasLogging() {
-		tempTrackedFeatures, err = trackedMappedComponents("logging", "receivers", uc.Logging.Receivers)
-		if err != nil {
-			return nil, err
-		}
-		allFeatures = append(allFeatures, tempTrackedFeatures...)
-
-		tempTrackedFeatures, err = trackedMappedComponents("logging", "processors", uc.Logging.Processors)
+		tempTrackedFeatures, err = trackedMappedComponents("metrics", "processors", userUc.Metrics.Processors)
 		if err != nil {
 			return nil, err
 		}
 		allFeatures = append(allFeatures, tempTrackedFeatures...)
 	}
 
-	if uc.HasCombined() {
-		tempTrackedFeatures, err = trackedMappedComponents("combined", "receivers", uc.Combined.Receivers)
+	if userUc.HasLogging() {
+		tempTrackedFeatures, err = trackedMappedComponents("logging", "receivers", userUc.Logging.Receivers)
+		if err != nil {
+			return nil, err
+		}
+		allFeatures = append(allFeatures, tempTrackedFeatures...)
+
+		tempTrackedFeatures, err = trackedMappedComponents("logging", "processors", userUc.Logging.Processors)
+		if err != nil {
+			return nil, err
+		}
+		allFeatures = append(allFeatures, tempTrackedFeatures...)
+	}
+
+	if userUc.HasCombined() {
+		tempTrackedFeatures, err = trackedMappedComponents("combined", "receivers", userUc.Combined.Receivers)
 		if err != nil {
 			return nil, err
 		}
@@ -439,7 +439,7 @@ func getMetadata(field reflect.StructField) metadata {
 	}
 }
 
-func getOTelLoggingSupportedConfig(ctx context.Context, uc *UnifiedConfig) Feature {
+func getOTelLoggingSupportedConfig(ctx context.Context, mergedUc *UnifiedConfig) Feature {
 	feature := Feature{
 		Module: "logging",
 		Kind:   "service",
@@ -448,7 +448,7 @@ func getOTelLoggingSupportedConfig(ctx context.Context, uc *UnifiedConfig) Featu
 		Value:  "false",
 	}
 
-	if uc.OTelLoggingSupported(ctx) {
+	if mergedUc.OTelLoggingSupported(ctx) {
 		feature.Value = "true"
 	}
 

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/features.yaml
@@ -13,7 +13,7 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "true"
+  value: "false"
 - module: logging
   feature: processors:parse_regex
   key: "[0].enabled"

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/features.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/features.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/features.yaml
@@ -13,4 +13,4 @@
 - module: logging
   feature: service:otel_logging
   key: otel_logging_supported_config
-  value: "false"
+  value: "true"

--- a/internal/self_metrics/self_metrics.go
+++ b/internal/self_metrics/self_metrics.go
@@ -98,8 +98,8 @@ func InstrumentEnabledReceiversMetric(ctx context.Context, uc *confgenerator.Uni
 	return nil
 }
 
-func InstrumentFeatureTrackingMetric(ctx context.Context, uc *confgenerator.UnifiedConfig, meter metricapi.Meter) error {
-	features, err := confgenerator.ExtractFeatures(ctx, uc)
+func InstrumentFeatureTrackingMetric(ctx context.Context, userUc, mergedUc *confgenerator.UnifiedConfig, meter metricapi.Meter) error {
+	features, err := confgenerator.ExtractFeatures(ctx, userUc, mergedUc)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func CollectOpsAgentSelfMetrics(ctx context.Context, userUc, mergedUc *confgener
 	}
 
 	featureTrackingProvider := CreateFeatureTrackingMeterProvider(exporter, res)
-	err = InstrumentFeatureTrackingMetric(ctx, userUc, featureTrackingProvider.Meter("ops_agent/feature_tracking"))
+	err = InstrumentFeatureTrackingMetric(ctx, userUc, mergedUc, featureTrackingProvider.Meter("ops_agent/feature_tracking"))
 	if err != nil {
 		return fmt.Errorf("failed to instrument feature tracking: %w", err)
 	}


### PR DESCRIPTION
## Description
The `UnifiedConfig.OTelLoggingSupported` method requires the `Merged Unified Config` (the result of combining the user set config and the built in config ) to determine correctly if "OTel Logging" supports the presented logging pipelines.

This breaks the `Feature Tracking` design of only analyzing the `user configuration`, but the alternatives (e.g. refactor Unified Config) would need refactoring in other packages or present other issues (e.g. `apps` and `confgenerator` dependency cycle). The `mergedUc` is only used for `getOTelLoggingSupportedConfig`.

The use for `otel_logging_supported_config` will be removed when Otel Logging Support is fully released (see b/399354366). Added TODO to track this.

This is a followup the PR's : 
- https://github.com/GoogleCloudPlatform/ops-agent/pull/1861
- https://github.com/GoogleCloudPlatform/ops-agent/pull/1897

## Explanation

The `merged config` is required to be able to match exactly the OTel Logging Support feedback a user would get when trying to enable `experimental_otel_logging: true` from the `congenerator` config validation. The config validation uses the merged config with the built in config pipelines. When using only the `user config`, there are edge cases (see [goldens example](https://github.com/GoogleCloudPlatform/ops-agent/blob/2.54.0/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/features.yaml) ) where a logging processors might not detected as not supported (e.g. `parse_regex` in the example).

## Related issue
- b/390671495
- b/399354366

## How has this been tested?
Unit tests were modified.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
