### PR TITLE
Updated Docker file to build Ops Agent Windows tarball. 

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -272,3 +272,15 @@ WORKDIR /work
 COPY . /work
 
 RUN & .\pkg\goo\build.ps1 -DestDir /work/out;
+
+###############################################################################
+# Packaging for the Ops Agent Plugin
+###############################################################################
+
+WORKDIR /work
+
+COPY . /work
+
+RUN & .\pkg\plugin\build.ps1 -DestDir /work/out/bin;
+
+

--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -82,6 +82,8 @@ Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/*.goo" -Destination "$env:KOKORO_
 # They are not distributed to customers.
 Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/*.pdb" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
 Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/*.dll" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
+# Copy Ops Agent UAP Plugin tarball to the result directory.
+Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/*.tar.gz" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
 
 # If Kokoro is being triggered by Louhi, then Louhi needs to be able to
 # reconstruct the path where the artifacts are placed. Louhi does not have

--- a/pkg/plugin/build.ps1
+++ b/pkg/plugin/build.ps1
@@ -1,0 +1,53 @@
+Param(
+    [Parameter(Mandatory=$false)][string]$DestDir,
+    [Parameter(Mandatory=$false)][string]$Arch
+)
+
+if (!$DestDir) {
+    $DestDir = '.'
+}
+
+# Read PKG_VERSION from VERSION file.
+#$PkgVersion = Select-String -Path "VERSION" -Pattern '^PKG_VERSION="(.*)"$' | %{$_.Matches.Groups[1].Value}
+
+# If ARCH is not supplied, set default value based on user's system.
+if (!$Arch) {
+  $Arch = (&{If([System.Environment]::Is64BitProcess) {'x86_64'} Else {'x86'}})
+}
+
+# Set GOARCH based on ARCH.
+switch ($Arch) {
+    'x86_64' { $GoArch = 'amd64'; break}
+    'x86'    { $GoArch = '386';   break}
+    default  { Throw 'Arch must be set to one of: x86, x86_64' }
+}
+
+# Create the license directory
+$LicenseDir = "$DestDir\THIRD_PARTY_LICENSES"
+$Subfolder = "$LicenseDir\subfolder"
+
+New-Item -ItemType Directory -Path $LicenseDir -Force | Out-Null
+New-Item -ItemType Directory -Path $Subfolder -Force | Out-Null
+
+"license to be added" | Out-File "$LicenseDir\text1.txt"
+"license to be added" | Out-File "$Subfolder\text2.txt"
+
+$TarFileName = "google-cloud-ops-agent-plugin-windows-$Arch.tar.gz" # Define tar file name
+
+$FilesToInclude = @(
+    "msvcp140.dll",
+    "vccorlib140.dll",
+    "vcruntime140.dll",
+    "fluent-bit.exe",
+    "fluent-bit.dll",
+    "opentelemetry-java-contrib-jmx-metrics.jar",
+    "google-cloud-metrics-agent_windows_${GoArch}.exe",
+    "google-cloud-ops-agent-wrapper.exe"
+    "plugin.exe"
+    "THIRD_PARTY_LICENSES"
+)
+
+# Create the tar archive
+& tar -czf "$DestDir\$TarFileName" -C "$DestDir" $FilesToInclude
+
+Write-Host "Tar archive created: $($DestDir)\$TarFileName"

--- a/pkg/plugin/build.ps1
+++ b/pkg/plugin/build.ps1
@@ -8,7 +8,7 @@ if (!$DestDir) {
 }
 
 # Read PKG_VERSION from VERSION file.
-#$PkgVersion = Select-String -Path "VERSION" -Pattern '^PKG_VERSION="(.*)"$' | %{$_.Matches.Groups[1].Value}
+$PkgVersion = Select-String -Path "VERSION" -Pattern '^PKG_VERSION="(.*)"$' | %{$_.Matches.Groups[1].Value}
 
 # If ARCH is not supplied, set default value based on user's system.
 if (!$Arch) {
@@ -32,7 +32,7 @@ New-Item -ItemType Directory -Path $Subfolder -Force | Out-Null
 "license to be added" | Out-File "$LicenseDir\text1.txt"
 "license to be added" | Out-File "$Subfolder\text2.txt"
 
-$TarFileName = "google-cloud-ops-agent-plugin-windows-$Arch.tar.gz" # Define tar file name
+$TarFileName = "google-cloud-ops-agent-plugin-$PkgVersion-windows-$Arch.tar.gz" # Define tar file name
 
 $FilesToInclude = @(
     "msvcp140.dll",

--- a/pkg/plugin/build.ps1
+++ b/pkg/plugin/build.ps1
@@ -48,6 +48,6 @@ $FilesToInclude = @(
 )
 
 # Create the tar archive
-& tar -czf "$DestDir\$TarFileName" -C "$DestDir" $FilesToInclude
+& tar -cvzf "$DestDir\$TarFileName" -C "$DestDir" $FilesToInclude
 
 Write-Host "Tar archive created: $($DestDir)\$TarFileName"


### PR DESCRIPTION
## Description
This PR added additional steps in the Windows dockerfile, to also build Ops Agent UAP Plugin tarball for Windows. 

## Related issue
b/399401166

## How has this been tested?
That it generates a tarball and includes everything expected.
It's accessible in kokoro presubmit tests: https://screenshot.googleplex.com/BRji5xWz9R4QwGd

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
