### PR TITLE
[Testing] Move GetConfigPath out of util into agents

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -213,8 +213,8 @@ func getOpsAgentLogFilesList(imageSpec string) []string {
 	if gce.IsOpsAgentUAPPlugin() {
 		return []string{
 			gce.SyslogLocation(imageSpec),
+			OpsAgentConfigPath(imageSpec),
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/google-cloud-ops-agent/health-checks.log",
-			"/etc/google-cloud-ops-agent/config.yaml",
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/google-cloud-ops-agent/subagents/logging-module.log",
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/google-cloud-ops-agent/subagents/metrics-module.log",
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/nvidia-installer.log",
@@ -227,8 +227,8 @@ func getOpsAgentLogFilesList(imageSpec string) []string {
 	}
 	return []string{
 		gce.SyslogLocation(imageSpec),
+		OpsAgentConfigPath(imageSpec),
 		"/var/log/google-cloud-ops-agent/health-checks.log",
-		"/etc/google-cloud-ops-agent/config.yaml",
 		"/var/log/google-cloud-ops-agent/subagents/logging-module.log",
 		"/var/log/google-cloud-ops-agent/subagents/metrics-module.log",
 		"/var/log/nvidia-installer.log",
@@ -260,7 +260,7 @@ func runOpsAgentDiagnosticsWindows(ctx context.Context, logger *logging.Director
 	gce.RunRemotely(ctx, logger.ToFile("health-checks.txt"), vm, fmt.Sprintf("Get-Content -Path '%s' -Raw", stateDir+`log\health-checks.log`))
 
 	for _, conf := range []string{
-		`C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`,
+		OpsAgentConfigPath(imageSpec),
 		stateDir + `generated_configs\fluentbit\fluent_bit_main.conf`,
 		stateDir + `generated_configs\fluentbit\fluent_bit_parser.conf`,
 		stateDir + `generated_configs\otel\otel.yaml`,
@@ -961,7 +961,7 @@ func SetupOpsAgentFrom(ctx context.Context, logger *log.Logger, vm *gce.VM, conf
 			// services have not fully started up yet.
 			time.Sleep(startupDelay)
 		}
-		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), util.GetConfigPath(vm.ImageSpec)); err != nil {
+		if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), OpsAgentConfigPath(vm.ImageSpec)); err != nil {
 			return fmt.Errorf("SetupOpsAgentFrom() failed to upload config file: %v", err)
 		}
 	}
@@ -1184,6 +1184,15 @@ func installWindowsPackageFromGCS(ctx context.Context, logger *log.Logger, vm *g
 		return fmt.Errorf("error installing agent from .goo file: %v", err)
 	}
 	return nil
+}
+
+// OpsAgentConfigPath returns the platform-specific filesystem location where
+// the Ops Agent config is stored.
+func OpsAgentConfigPath(imageSpec string) string {
+	if gce.IsWindows(imageSpec) {
+		return `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
+	}
+	return "/etc/google-cloud-ops-agent/config.yaml"
 }
 
 func GetOtelConfigPath(imageSpec string) string {

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -600,7 +600,7 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 	}
 	time.Sleep(60 * time.Second)
 
-	backupConfigFilePath := util.GetConfigPath(vm.ImageSpec) + ".bak"
+	backupConfigFilePath := agents.OpsAgentConfigPath(vm.ImageSpec) + ".bak"
 	if err = assertFilePresence(ctx, logger.ToMainLog(), vm, backupConfigFilePath); err != nil {
 		return nonRetryable, fmt.Errorf("error when fetching back up config file %s: %v", backupConfigFilePath, err)
 	}

--- a/integration_test/util/util.go
+++ b/integration_test/util/util.go
@@ -18,16 +18,7 @@ package util
 
 import (
 	"fmt"
-
-	"github.com/GoogleCloudPlatform/ops-agent/integration_test/gce"
 )
-
-func GetConfigPath(imageSpec string) string {
-	if gce.IsWindows(imageSpec) {
-		return `C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml`
-	}
-	return "/etc/google-cloud-ops-agent/config.yaml"
-}
 
 // DumpPointerArray formats the given array of pointers-to-structs as a strings
 // using the given format, rather than just formatting them as addresses.


### PR DESCRIPTION
## Description
As a preparation step for https://github.com/GoogleCloudPlatform/ops-agent/pull/1936, this cuts an unnecessary dependency edge from util -> gce and puts a simple helper function into `agents.go` where it belongs.

## Related issue
b/410866041

## How has this been tested?
presubmits

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
