### PR TITLE
Record the Ops Agent version in a file and add it to the UAP plugin tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,12 +171,12 @@ COPY --from=centos8-build-fluent-bit /work/cache /work/cache
 COPY --from=centos8-build-systemd /work/cache /work/cache
 COPY --from=centos8-build-diagnostics /work/cache /work/cache
 COPY --from=centos8-build-wrapper /work/cache /work/cache
-RUN ./pkg/rpm/build.sh
+# RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache centos8
 
 
@@ -285,12 +285,12 @@ COPY --from=rockylinux9-build-fluent-bit /work/cache /work/cache
 COPY --from=rockylinux9-build-systemd /work/cache /work/cache
 COPY --from=rockylinux9-build-diagnostics /work/cache /work/cache
 COPY --from=rockylinux9-build-wrapper /work/cache /work/cache
-RUN ./pkg/rpm/build.sh
+# RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache rockylinux9
 
 
@@ -394,12 +394,12 @@ COPY --from=bookworm-build-fluent-bit /work/cache /work/cache
 COPY --from=bookworm-build-systemd /work/cache /work/cache
 COPY --from=bookworm-build-diagnostics /work/cache /work/cache
 COPY --from=bookworm-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
+# RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache bookworm
 
 
@@ -503,12 +503,12 @@ COPY --from=bullseye-build-fluent-bit /work/cache /work/cache
 COPY --from=bullseye-build-systemd /work/cache /work/cache
 COPY --from=bullseye-build-diagnostics /work/cache /work/cache
 COPY --from=bullseye-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
+# RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache bullseye
 
 
@@ -631,12 +631,12 @@ COPY --from=sles12-build-fluent-bit /work/cache /work/cache
 COPY --from=sles12-build-systemd /work/cache /work/cache
 COPY --from=sles12-build-diagnostics /work/cache /work/cache
 COPY --from=sles12-build-wrapper /work/cache /work/cache
-RUN ./pkg/rpm/build.sh
+# RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache sles12
 
 
@@ -745,12 +745,12 @@ COPY --from=sles15-build-fluent-bit /work/cache /work/cache
 COPY --from=sles15-build-systemd /work/cache /work/cache
 COPY --from=sles15-build-diagnostics /work/cache /work/cache
 COPY --from=sles15-build-wrapper /work/cache /work/cache
-RUN ./pkg/rpm/build.sh
+# RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache sles15
 
 
@@ -854,12 +854,12 @@ COPY --from=focal-build-fluent-bit /work/cache /work/cache
 COPY --from=focal-build-systemd /work/cache /work/cache
 COPY --from=focal-build-diagnostics /work/cache /work/cache
 COPY --from=focal-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
+# RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache focal
 
 
@@ -963,12 +963,12 @@ COPY --from=jammy-build-fluent-bit /work/cache /work/cache
 COPY --from=jammy-build-systemd /work/cache /work/cache
 COPY --from=jammy-build-diagnostics /work/cache /work/cache
 COPY --from=jammy-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
+# RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache jammy
 
 
@@ -1072,12 +1072,12 @@ COPY --from=noble-build-fluent-bit /work/cache /work/cache
 COPY --from=noble-build-systemd /work/cache /work/cache
 COPY --from=noble-build-diagnostics /work/cache /work/cache
 COPY --from=noble-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
+# RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache noble
 
 
@@ -1181,12 +1181,12 @@ COPY --from=oracular-build-fluent-bit /work/cache /work/cache
 COPY --from=oracular-build-systemd /work/cache /work/cache
 COPY --from=oracular-build-diagnostics /work/cache /work/cache
 COPY --from=oracular-build-wrapper /work/cache /work/cache
-RUN ./pkg/deb/build.sh
+# RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache oracular
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ COPY --from=centos8-build-fluent-bit /work/cache /work/cache
 COPY --from=centos8-build-systemd /work/cache /work/cache
 COPY --from=centos8-build-diagnostics /work/cache /work/cache
 COPY --from=centos8-build-wrapper /work/cache /work/cache
