### PR TITLE
Update Go version to 1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG CMAKE_VERSION=3.25.2
 ARG OPENJDK_MAJOR_VERSION=17
 ARG OPENJDK_FULL_VERSION=17.0.8
 ARG OPENJDK_VERSION_SUFFIX=7
-ARG GO_VERSION=1.21.11
+ARG GO_VERSION=1.24.3
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -77,10 +77,10 @@ RUN Expand-Archive /local/win_flex_bison.zip -Destination /WinFlexBison; `
 #
 # Install Golang
 #
-ADD https://go.dev/dl/go1.21.11.windows-amd64.msi /local/go1.21.11.windows-amd64.msi
+ADD https://go.dev/dl/go1.24.3.windows-amd64.msi /local/go1.24.3.windows-amd64.msi
 
 RUN Start-Process msiexec.exe `
-    -ArgumentList '/i C:\local\go1.21.11.windows-amd64.msi ', '/quiet ', `
+    -ArgumentList '/i C:\local\go1.24.3.windows-amd64.msi ', '/quiet ', `
     '/norestart ', 'ALLUSERS=1,INSTALLDIR=C:\Go' -NoNewWindow -Wait;
 
 #

--- a/dockerfiles/template-header
+++ b/dockerfiles/template-header
@@ -24,7 +24,7 @@ ARG CMAKE_VERSION=3.25.2
 ARG OPENJDK_MAJOR_VERSION=17
 ARG OPENJDK_FULL_VERSION=17.0.8
 ARG OPENJDK_VERSION_SUFFIX=7
-ARG GO_VERSION=1.21.11
+ARG GO_VERSION=1.24.3
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager


### PR DESCRIPTION
## Description
Update Go version to 1.24.3

## Related issue
[b/417214181](http://b/417214181)

## How has this been tested?
Unit tests and integration tests should all pass with this change. 

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
