### PR TITLE
Enable Ops Agent Integration Tests for UAP Plugin on Windows

### DIFF
--- a/kokoro/config/test/ops_agent/presubmit/windows_x86_64_uap_plugin.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/windows_x86_64_uap_plugin.gcl
@@ -1,0 +1,11 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'windows'
+      ARCH = 'x86_64'
+      IS_OPS_AGENT_UAP_PLUGIN = 'true'
+    }
+  }
+}


### PR DESCRIPTION
## Description
This goes after https://github.com/GoogleCloudPlatform/ops-agent/pull/1909. 
This PR adds the kokoro config to enable running the ops agent integration tests for UAP on Windows during PR presubmit


## Related issue
b/399399492

## How has this been tested?
Ops Agent Integration tests should pass for the UAP plugin on Windows. 

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