-# RUN ./pkg/rpm/build.sh
+RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -285,7 +285,7 @@ COPY --from=rockylinux9-build-fluent-bit /work/cache /work/cache
 COPY --from=rockylinux9-build-systemd /work/cache /work/cache
 COPY --from=rockylinux9-build-diagnostics /work/cache /work/cache
 COPY --from=rockylinux9-build-wrapper /work/cache /work/cache
-# RUN ./pkg/rpm/build.sh
+RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -394,7 +394,7 @@ COPY --from=bookworm-build-fluent-bit /work/cache /work/cache
 COPY --from=bookworm-build-systemd /work/cache /work/cache
 COPY --from=bookworm-build-diagnostics /work/cache /work/cache
 COPY --from=bookworm-build-wrapper /work/cache /work/cache
-# RUN ./pkg/deb/build.sh
+RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -503,7 +503,7 @@ COPY --from=bullseye-build-fluent-bit /work/cache /work/cache
 COPY --from=bullseye-build-systemd /work/cache /work/cache
 COPY --from=bullseye-build-diagnostics /work/cache /work/cache
 COPY --from=bullseye-build-wrapper /work/cache /work/cache
-# RUN ./pkg/deb/build.sh
+RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -631,7 +631,7 @@ COPY --from=sles12-build-fluent-bit /work/cache /work/cache
 COPY --from=sles12-build-systemd /work/cache /work/cache
 COPY --from=sles12-build-diagnostics /work/cache /work/cache
 COPY --from=sles12-build-wrapper /work/cache /work/cache
-# RUN ./pkg/rpm/build.sh
+RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -745,7 +745,7 @@ COPY --from=sles15-build-fluent-bit /work/cache /work/cache
 COPY --from=sles15-build-systemd /work/cache /work/cache
 COPY --from=sles15-build-diagnostics /work/cache /work/cache
 COPY --from=sles15-build-wrapper /work/cache /work/cache
-# RUN ./pkg/rpm/build.sh
+RUN ./pkg/rpm/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -854,7 +854,7 @@ COPY --from=focal-build-fluent-bit /work/cache /work/cache
 COPY --from=focal-build-systemd /work/cache /work/cache
 COPY --from=focal-build-diagnostics /work/cache /work/cache
 COPY --from=focal-build-wrapper /work/cache /work/cache
-# RUN ./pkg/deb/build.sh
+RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -963,7 +963,7 @@ COPY --from=jammy-build-fluent-bit /work/cache /work/cache
 COPY --from=jammy-build-systemd /work/cache /work/cache
 COPY --from=jammy-build-diagnostics /work/cache /work/cache
 COPY --from=jammy-build-wrapper /work/cache /work/cache
-# RUN ./pkg/deb/build.sh
+RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -1072,7 +1072,7 @@ COPY --from=noble-build-fluent-bit /work/cache /work/cache
 COPY --from=noble-build-systemd /work/cache /work/cache
 COPY --from=noble-build-diagnostics /work/cache /work/cache
 COPY --from=noble-build-wrapper /work/cache /work/cache
-# RUN ./pkg/deb/build.sh
+RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
@@ -1181,7 +1181,7 @@ COPY --from=oracular-build-fluent-bit /work/cache /work/cache
 COPY --from=oracular-build-systemd /work/cache /work/cache
 COPY --from=oracular-build-diagnostics /work/cache /work/cache
 COPY --from=oracular-build-wrapper /work/cache /work/cache
