### PR TITLE
Disable UAP Plugin integration tests on all 2019 Windows Images

### DIFF
--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -372,9 +372,9 @@ func IsWindows2016(imageSpec string) bool {
 	return IsWindows(imageSpec) && strings.Contains(imageSpec, "2016")
 }
 
-// IsSql2019Windows2019 returns whether the given image is windows-sql-cloud:sql-std-2019-win-2019.
-func IsSql2019Windows2019(imageSpec string) bool {
-	return IsWindows(imageSpec) && strings.Contains(imageSpec, "sql-std-2019-win-2019")
+// IsWindows2019 returns whether the given image is a Windows 2016 image..
+func IsWindows2019(imageSpec string) bool {
+	return IsWindows(imageSpec) && strings.Contains(imageSpec, "2019")
 }
 
 // OSKind returns "linux" or "windows" based on the given image spec.
@@ -2384,7 +2384,7 @@ func RunForEachImage(t *testing.T, testBody func(t *testing.T, imageSpec string)
 	for _, imageSpec := range imageSpecs {
 		imageSpec := imageSpec // https://golang.org/doc/faq#closures_and_goroutines
 		// FIXME(b/406277901): Re-enable tests to run for the UAP plugin on the two images.
-		if IsOpsAgentUAPPlugin() && (IsWindows2016(imageSpec) || IsSql2019Windows2019(imageSpec)) {
+		if IsOpsAgentUAPPlugin() && (IsWindows2016(imageSpec) || IsWindows2019(imageSpec)) {
 			continue
 		}
 		t.Run(imageSpec, func(t *testing.T) {

--- a/integration_test/gce/gce_testing.go
+++ b/integration_test/gce/gce_testing.go
@@ -372,7 +372,7 @@ func IsWindows2016(imageSpec string) bool {
 	return IsWindows(imageSpec) && strings.Contains(imageSpec, "2016")
 }
 
-// IsWindows2019 returns whether the given image is a Windows 2016 image..
+// IsWindows2019 returns whether the given image is a Windows 2019 image.
 func IsWindows2019(imageSpec string) bool {
 	return IsWindows(imageSpec) && strings.Contains(imageSpec, "2019")
 }

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -983,7 +983,7 @@ func determineTestsToSkip(tests []test, impactedApps map[string]bool) {
 			tests[i].skipReason = fmt.Sprintf("Skipping %v because we only want to test %v on %v", test.app, SAPHANAApp, SAPHANAImageSpec)
 			continue
 		}
-		if gce.IsOpsAgentUAPPlugin() && (gce.IsWindows2016(test.imageSpec) || gce.IsSql2019Windows2019(test.imageSpec)) {
+		if gce.IsOpsAgentUAPPlugin() && (gce.IsWindows2016(test.imageSpec) || gce.IsWindows2019(test.imageSpec)) {
 			tests[i].skipReason = "skip running the test against the Ops Agent UAP Plugin on the windows image"
 			continue
 		}


### PR DESCRIPTION
## Description
Ops agent and 3p integration tests wont run against UAP plugin on all 2019 Windows Images. The flake `"localhost:1234": dial tcp [::1]:1234: connectex: No connection could be made because the target machine actively refused it.`  happens frequently on the 2019 images, and the root cause hasn't been identified.

## Related issue
b/399399492

## How has this been tested?
We should see less flakes for the UAP plugin during Louhi Nightly runs: https://fusion2.corp.google.com/invocations/6864e33c-fb43-4ec5-b43c-5a884eb07674/targets/logs;config=default/tests 

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
