### PR TITLE
[Testing] Upgrade test container to go 1.24.

### DIFF
--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -14,7 +14,7 @@
 
 # To edit this file, follow these instructions: go/sdi-integ-test#updating-the-test-runner-container.
 
-FROM golang:1.23-bullseye
+FROM golang:1.24-bullseye
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 


### PR DESCRIPTION
## Description
This is for https://github.com/GoogleCloudPlatform/ops-agent/pull/1936.

I'm following instructions in
go/sdi-integ-test#updating-the-test-runner-container. 

## Related issue
b/410866041

## How has this been tested?
tested locally using instructions in go/sdi-integ-test#updating-the-test-runner-container. There's some auth issue, but it's unrelated to this PR.

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
