### PR TITLE
integration_test : Add `TestAppHubLogLabels` to test AppHub integration from Ops Agent collected logs.

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -961,7 +961,7 @@ func ManagedInstanceGroupVMSetup(t *testing.T, imageSpec string, extraCreateArgu
 		Metadata:             additionalMetadata,
 	}
 	migVM := gce.SetupManagedInstanceGroupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)
-	logger.ToMainLog().Printf("VM is ready: %#v", migVM.VM)
+	logger.ToMainLog().Printf("ManagedInstanceGroupVM is ready: %#v", migVM.VM)
 	t.Cleanup(func() {
 		RunOpsAgentDiagnostics(ctx, logger, migVM.VM)
 	})

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -941,7 +941,7 @@ func CommonSetupWithExtraCreateArgumentsAndMetadata(t *testing.T, imageSpec stri
 }
 
 // CommonSetupWithExtraCreateArgumentsAndMetadata sets up the VM for testing with extra creation arguments for the `gcloud compute instances create` command and additional metadata.
-func ManagedInstanceGroupSetup(t *testing.T, imageSpec string, extraCreateArguments []string, additionalMetadata map[string]string) (context.Context, *logging.DirectoryLogger, *gce.VM) {
+func ManagedInstanceGroupSetup(t *testing.T, imageSpec string, extraCreateArguments []string, additionalMetadata map[string]string) (context.Context, *logging.DirectoryLogger, *gce.ManagedInstanceGroupVM) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
 	t.Cleanup(cancel)
@@ -960,12 +960,12 @@ func ManagedInstanceGroupSetup(t *testing.T, imageSpec string, extraCreateArgume
 		ExtraCreateArguments: extraCreateArguments,
 		Metadata:             additionalMetadata,
 	}
-	vm := gce.SetupManagedInstanceGroupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)
-	logger.ToMainLog().Printf("VM is ready: %#v", vm)
+	migVM := gce.SetupManagedInstanceGroupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)
+	logger.ToMainLog().Printf("VM is ready: %#v", migVM.VM)
 	t.Cleanup(func() {
-		RunOpsAgentDiagnostics(ctx, logger, vm)
+		RunOpsAgentDiagnostics(ctx, logger, migVM.VM)
 	})
