### PR TITLE
Make Ops Agent Windows Plugin Tarball accessible in Louhi Nightly runs 

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -83,7 +83,7 @@ Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/*.goo" -Destination "$env:KOKORO_
 Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/*.pdb" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
 Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/*.dll" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
 # Copy Ops Agent UAP Plugin tarball to the result directory.
-Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/*.tar.gz" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
+Move-Item -Path "$env:KOKORO_ARTIFACTS_DIR/out/bin/google-cloud-ops-agent-plugin*.tar.gz" -Destination "$env:KOKORO_ARTIFACTS_DIR/result"
 
 # If Kokoro is being triggered by Louhi, then Louhi needs to be able to
 # reconstruct the path where the artifacts are placed. Louhi does not have
@@ -98,4 +98,5 @@ if ($env:_LOUHI_TAG_NAME -ne $null) {
   $arch=$louhi_tag_components[4]
   $gcs_bucket="gs://${env:_STAGING_ARTIFACTS_PROJECT_ID}-ops-agent-releases/${ver}/${ref}/${target}/${arch}/"
   gsutil cp "$env:KOKORO_ARTIFACTS_DIR/result/*.goo"  "${gcs_bucket}"
+  gsutil cp "$env:KOKORO_ARTIFACTS_DIR/result/google-cloud-ops-agent-plugin*.tar.gz"  "${gcs_bucket}"
 }


### PR DESCRIPTION
## Description
Make Ops Agent Windows Plugin Tarball accessible in Louhi Nightly runs 

## Related issue
b/399401413

## How has this been tested?
After this PR is submitted, removing the if clause at https://source.corp.google.com/h/louhi-config-internal/collection-services/+/master:.louhi/stage_types/ops_agent/integration_test/create_repo.yml;l=68 should not trigger any errors, as the plugin .tar.gz file will be available on Windows.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
