### PR TITLE
Remove extra whitespace from iisMergeRecordFields lua script

### DIFF
--- a/apps/iis.go
+++ b/apps/iis.go
@@ -175,11 +175,11 @@ const (
 	  else
 		record["http_request_requestUrl"] = table.concat({record["cs_uri_stem"], "?", record["cs_uri_query"]})
 	  end
-	  
+
 	  record["cs_uri_query"] = nil
 	  record["cs_uri_stem"] = nil
 	  record["s_port"] = nil
-	  return 2, timestamp, record 
+	  return 2, timestamp, record
 	end
 	`
 )

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/95e2e82d775f42f2e585263a1590daa0.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/95e2e82d775f42f2e585263a1590daa0.lua
@@ -17,10 +17,10 @@
 	  else
 		record["http_request_requestUrl"] = table.concat({record["cs_uri_stem"], "?", record["cs_uri_query"]})
 	  end
-	  
+
 	  record["cs_uri_query"] = nil
 	  record["cs_uri_stem"] = nil
 	  record["s_port"] = nil
-	  return 2, timestamp, record 
+	  return 2, timestamp, record
 	end
 	

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/fluent_bit_main.conf
@@ -156,7 +156,7 @@
     Match  iis.iis_access
     Name   lua
     call   iis_merge_fields
-    script c4a02ad01ceead92b7ebcde9cc09540d.lua
+    script 95e2e82d775f42f2e585263a1590daa0.lua
 
 [FILTER]
     Exclude message ^#(?:Fields|Date|Version|Software):

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/95e2e82d775f42f2e585263a1590daa0.lua
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/95e2e82d775f42f2e585263a1590daa0.lua
@@ -17,10 +17,10 @@
 	  else
 		record["http_request_requestUrl"] = table.concat({record["cs_uri_stem"], "?", record["cs_uri_query"]})
 	  end
-	  
+
 	  record["cs_uri_query"] = nil
 	  record["cs_uri_stem"] = nil
 	  record["s_port"] = nil
-	  return 2, timestamp, record 
+	  return 2, timestamp, record
 	end
 	

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/fluent_bit_main.conf
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/fluent_bit_main.conf
@@ -156,7 +156,7 @@
     Match  iis.iis_access
     Name   lua
     call   iis_merge_fields
-    script c4a02ad01ceead92b7ebcde9cc09540d.lua
+    script 95e2e82d775f42f2e585263a1590daa0.lua
 
 [FILTER]
     Exclude message ^#(?:Fields|Date|Version|Software):


### PR DESCRIPTION
## Description
This change removes extra whitespace from iisMergeRecordFields lua script

## Related issue
N/A

## How has this been tested?

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.