### PR TITLE
Fix TestNetworkHealthCheck test for UAP Plugin

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4874,7 +4874,6 @@ func TestNetworkHealthCheck(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		time.Sleep(time.Second * 30) // Allow some time for the health check to run after restart.
 		cmdOut, err = getHealthCheckResultsForImage(ctx, logger, vm)
 		if err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4844,9 +4844,6 @@ func TestNetworkHealthCheck(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
-		if !isHealthCheckTestImage(imageSpec) {
-			t.SkipNow()
-		}
 
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 
@@ -4877,6 +4874,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		time.Sleep(time.Second * 30) // Allow some time for the health check to run after restart.
 		cmdOut, err = getHealthCheckResultsForImage(ctx, logger, vm)
 		if err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4868,7 +4868,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 		if _, err := gce.AddTagToVm(ctx, logger, vm, []string{gce.DenyEgressTrafficTag}); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(time.Minute)
+		time.Sleep(2 * time.Minute)
 
 		if _, err := gce.RunRemotely(ctx, logger, vm, agents.StartCommandForImage(vm.ImageSpec)); err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4844,6 +4844,9 @@ func TestNetworkHealthCheck(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
+		if !isHealthCheckTestImage(imageSpec) {
+			t.SkipNow()
+		}
 
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 


### PR DESCRIPTION
## Description
The `TestNetworkHealthCheck` test persistently fails during Louhi nightly runs for the UAP plugin on Windows 2022. This failure is likely due to a race condition where the health check is generated before the network firewall takes effect. To avoid this, the sleep duration between applying the network tag and restarting the ops agent will be extended to 2 minutes.
## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/399399492 

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