-	return ctx, logger, vm
+	return ctx, logger, migVM
 }
 
 func InstallOpsAgentUAPPlugin(ctx context.Context, logger *log.Logger, vm *gce.VM, location PackageLocation) error {

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -940,8 +940,8 @@ func CommonSetupWithExtraCreateArgumentsAndMetadata(t *testing.T, imageSpec stri
 	return ctx, logger, vm
 }
 
-// CommonSetupWithExtraCreateArgumentsAndMetadata sets up the VM for testing with extra creation arguments for the `gcloud compute instances create` command and additional metadata.
-func ManagedInstanceGroupSetup(t *testing.T, imageSpec string, extraCreateArguments []string, additionalMetadata map[string]string) (context.Context, *logging.DirectoryLogger, *gce.ManagedInstanceGroupVM) {
+// ManagedInstanceGroupVMSetup sets up a Managed Instance Group VM for testing with extra creation arguments for the `gcloud compute instances create` command and additional metadata.
+func ManagedInstanceGroupVMSetup(t *testing.T, imageSpec string, extraCreateArguments []string, additionalMetadata map[string]string) (context.Context, *logging.DirectoryLogger, *gce.ManagedInstanceGroupVM) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
 	t.Cleanup(cancel)

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1442,7 +1442,7 @@ func attemptCreateManagedInstanceGroupInstance(ctx context.Context, logger *log.
 	}
 
 	createTemplateArgs := []string{
-		"beta", "compute", "instance-templates", "create", vm.Name + "-temp",
+		"beta", "compute", "instance-templates", "create", vm.Name + "-t",
 		"--project=" + vm.Project,
 		"--machine-type=" + vm.MachineType,
 		"--network=" + vm.Network,
@@ -1488,7 +1488,7 @@ func attemptCreateManagedInstanceGroupInstance(ctx context.Context, logger *log.
 		"--project=" + vm.Project,
 		"--zone=" + vm.Zone,
 		"--size=0",
-		"--template=" + vm.Name + "-temp",
+		"--template=" + vm.Name + "-t",
 		"--stateful-internal-ip=enabled",
 		"--format=json",
 	}
@@ -1961,7 +1961,7 @@ func DeleteManagedInstanceGroupInstance(logger *log.Logger, vm *VM) error {
 		attempt++
 		_, err = RunGcloud(ctx, logger, "",
 			[]string{
-				"compute", "instance-templates", "delete", vm.Name + "-temp",
+				"compute", "instance-templates", "delete", vm.Name + "-t",
 				"--project=" + vm.Project,
 			})
 		if err == nil {

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -320,7 +320,7 @@ func (migVM ManagedInstanceGroupVM) ManagedInstanceGroupName() string {
 }
 
 func (migVM ManagedInstanceGroupVM) InstanceTemplateName() string {
-	return migVM.Name + "-temp"
+	return migVM.Name + "-tmpl"
 }
 
 func (migVM ManagedInstanceGroupVM) AppHubWorkloadName() string {
@@ -1361,7 +1361,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	}
 
 	args := []string{
-		// "beta" is needed for --max-run-duration below.
+		// "beta" is needed for --max-run-duration.
 		"beta", "compute", "instances", "create", vm.Name,
 		"--project=" + vm.Project,
 		"--zone=" + vm.Zone,
@@ -1423,9 +1423,10 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	return vm, nil
 }
 
-// attemptCreateManagedInstanceGroupVM creates a VM instance and waits for it to be ready.
-// Returns a VM object or an error (never both). The caller is responsible for
-// deleting the VM if (and only if) the returned error is nil.
+// attemptCreateManagedInstanceGroupVM creates a individual VM instance in a Managed Instance Group
+// and waits for it to be ready.
+// Returns a ManagedInstanceGroupVM object or an error (never both). The caller is responsible for
+// deleting the ManagedInstanceGroupVM if (and only if) the returned error is nil.
 func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger, options VMOptions) (migVmToReturn *ManagedInstanceGroupVM, errToReturn error) {
 	// We need a shorter uuid here to add suffixes and not go over the 63 character limit
 	// for resource names.
@@ -1437,6 +1438,7 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 
 	// Step #1 : Create vm instance template
 	createTemplateArgs := []string{
+		// "beta" is needed for --max-run-duration.
 		"beta", "compute", "instance-templates", "create", migVM.InstanceTemplateName(),
 		"--project=" + migVM.Project,
 		"--machine-type=" + migVM.MachineType,

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -325,6 +325,7 @@ func (vm VM) extractMetadataFromOutput(output CommandOutput) error {
 		return err
 	}
 	vm.IPAddress = ipAddress
+	return nil
 }
 
 // ManagedInstanceGroupVM represents an individual VM in a Managed Instace Group.
@@ -1413,8 +1414,12 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 		}
 	}()
 
-	vm.extractMetadataFromOutput(output)
+	if err := vm.extractMetadataFromOutput(output); err != nil {
+		return nil, err
+	}
+
 	logger.Printf("Instance Log: %v", instanceLogURL(vm))
+
 	// This is just informational, so it's ok if it fails. Just warn and proceed.
 	if _, err := DescribeVMDisk(ctx, logger, vm); err != nil {
 		logger.Printf("Unable to retrieve information about the VM's boot disk: %v", err)
@@ -1530,13 +1535,17 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 		return nil, err
 	}
 
-	migVM.extractMetadataFromOutput(output)
-	logger.Printf("Instance Log: %v", instanceLogURL(vm))
+	if err := migVM.extractMetadataFromOutput(output); err != nil {
+		return nil, err
+	}
+
+	logger.Printf("Instance Log: %v", instanceLogURL(migVM.VM))
 
 	// This is just informational, so it's ok if it fails. Just warn and proceed.
 	if _, err := DescribeVMDisk(ctx, logger, migVM.VM); err != nil {
 		logger.Printf("Unable to retrieve information about the VM's boot disk: %v", err)
 	}
+
 	if err := verifyVMCreation(ctx, logger, migVM.VM); err != nil {
 		return nil, err
 	}

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -180,8 +180,6 @@ const (
 
 	DenyEgressTrafficTag = "test-ops-agent-deny-egress-traffic-tag"
 
-	AppHubIntegrationTestApp = "ops-agent-app-hub-integration-test-app"
-
 	TraceQueryMaxAttempts = QueryMaxAttempts / traceQueryDerate
 )
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1442,7 +1442,7 @@ func attemptCreateManagedInstanceGroupInstance(ctx context.Context, logger *log.
 	}
 
 	createTemplateArgs := []string{
-		"compute", "instance-templates", "create", vm.Name + "-temp",
+		"beta", "compute", "instance-templates", "create", vm.Name + "-temp",
 		"--project=" + vm.Project,
 		"--machine-type=" + vm.MachineType,
 		"--network=" + vm.Network,

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1494,7 +1494,7 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 
 	// Step #3 : Create test VM in Managed Instance Group.
 	createVMArgs := []string{
-		"compute", "instance-groups", "managed", "create-instance", migVM.Name,
+		"compute", "instance-groups", "managed", "create-instance", migVM.ManagedInstanceGroupName(),
 		"--instance=" + migVM.Name,
 		"--project=" + migVM.Project,
 		"--zone=" + migVM.Zone,
@@ -1506,7 +1506,21 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 		return nil, err
 	}
 
-	// Step #4 : Query newly created VM metadata.
+	// Step #4 : Wait until Managed Instance Group is stable.
+	waitUntilStableArgs := []string{
+		"compute", "instance-groups", "managed", "wait-until", migVM.ManagedInstanceGroupName(),
+		"--stable",
+		"--project=" + migVM.Project,
+		"--zone=" + migVM.Zone,
+		"--format=json",
+	}
+
+	output, err = RunGcloud(ctx, logger, "", waitUntilStableArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step #5 : Query newly created VM metadata.
 	listVMArgs := []string{
 		"compute", "instances", "list",
 		"--filter=name=( '" + migVM.Name + "' ... )",

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1496,7 +1496,7 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 
 	output, err = RunGcloud(ctx, logger, "", createVMArgs)
 	if err != nil {
-		logger.Println(err)
+		return nil, err
 	}
 
 	// Step #4 : Wait until Managed Instance Group is stable with a 300s timeout.

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1477,7 +1477,6 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 		"--zone=" + migVM.Zone,
 		"--size=0",
 		"--template=" + migVM.InstanceTemplateName(),
-		"--stateful-internal-ip=enabled",
 		"--format=json",
 	}
 

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1403,13 +1403,13 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	}
 	vm.ID = id
 
+	logger.Printf("Instance Log: %v", instanceLogURL(vm))
+
 	ipAddress, err := extractIPAddress(output.Stdout)
 	if err != nil {
 		return nil, err
 	}
 	vm.IPAddress = ipAddress
-
-	logger.Printf("Instance Log: %v", instanceLogURL(vm))
 
 	// This is just informational, so it's ok if it fails. Just warn and proceed.
 	if _, err := DescribeVMDisk(ctx, logger, vm); err != nil {
@@ -1535,13 +1535,13 @@ func attemptCreateManagedInstanceGroupVM(ctx context.Context, logger *log.Logger
 	}
 	migVM.ID = id
 
+	logger.Printf("Instance Log: %v", instanceLogURL(migVM.VM))
+
 	ipAddress, err := extractIPAddress(output.Stdout)
 	if err != nil {
 		return nil, err
 	}
 	migVM.IPAddress = ipAddress
-
-	logger.Printf("Instance Log: %v", instanceLogURL((*migVM).VM))
 
 	// This is just informational, so it's ok if it fails. Just warn and proceed.
 	if _, err := DescribeVMDisk(ctx, logger, migVM.VM); err != nil {
@@ -1827,8 +1827,8 @@ func DeleteManagedInstanceGroupVM(logger *log.Logger, migVM *ManagedInstanceGrou
 		return handleDeleteError(err, attempt)
 	}
 	err := backoff.Retry(tryDeleteMIG, backoffPolicy)
-	if err == nil {
-		migVM.AlreadyDeleted = true
+	if err != nil {
+		return err
 	}
 
 	attempt = 0

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -683,7 +683,7 @@ func AssertLogMissing(ctx context.Context, logger *log.Logger, vm *VM, logNameRe
 			return nil
 		}
 		logger.Printf("Query returned found=%v, err=%v, attempt=%d", found, err, attempt)
-		if !strings.Contains(err.Error(), "Internal error encountered") {
+		if err != nil && !strings.Contains(err.Error(), "Internal error encountered") {
 			// A non-retryable error.
 			return fmt.Errorf("AssertLogMissing() failed: %v", err)
 		}

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -1423,7 +1423,7 @@ func attemptCreateInstance(ctx context.Context, logger *log.Logger, options VMOp
 	return vm, nil
 }
 
-// attemptCreateManagedInstanceGroupVM creates a individual VM instance in a Managed Instance Group
+// attemptCreateManagedInstanceGroupVM creates an individual VM instance in a Managed Instance Group
 // and waits for it to be ready.
 // Returns a ManagedInstanceGroupVM object or an error (never both). The caller is responsible for
 // deleting the ManagedInstanceGroupVM if (and only if) the returned error is nil.
@@ -2332,9 +2332,9 @@ func SetupVM(ctx context.Context, t *testing.T, logger *log.Logger, options VMOp
 	return vm
 }
 
-// SetupManagedInstanceGroupVM creates a new VM according to the given options.
-// If VM creation fails, it will abort the test.
-// At the end of the test, the VM will be cleaned up.
+// SetupManagedInstanceGroupVM creates an individual VM instance in a Managed Instance Group according to the given options.
+// If the ManagedInstanceGroupVM creation fails, it will abort the test.
+// At the end of the test, the ManagedInstanceGroupVM will be cleaned up.
 func SetupManagedInstanceGroupVM(ctx context.Context, t *testing.T, logger *log.Logger, options VMOptions) *ManagedInstanceGroupVM {
 	t.Helper()
 

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5146,10 +5146,7 @@ func listAndDeleteResources(ctx context.Context, logger *log.Logger, resourceTyp
 	}
 
 	for _, r := range resources {
-		deleteArgs := append(resourceType,
-			[]string{"delete", filepath.Base(r.Name),
-				"--format=json",
-			}...)
+		deleteArgs := append(resourceType, []string{"delete", filepath.Base(r.Name), "--format=json"}...)
 		if r.Zone != "" {
 			deleteArgs = append(deleteArgs, "--zone")
 			deleteArgs = append(deleteArgs, filepath.Base(r.Zone))

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -214,7 +214,7 @@ func setupMainLogAndVM(t *testing.T, imageSpec string) (context.Context, *log.Lo
 // If you need to write to something besides the main log, just call
 // agents.CommonSetup instead.
 func setupMainLogAndManagedInstaceGroupVM(t *testing.T, imageSpec string) (context.Context, *log.Logger, *gce.ManagedInstanceGroupVM) {
-	ctx, dirLog, migVM := agents.ManagedInstanceGroupSetup(t, imageSpec, nil, nil)
+	ctx, dirLog, migVM := agents.ManagedInstanceGroupVMSetup(t, imageSpec, nil, nil)
 	return ctx, dirLog.ToMainLog(), migVM
 }
 

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5179,7 +5179,7 @@ func cleanupStaleResourcesForTestAppHubLogLabels(ctx context.Context, logger *lo
 		"( creationTimestamp < "+staleResourceTimestamp+" AND name ~ .*test-[0-9]{1,8}-.*-mig$ )",
 		[]string{"--project", project})
 	listAndDeleteResources(ctx, logger, []string{"compute", "instance-templates"},
-		"( creationTimestamp < "+staleResourceTimestamp+" AND name ~ .*test-[0-9]{1,8}-.*-temp$ )",
+		"( creationTimestamp < "+staleResourceTimestamp+" AND name ~ .*test-[0-9]{1,8}-.*-tmpl$ )",
 		[]string{"--project", project})
 	listAndDeleteResources(ctx, logger, []string{"apphub", "applications", "workloads"},
 		"( createTime < "+staleResourceTimestamp+" AND name ~ .*test-[0-9]{1,8}-.*-wl$ )",
@@ -5220,7 +5220,6 @@ func TestAppHubLogLabels(t *testing.T) {
 
 		// Setup Apphub #2 : Register Managed Instance Group as AppHub workload.
 		migResourceString := strings.Replace(output.Stdout, "https://apphub.googleapis.com/v1/", "", 1)
-		logger.Println("found uri : ", migResourceString)
 		registerAppHubWorkloadArgs := []string{
 			"apphub", "applications", "workloads", "create", migVM.AppHubWorkloadName(),
 			"--application=" + AppHubIntegrationTestApp,

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5257,10 +5257,10 @@ func TestAppHubLogLabels(t *testing.T) {
 
 		tag := systemLogTagForImage(migVM.ImageSpec)
 		query := logMessageQueryForImage(migVM.ImageSpec, "123456789")
-		query += fmt.Sprintf(` AND labels."compute.googleapis.com/instance_group_manager/name"=~"%s"`, migVM.ManagedInstanceGroupName())
-		query += fmt.Sprintf(` AND labels."compute.googleapis.com/instance_group_manager/zone"=~"%s"`, migVM.Zone)
-		query += fmt.Sprintf(` AND apphub.application.id=~"%s"`, AppHubIntegrationTestApp)
-		query += fmt.Sprintf(` AND apphub.workload.id=~"%s"`, migVM.AppHubWorkloadName())
+		query += fmt.Sprintf(` AND labels."compute.googleapis.com/instance_group_manager/name"="%s"`, migVM.ManagedInstanceGroupName())
+		query += fmt.Sprintf(` AND labels."compute.googleapis.com/instance_group_manager/zone"="%s"`, migVM.Zone)
+		query += fmt.Sprintf(` AND apphub.application.id="%s"`, AppHubIntegrationTestApp)
+		query += fmt.Sprintf(` AND apphub.workload.id="%s"`, migVM.AppHubWorkloadName())
 
 		if err := gce.WaitForLog(ctx, logger, migVM.VM, tag, time.Hour, query); err != nil {
 			t.Error(err)


### PR DESCRIPTION
## Description
This test does the following : 
- Create a test Instance Template and a Managed Instance Group (MIG).
- Creates a VM in the MIG that the test can SSH into.
- Register MIG to a test AppHub application `ops-agent-app-hub-integration-test-app` as a workload.
- Verify a custom `syslog` log contains the correct `apphub.*` labels in Cloud Logging.
- Cleanup resources created for test and stale resources (older than 24h) from previous test executions.

## Related issue
b/354756009

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
