### PR TITLE
Fixed UAP Windows Tarball Naming 

### DIFF
--- a/pkg/plugin/build.ps1
+++ b/pkg/plugin/build.ps1
@@ -33,7 +33,7 @@ New-Item -ItemType Directory -Path $Subfolder -Force | Out-Null
 "license to be added" | Out-File "$LicenseDir\text1.txt"
 "license to be added" | Out-File "$Subfolder\text2.txt"
 
-$TarFileName = "google-cloud-ops-agent-plugin-$PkgVersion-windows-$Arch.tar.gz" # Define tar file name
+$TarFileName = "google-cloud-ops-agent-plugin_$PkgVersion-windows-$Arch.tar.gz" # Define tar file name
 
 $FilesToInclude = @(
     "msvcp140.dll",


### PR DESCRIPTION
## Description
Fixed UAP Windows Tarball Naming 

## Related issue
b/399401413

## How has this been tested?
Louhi cannot find the package if `-` is used instead of `_`: https://louhi.dev/6025093129699328/execution-detail/4836444415066112

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