-# RUN ./pkg/deb/build.sh
+RUN ./pkg/deb/build.sh
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache centos8
 
 
@@ -290,7 +290,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache rockylinux9
 
 
@@ -399,7 +399,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache bookworm
 
 
@@ -508,7 +508,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache bullseye
 
 
@@ -636,7 +636,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache sles12
 
 
@@ -750,7 +750,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache sles15
 
 
@@ -859,7 +859,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache focal
 
 
@@ -968,7 +968,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache jammy
 
 
@@ -1077,7 +1077,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache noble
 
 
@@ -1186,7 +1186,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache oracular
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -176,6 +176,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache centos8
 
 
@@ -289,6 +290,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache rockylinux9
 
 
@@ -397,6 +399,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache bookworm
 
 
@@ -505,6 +508,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache bullseye
 
 
@@ -632,6 +636,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache sles12
 
 
@@ -745,6 +750,7 @@ RUN ./pkg/rpm/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache sles15
 
 
@@ -853,6 +859,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache focal
 
 
@@ -961,6 +968,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache jammy
 
 
@@ -1069,6 +1077,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache noble
 
 
@@ -1177,6 +1186,7 @@ RUN ./pkg/deb/build.sh
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache oracular
 
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -265,7 +265,7 @@ ARG BUILD_DISTRO=windows-$WINDOWS_VERSION
 RUN Get-Content VERSION | Where-Object length | ForEach-Object { Invoke-Expression "`$env:$_" }; `
     go build -o bin/plugin.exe -ldflags \"-X github.com/GoogleCloudPlatform/ops-agent/internal/version.BuildDistro=$env:BUILD_DISTRO -X github.com/GoogleCloudPlatform/ops-agent/internal/version.Version=$env:PKG_VERSION\" ./cmd/ops_agent_uap_plugin; `
     Copy-Item -Path bin/plugin.exe -Destination /work/out/bin/; `
-    $env:PKG_VERSION | Out-File -FilePath /work/out/bin/VERSION -Encoding UTF8;
+    $env:PKG_VERSION | Out-File -FilePath /work/out/bin/OPS_AGENT_VERSION -Encoding UTF8;
 ###############################################################################
 # Packaging
 ###############################################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -265,8 +265,7 @@ ARG BUILD_DISTRO=windows-$WINDOWS_VERSION
 RUN Get-Content VERSION | Where-Object length | ForEach-Object { Invoke-Expression "`$env:$_" }; `
     go build -o bin/plugin.exe -ldflags \"-X github.com/GoogleCloudPlatform/ops-agent/internal/version.BuildDistro=$env:BUILD_DISTRO -X github.com/GoogleCloudPlatform/ops-agent/internal/version.Version=$env:PKG_VERSION\" ./cmd/ops_agent_uap_plugin; `
     Copy-Item -Path bin/plugin.exe -Destination /work/out/bin/; `
-    Copy-Item -Path VERSION -Destination /work/out/bin/;
-
+    $env:PKG_VERSION | Out-File -FilePath /work/out/bin/VERSION -Encoding UTF8;
 ###############################################################################
 # Packaging
 ###############################################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -264,7 +264,8 @@ ARG WINDOWS_VERSION
 ARG BUILD_DISTRO=windows-$WINDOWS_VERSION
 RUN Get-Content VERSION | Where-Object length | ForEach-Object { Invoke-Expression "`$env:$_" }; `
     go build -o bin/plugin.exe -ldflags \"-X github.com/GoogleCloudPlatform/ops-agent/internal/version.BuildDistro=$env:BUILD_DISTRO -X github.com/GoogleCloudPlatform/ops-agent/internal/version.Version=$env:PKG_VERSION\" ./cmd/ops_agent_uap_plugin; `
