### PR TITLE
Update go version to 1.23 in `go_test.Dockerfile`.

### DIFF
--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -14,7 +14,7 @@
 
 # To edit this file, follow these instructions: go/sdi-integ-test#updating-the-test-runner-container.
 
-FROM golang:1.22-bullseye
+FROM golang:1.23-bullseye
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 


### PR DESCRIPTION
## Description
To update the repo version of go in `go.mod`, the integration test container image go version needs to match the new version. See https://github.com/GoogleCloudPlatform/ops-agent/pull/1924.

Following instructions in go/sdi-integ-test#updating-the-test-runner-container .

## Related issue
b/408029807

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