-    Copy-Item -Path bin/plugin.exe -Destination /work/out/bin/;
+    Copy-Item -Path bin/plugin.exe -Destination /work/out/bin/; `
+    Copy-Item -Path VERSION -Destination /work/out/bin/;
 
 ###############################################################################
 # Packaging

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -94,6 +94,7 @@ COPY --from={target_name}-build-wrapper /work/cache /work/cache
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
+RUN cp VERSION  /work/cache
 RUN ./pkg/plugin/build.sh /work/cache {target_name}
 
 

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -94,7 +94,7 @@ COPY --from={target_name}-build-wrapper /work/cache /work/cache
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/OPS_AGENT_VERSION
 RUN ./pkg/plugin/build.sh /work/cache {target_name}
 
 

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -89,7 +89,7 @@ COPY --from={target_name}-build-fluent-bit /work/cache /work/cache
 COPY --from={target_name}-build-systemd /work/cache /work/cache
 COPY --from={target_name}-build-diagnostics /work/cache /work/cache
 COPY --from={target_name}-build-wrapper /work/cache /work/cache
-# {package_build}
+{package_build}
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -89,12 +89,12 @@ COPY --from={target_name}-build-fluent-bit /work/cache /work/cache
 COPY --from={target_name}-build-systemd /work/cache /work/cache
 COPY --from={target_name}-build-diagnostics /work/cache /work/cache
 COPY --from={target_name}-build-wrapper /work/cache /work/cache
-{package_build}
+# {package_build}
 
 COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
 COPY ./builds/ops_agent_plugin.sh .
 RUN ./ops_agent_plugin.sh /work/cache/
-RUN cp VERSION  /work/cache
+RUN source VERSION && echo $PKG_VERSION  > /work/cache/VERSION
 RUN ./pkg/plugin/build.sh /work/cache {target_name}
 
 

--- a/pkg/plugin/build.ps1
+++ b/pkg/plugin/build.ps1
@@ -46,6 +46,7 @@ $FilesToInclude = @(
     "google-cloud-ops-agent-wrapper.exe"
     "plugin.exe"
     "THIRD_PARTY_LICENSES"
+    "VERSION"
 )
 
 # Create the tar archive

--- a/pkg/plugin/build.ps1
+++ b/pkg/plugin/build.ps1
@@ -46,7 +46,7 @@ $FilesToInclude = @(
     "google-cloud-ops-agent-wrapper.exe"
     "plugin.exe"
     "THIRD_PARTY_LICENSES"
-    "VERSION"
+    "OPS_AGENT_VERSION"
 )
 
 # Create the tar archive

--- a/pkg/plugin/build.sh
+++ b/pkg/plugin/build.sh
@@ -38,7 +38,7 @@ cp $WS/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_diagnostics ${P
 cp $WS/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol ${PLUGIN_DIR}/subagents/opentelemetry-collector/otelopscol
 cp $WS/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar ${PLUGIN_DIR}/subagents/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar
 cp $WS/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit ${PLUGIN_DIR}/subagents/fluent-bit/bin/fluent-bit
-cp $WS/VERSION ${PLUGIN_DIR}/VERSION
+cp $WS/OPS_AGENT_VERSION ${PLUGIN_DIR}/OPS_AGENT_VERSION
 
 tar -cvzf /google-cloud-ops-agent-plugin_${PKG_VERSION}-${TARGET_NAME}-$TARGETARCH.tar.gz -C $PLUGIN_DIR/ .
 echo 'DONE creating plugin'

--- a/pkg/plugin/build.sh
+++ b/pkg/plugin/build.sh
@@ -38,6 +38,7 @@ cp $WS/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_diagnostics ${P
 cp $WS/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol ${PLUGIN_DIR}/subagents/opentelemetry-collector/otelopscol
 cp $WS/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar ${PLUGIN_DIR}/subagents/opentelemetry-collector/opentelemetry-java-contrib-jmx-metrics.jar
 cp $WS/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit ${PLUGIN_DIR}/subagents/fluent-bit/bin/fluent-bit
+cp $WS/VERSION ${PLUGIN_DIR}/VERSION
 
 tar -cvzf /google-cloud-ops-agent-plugin_${PKG_VERSION}-${TARGET_NAME}-$TARGETARCH.tar.gz -C $PLUGIN_DIR/ .
 echo 'DONE creating plugin'


### PR DESCRIPTION
## Description
Ensure the Ops Agent version is available within the UAP plugin content.

## Related issue
b/406575604
## How has this been tested?


## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
