### PR TITLE
Deprecate instrumentation scope processor

### DIFF
--- a/apps/active_directory_ds.go
+++ b/apps/active_directory_ds.go
@@ -45,7 +45,10 @@ func (r MetricsReceiverActiveDirectoryDS) Pipelines(_ context.Context) ([]otel.R
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/activemq.go
+++ b/apps/activemq.go
@@ -47,7 +47,10 @@ func (r MetricsReceiverActivemq) Pipelines(_ context.Context) ([]otel.ReceiverPi
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/aerospike.go
+++ b/apps/aerospike.go
@@ -96,8 +96,9 @@ func (r MetricsReceiverAerospike) Pipelines(_ context.Context) ([]otel.ReceiverP
 			otel.TransformationMetrics(
 				otel.FlattenResourceAttribute("aerospike.node.name", "node_name"),
 				otel.FlattenResourceAttribute("aerospike.namespace", "namespace_name"),
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/apache.go
+++ b/apps/apache.go
@@ -60,8 +60,9 @@ func (r MetricsReceiverApache) Pipelines(_ context.Context) ([]otel.ReceiverPipe
 			),
 			otel.TransformationMetrics(
 				otel.FlattenResourceAttribute("apache.server.name", "server_name"),
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/cassandra.go
+++ b/apps/cassandra.go
@@ -48,7 +48,10 @@ func (r MetricsReceiverCassandra) Pipelines(_ context.Context) ([]otel.ReceiverP
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/couchbase.go
+++ b/apps/couchbase.go
@@ -160,8 +160,13 @@ func (r MetricsReceiverCouchbase) Pipelines(_ context.Context) ([]otel.ReceiverP
 				otel.AddPrefix("workload.googleapis.com"),
 			),
 			// Using the transform processor for metrics
-			otel.TransformationMetrics(r.transformMetrics()...),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				append(
+					r.transformMetrics(),
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				)...
+			),
 		}},
 	}}, nil
 }

--- a/apps/couchbase.go
+++ b/apps/couchbase.go
@@ -165,7 +165,7 @@ func (r MetricsReceiverCouchbase) Pipelines(_ context.Context) ([]otel.ReceiverP
 					r.transformMetrics(),
 					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
 					otel.SetScopeVersion("1.0"),
-				)...
+				)...,
 			),
 		}},
 	}}, nil

--- a/apps/couchdb.go
+++ b/apps/couchdb.go
@@ -59,7 +59,10 @@ func (r MetricsReceiverCouchdb) Pipelines(_ context.Context) ([]otel.ReceiverPip
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/dcgm.go
+++ b/apps/dcgm.go
@@ -88,8 +88,9 @@ func (r MetricsReceiverDcgm) Pipelines(_ context.Context) ([]otel.ReceiverPipeli
 					otel.FlattenResourceAttribute("gpu.model", "model"),
 					otel.FlattenResourceAttribute("gpu.number", "gpu_number"),
 					otel.FlattenResourceAttribute("gpu.uuid", "uuid"),
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("2.0"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "2.0"),
 			}},
 		}}, nil
 	}
@@ -133,7 +134,7 @@ func (r MetricsReceiverDcgm) Pipelines(_ context.Context) ([]otel.ReceiverPipeli
 			Config: map[string]interface{}{
 				"collection_interval": r.CollectionIntervalString(),
 				"endpoint":            r.Endpoint,
-				"metrics": metricsConfig,
+				"metrics":             metricsConfig,
 			},
 		},
 		Processors: map[string][]otel.Component{"metrics": {
@@ -199,8 +200,9 @@ func (r MetricsReceiverDcgm) Pipelines(_ context.Context) ([]otel.ReceiverPipeli
 				otel.FlattenResourceAttribute("gpu.model", "model"),
 				otel.FlattenResourceAttribute("gpu.number", "gpu_number"),
 				otel.FlattenResourceAttribute("gpu.uuid", "uuid"),
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/elasticsearch.go
+++ b/apps/elasticsearch.go
@@ -89,7 +89,10 @@ func (r MetricsReceiverElasticsearch) Pipelines(_ context.Context) ([]otel.Recei
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/flink.go
+++ b/apps/flink.go
@@ -61,8 +61,9 @@ func (r MetricsReceiverFlink) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 				otel.FlattenResourceAttribute("flink.task.name", "task_name"),
 				otel.FlattenResourceAttribute("flink.subtask.index", "subtask_index"),
 				otel.FlattenResourceAttribute("flink.resource.type", "resource_type"),
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/hadoop.go
+++ b/apps/hadoop.go
@@ -50,7 +50,10 @@ func (r MetricsReceiverHadoop) Pipelines(_ context.Context) ([]otel.ReceiverPipe
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/hbase.go
+++ b/apps/hbase.go
@@ -53,7 +53,10 @@ func (r MetricsReceiverHbase) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 						otel.AggregateLabels("max", "state"),
 					),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/iis.go
+++ b/apps/iis.go
@@ -49,6 +49,8 @@ func (r MetricsReceiverIis) Pipelines(_ context.Context) ([]otel.ReceiverPipelin
 				otel.TransformationMetrics(
 					otel.FlattenResourceAttribute("iis.site", "site"),
 					otel.FlattenResourceAttribute("iis.application_pool", "app_pool"),
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("2.0"),
 				),
 				// Drop all resource keys; Must be done in a separate transform,
 				// otherwise the above flatten resource attribute queries will only
@@ -68,7 +70,6 @@ func (r MetricsReceiverIis) Pipelines(_ context.Context) ([]otel.ReceiverPipelin
 					otel.AddPrefix("workload.googleapis.com"),
 				),
 				otel.NormalizeSums(),
-				otel.ModifyInstrumentationScope(r.Type(), "2.0"),
 			}},
 		}}, nil
 	}
@@ -137,7 +138,10 @@ func (r MetricsReceiverIis) Pipelines(_ context.Context) ([]otel.ReceiverPipelin
 				"agent.googleapis.com/iis/request_count",
 			),
 			otel.NormalizeSums(),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/jetty.go
+++ b/apps/jetty.go
@@ -50,7 +50,10 @@ func (r MetricsReceiverJetty) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/jvm.go
+++ b/apps/jvm.go
@@ -43,7 +43,10 @@ func (r MetricsReceiverJVM) Pipelines(_ context.Context) ([]otel.ReceiverPipelin
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/kafka.go
+++ b/apps/kafka.go
@@ -63,7 +63,10 @@ func (r MetricsReceiverKafka) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/memcached.go
+++ b/apps/memcached.go
@@ -59,7 +59,10 @@ func (r MetricsReceiverMemcached) Pipelines(_ context.Context) ([]otel.ReceiverP
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/mongodb.go
+++ b/apps/mongodb.go
@@ -82,7 +82,10 @@ func (r MetricsReceiverMongoDB) Pipelines(_ context.Context) ([]otel.ReceiverPip
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/mssql.go
+++ b/apps/mssql.go
@@ -53,9 +53,10 @@ func (m MetricsReceiverMssql) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 				),
 				otel.TransformationMetrics(
 					otel.FlattenResourceAttribute("sqlserver.database.name", "database"),
+					otel.SetScopeName("agent.googleapis.com/"+m.Type()),
+					otel.SetScopeVersion("2.0"),
 				),
 				otel.NormalizeSums(),
-				otel.ModifyInstrumentationScope(m.Type(), "2.0"),
 			}},
 		}}, nil
 	}
@@ -101,7 +102,10 @@ func (m MetricsReceiverMssql) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 				),
 				otel.AddPrefix("agent.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(m.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+m.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/mysql.go
+++ b/apps/mysql.go
@@ -120,7 +120,10 @@ func (r MetricsReceiverMySql) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 					),
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			}},
 		},
 	}, nil

--- a/apps/nginx.go
+++ b/apps/nginx.go
@@ -53,7 +53,10 @@ func (r MetricsReceiverNginx) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/oracledb.go
+++ b/apps/oracledb.go
@@ -119,7 +119,10 @@ func (r MetricsReceiverOracleDB) Pipelines(_ context.Context) ([]otel.ReceiverPi
 					otel.RenameLabel("WAIT_CLASS", "wait_class"),
 				),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/postgresql.go
+++ b/apps/postgresql.go
@@ -92,6 +92,8 @@ func (r MetricsReceiverPostgresql) Pipelines(_ context.Context) ([]otel.Receiver
 				// The two metrics are mutually exclusive so we do not need to worry about overwriting or removing the original wal.lag.
 				otel.ConvertFloatToInt("postgresql.wal.delay"),
 				otel.SetName("postgresql.wal.delay", "postgresql.wal.lag"),
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
 			otel.MetricsTransform(
 				otel.UpdateMetric("postgresql.bgwriter.duration",
@@ -99,7 +101,6 @@ func (r MetricsReceiverPostgresql) Pipelines(_ context.Context) ([]otel.Receiver
 				),
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/rabbitmq.go
+++ b/apps/rabbitmq.go
@@ -161,8 +161,9 @@ func (r MetricsReceiverRabbitmq) Pipelines(_ context.Context) ([]otel.ReceiverPi
 				otel.FlattenResourceAttribute("rabbitmq.queue.name", "queue_name"),
 				otel.FlattenResourceAttribute("rabbitmq.node.name", "node_name"),
 				otel.FlattenResourceAttribute("rabbitmq.vhost.name", "vhost_name"),
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/redis.go
+++ b/apps/redis.go
@@ -74,7 +74,10 @@ func (r MetricsReceiverRedis) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/saphana.go
+++ b/apps/saphana.go
@@ -182,8 +182,9 @@ func (s MetricsReceiverSapHana) Pipelines(_ context.Context) ([]otel.ReceiverPip
 			),
 			otel.TransformationMetrics(
 				otel.FlattenResourceAttribute("saphana.host", "host"),
+				otel.SetScopeName("agent.googleapis.com/"+s.Type()),
+				otel.SetScopeVersion("1.0"),
 			),
-			otel.ModifyInstrumentationScope(s.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/solr.go
+++ b/apps/solr.go
@@ -46,7 +46,10 @@ func (r MetricsReceiverSolr) Pipelines(_ context.Context) ([]otel.ReceiverPipeli
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/tomcat.go
+++ b/apps/tomcat.go
@@ -48,7 +48,10 @@ func (r MetricsReceiverTomcat) Pipelines(_ context.Context) ([]otel.ReceiverPipe
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/varnish.go
+++ b/apps/varnish.go
@@ -48,7 +48,10 @@ func (r MetricsReceiverVarnish) Pipelines(_ context.Context) ([]otel.ReceiverPip
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/apps/vault.go
+++ b/apps/vault.go
@@ -138,7 +138,13 @@ func (r MetricsReceiverVault) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 			},
 		},
 		Processors: map[string][]otel.Component{"metrics": {
-			otel.TransformationMetrics(queries...),
+			otel.TransformationMetrics(
+				append(
+					queries,
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				)...,
+			),
 			otel.MetricsFilter(
 				"include",
 				"strict",
@@ -172,7 +178,6 @@ func (r MetricsReceiverVault) Pipelines(_ context.Context) ([]otel.ReceiverPipel
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
 		}},
 	}}, nil
 }

--- a/apps/wildfly.go
+++ b/apps/wildfly.go
@@ -52,7 +52,10 @@ func (r MetricsReceiverWildfly) Pipelines(_ context.Context) ([]otel.ReceiverPip
 				otel.MetricsTransform(
 					otel.AddPrefix("workload.googleapis.com"),
 				),
-				otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+				otel.TransformationMetrics(
+					otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+					otel.SetScopeVersion("1.0"),
+				),
 			},
 		)
 }

--- a/apps/zookeeper.go
+++ b/apps/zookeeper.go
@@ -58,7 +58,10 @@ func (r MetricsReceiverZookeeper) Pipelines(_ context.Context) ([]otel.ReceiverP
 			otel.MetricsTransform(
 				otel.AddPrefix("workload.googleapis.com"),
 			),
-			otel.ModifyInstrumentationScope(r.Type(), "1.0"),
+			otel.TransformationMetrics(
+				otel.SetScopeName("agent.googleapis.com/"+r.Type()),
+				otel.SetScopeVersion("1.0"),
+			),
 		}},
 	}}, nil
 }

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -515,19 +515,6 @@ func CondenseResourceMetrics() Component {
 	}
 }
 
-// ModifyInstrumentationScope sets the instrumentation scope name and version
-// fields which will later be exported to Cloud Monitoring metric labels.
-// The name will always be prefixed with "agent.googleapis.com/".
-func ModifyInstrumentationScope(name string, version string) Component {
-	return Component{
-		Type: "modifyscope",
-		Config: map[string]interface{}{
-			"override_scope_name":    "agent.googleapis.com/" + name,
-			"override_scope_version": version,
-		},
-	}
-}
-
 // GroupByGMPAttrs moves the "namespace", "cluster", and "location"
 // metric attributes to resource attributes. The
 // googlemanagedprometheus exporter will use these resource attributes

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -188,11 +188,15 @@ func Filter(dataType, context string, expressions []ottl.Value) Component {
 func TransformationMetrics(queries ...TransformQuery) Component {
 	metricQueryStrings := []string{}
 	datapointQueryStrings := []string{}
+	scopeQueryStrings := []string{}
+
 	for _, q := range queries {
 		switch q.Context {
 		case Metric:
 			metricQueryStrings = append(metricQueryStrings, string(q.Statement))
-		default:
+		case Scope:
+			scopeQueryStrings = append(scopeQueryStrings, string(q.Statement))
+		case Datapoint:
 			datapointQueryStrings = append(datapointQueryStrings, string(q.Statement))
 		}
 	}
@@ -213,6 +217,14 @@ func TransformationMetrics(queries ...TransformQuery) Component {
 		}
 		metricStatements = append(metricStatements, datapointMetricStatement)
 	}
+	if len(scopeQueryStrings) != 0 {
+		scopeMetricStatement := map[string]any{
+			"context":    "scope",
+			"statements": scopeQueryStrings,
+		}
+		metricStatements = append(metricStatements, scopeMetricStatement)
+	}
+
 	return Component{
 		Type: "transform",
 		Config: map[string]any{
@@ -227,6 +239,7 @@ type TransformQueryContext string
 const (
 	Metric    TransformQueryContext = "metric"
 	Datapoint TransformQueryContext = "datapoint"
+	Scope     TransformQueryContext = "scope"
 )
 
 // TransformQuery is a type wrapper for query expressions supported by the transform
@@ -329,6 +342,22 @@ func RetainResource(resourceAttributeKeys ...string) TransformQuery {
 	return TransformQuery{
 		Context:   Datapoint,
 		Statement: fmt.Sprintf(`keep_keys(resource.attributes, [%s])`, strings.Join(resourceAttributeKeys[:], ",")),
+	}
+}
+
+// SetScopeName returns a metrics transform that sets the name of the instrumentation scope
+func SetScopeName(newName string) TransformQuery {
+	return TransformQuery{
+		Context:   Scope,
+		Statement: fmt.Sprintf(`set(name, "%s")`, newName),
+	}
+}
+
+// SetScopeVersion returns a metrics transform that sets the version of the instrumentation scope
+func SetScopeVersion(newVersion string) TransformQuery {
+	return TransformQuery{
+		Context:   Scope,
+		Statement: fmt.Sprintf(`set(version, "%s")`, newVersion),
 	}
 }
 

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -683,7 +689,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -693,7 +699,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -683,7 +689,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -693,7 +699,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -517,12 +517,6 @@ processors:
       include: ^[AB](.*)$$
       match_type: regexp
       new_name: $${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -531,6 +525,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -641,7 +647,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -651,7 +657,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -517,12 +517,6 @@ processors:
       include: ^[AB](.*)$$
       match_type: regexp
       new_name: $${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -531,6 +525,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -641,7 +647,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -651,7 +657,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -646,7 +652,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -656,7 +662,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -646,7 +652,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -656,7 +662,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -646,7 +652,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -656,7 +662,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -646,7 +652,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -656,7 +662,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -646,7 +652,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -656,7 +662,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -508,12 +508,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -526,6 +520,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -646,7 +652,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -656,7 +662,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -500,12 +500,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -514,6 +508,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -634,7 +640,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +650,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -500,12 +500,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -514,6 +508,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -634,7 +640,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +650,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -499,16 +499,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -598,6 +598,12 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1107,7 +1113,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1117,7 +1123,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -499,16 +499,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -598,6 +598,12 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1107,7 +1113,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1117,7 +1123,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -499,16 +499,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -593,6 +593,12 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1074,7 +1080,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1084,7 +1090,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -499,16 +499,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -593,6 +593,12 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1074,7 +1080,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1084,7 +1090,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -499,16 +499,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -538,6 +538,12 @@ processors:
       - set(cache["value"], cache["__field_3"])
       - set(cache["value"], "log_source_id1") where cache["value"] == nil
       - set(attributes["gcp.log_name"], cache["value"]) where (cache != nil and cache["value"] != nil)
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1018,7 +1024,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1028,7 +1034,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -499,16 +499,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -538,6 +538,12 @@ processors:
       - set(cache["value"], cache["__field_3"])
       - set(cache["value"], "log_source_id1") where cache["value"] == nil
       - set(attributes["gcp.log_name"], cache["value"]) where (cache != nil and cache["value"] != nil)
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1018,7 +1024,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1028,7 +1034,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -506,16 +506,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -622,7 +628,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -632,7 +638,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -506,16 +506,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -622,7 +628,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -632,7 +638,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -497,16 +497,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -613,7 +619,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -623,7 +629,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -497,16 +497,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -613,7 +619,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -623,7 +629,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -497,16 +497,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -613,7 +619,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -623,7 +629,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -497,16 +497,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -613,7 +619,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -623,7 +629,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -530,12 +530,6 @@ processors:
       include: ^[AB](.*)$$
       match_type: regexp
       new_name: $${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -544,6 +538,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -654,7 +660,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -664,7 +670,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -530,12 +530,6 @@ processors:
       include: ^[AB](.*)$$
       match_type: regexp
       new_name: $${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -544,6 +538,18 @@ processors:
     detectors:
     - gcp
     override: false
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -654,7 +660,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -664,7 +670,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,7 +547,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -513,7 +516,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,7 +547,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -513,7 +516,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/activemq_2:
-    override_scope_name: agent.googleapis.com/activemq
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/activemq_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/activemq_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/activemq")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/activemq_0
       - metricstransform/activemq_1
-      - modifyscope/activemq_2
+      - transform/activemq_2
       - resourcedetection/_global_0
       receivers:
       - jmx/activemq
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/aerospike_3:
-    override_scope_name: agent.googleapis.com/aerospike
-    override_scope_version: "1.0"
   normalizesums/aerospike_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -482,6 +479,10 @@ processors:
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/aerospike")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -551,7 +552,6 @@ service:
       - normalizesums/aerospike_0
       - metricstransform/aerospike_1
       - transform/aerospike_2
-      - modifyscope/aerospike_3
       - resourcedetection/_global_0
       receivers:
       - aerospike/aerospike

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/aerospike_3:
-    override_scope_name: agent.googleapis.com/aerospike
-    override_scope_version: "1.0"
   normalizesums/aerospike_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -453,6 +450,10 @@ processors:
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/aerospike")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -520,7 +521,6 @@ service:
       - normalizesums/aerospike_0
       - metricstransform/aerospike_1
       - transform/aerospike_2
-      - modifyscope/aerospike_3
       - resourcedetection/_global_0
       receivers:
       - aerospike/aerospike

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
@@ -505,15 +505,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/aerospike_3:
-    override_scope_name: agent.googleapis.com/aerospike
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/aerospike_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -525,6 +516,22 @@ processors:
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/aerospike")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -627,7 +634,6 @@ service:
       - normalizesums/aerospike_0
       - metricstransform/aerospike_1
       - transform/aerospike_2
-      - modifyscope/aerospike_3
       - resourcedetection/_global_0
       receivers:
       - aerospike/aerospike
@@ -649,7 +655,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -659,7 +665,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
@@ -505,15 +505,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/aerospike_3:
-    override_scope_name: agent.googleapis.com/aerospike
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/aerospike_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -525,6 +516,22 @@ processors:
       statements:
       - set(attributes["node_name"], resource.attributes["aerospike.node.name"])
       - set(attributes["namespace_name"], resource.attributes["aerospike.namespace"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/aerospike")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -627,7 +634,6 @@ service:
       - normalizesums/aerospike_0
       - metricstransform/aerospike_1
       - transform/aerospike_2
-      - modifyscope/aerospike_3
       - resourcedetection/_global_0
       receivers:
       - aerospike/aerospike
@@ -649,7 +655,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -659,7 +665,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
@@ -475,9 +475,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -487,6 +484,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -553,7 +554,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
@@ -446,9 +446,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -458,6 +455,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -522,7 +523,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
@@ -511,15 +511,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -530,6 +521,22 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -629,7 +636,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache
@@ -651,7 +657,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -661,7 +667,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
@@ -511,15 +511,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -530,6 +521,22 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -629,7 +636,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache
@@ -651,7 +657,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -661,7 +667,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -475,9 +475,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -487,6 +484,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -553,7 +554,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
@@ -446,9 +446,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -458,6 +455,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -522,7 +523,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -511,15 +511,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -530,6 +521,22 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -629,7 +636,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache
@@ -651,7 +657,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -661,7 +667,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
@@ -511,15 +511,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/apache_4:
-    override_scope_name: agent.googleapis.com/apache
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/apache_1: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -530,6 +521,22 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["server_name"], resource.attributes["apache.server.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/apache")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -629,7 +636,6 @@ service:
       - normalizesums/apache_1
       - metricstransform/apache_2
       - transform/apache_3
-      - modifyscope/apache_4
       - resourcedetection/_global_0
       receivers:
       - apache/apache
@@ -651,7 +657,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -661,7 +667,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,7 +547,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -513,7 +516,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,7 +547,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -513,7 +516,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/cassandra_2:
-    override_scope_name: agent.googleapis.com/cassandra
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/cassandra_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/cassandra_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/cassandra")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -620,7 +629,7 @@ service:
       processors:
       - normalizesums/cassandra_0
       - metricstransform/cassandra_1
-      - modifyscope/cassandra_2
+      - transform/cassandra_2
       - resourcedetection/_global_0
       receivers:
       - jmx/cassandra
@@ -642,7 +651,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -652,7 +661,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -559,9 +559,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchbase_4:
-    override_scope_name: agent.googleapis.com/couchbase
-    override_scope_version: "1.0"
   normalizesums/couchbase_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -591,6 +588,10 @@ processors:
       - set(metric.unit, "{operations}") where metric.name == "workload.googleapis.com/couchbase.bucket.operation.count"
       - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
       - set(metric.unit, "{vbuckets}") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchbase")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -670,7 +671,6 @@ service:
       - filter/couchbase_1
       - metricstransform/couchbase_2
       - transform/couchbase_3
-      - modifyscope/couchbase_4
       - resourcedetection/_global_0
       receivers:
       - prometheus/couchbase

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
@@ -530,9 +530,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchbase_4:
-    override_scope_name: agent.googleapis.com/couchbase
-    override_scope_version: "1.0"
   normalizesums/couchbase_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -562,6 +559,10 @@ processors:
       - set(metric.unit, "{operations}") where metric.name == "workload.googleapis.com/couchbase.bucket.operation.count"
       - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
       - set(metric.unit, "{vbuckets}") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchbase")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -639,7 +640,6 @@ service:
       - filter/couchbase_1
       - metricstransform/couchbase_2
       - transform/couchbase_3
-      - modifyscope/couchbase_4
       - resourcedetection/_global_0
       receivers:
       - prometheus/couchbase

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -595,15 +595,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchbase_4:
-    override_scope_name: agent.googleapis.com/couchbase
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/couchbase_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -634,6 +625,22 @@ processors:
       - set(metric.unit, "{operations}") where metric.name == "workload.googleapis.com/couchbase.bucket.operation.count"
       - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
       - set(metric.unit, "{vbuckets}") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchbase")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -746,7 +753,6 @@ service:
       - filter/couchbase_1
       - metricstransform/couchbase_2
       - transform/couchbase_3
-      - modifyscope/couchbase_4
       - resourcedetection/_global_0
       receivers:
       - prometheus/couchbase
@@ -768,7 +774,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -778,7 +784,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
@@ -595,15 +595,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchbase_4:
-    override_scope_name: agent.googleapis.com/couchbase
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/couchbase_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -634,6 +625,22 @@ processors:
       - set(metric.unit, "{operations}") where metric.name == "workload.googleapis.com/couchbase.bucket.operation.count"
       - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
       - set(metric.unit, "{vbuckets}") where metric.name == "workload.googleapis.com/couchbase.bucket.vbucket.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchbase")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -746,7 +753,6 @@ service:
       - filter/couchbase_1
       - metricstransform/couchbase_2
       - transform/couchbase_3
-      - modifyscope/couchbase_4
       - resourcedetection/_global_0
       receivers:
       - prometheus/couchbase
@@ -768,7 +774,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -778,7 +784,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchdb_2:
-    override_scope_name: agent.googleapis.com/couchdb
-    override_scope_version: "1.0"
   normalizesums/couchdb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/couchdb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchdb")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -542,7 +545,7 @@ service:
       processors:
       - normalizesums/couchdb_0
       - metricstransform/couchdb_1
-      - modifyscope/couchdb_2
+      - transform/couchdb_2
       - resourcedetection/_global_0
       receivers:
       - couchdb/couchdb

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchdb_2:
-    override_scope_name: agent.googleapis.com/couchdb
-    override_scope_version: "1.0"
   normalizesums/couchdb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/couchdb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchdb")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -511,7 +514,7 @@ service:
       processors:
       - normalizesums/couchdb_0
       - metricstransform/couchdb_1
-      - modifyscope/couchdb_2
+      - transform/couchdb_2
       - resourcedetection/_global_0
       receivers:
       - couchdb/couchdb

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchdb_2:
-    override_scope_name: agent.googleapis.com/couchdb
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/couchdb_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/couchdb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchdb")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -618,7 +627,7 @@ service:
       processors:
       - normalizesums/couchdb_0
       - metricstransform/couchdb_1
-      - modifyscope/couchdb_2
+      - transform/couchdb_2
       - resourcedetection/_global_0
       receivers:
       - couchdb/couchdb
@@ -640,7 +649,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -650,7 +659,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/couchdb_2:
-    override_scope_name: agent.googleapis.com/couchdb
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/couchdb_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/couchdb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/couchdb")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -618,7 +627,7 @@ service:
       processors:
       - normalizesums/couchdb_0
       - metricstransform/couchdb_1
-      - modifyscope/couchdb_2
+      - transform/couchdb_2
       - resourcedetection/_global_0
       receivers:
       - couchdb/couchdb
@@ -640,7 +649,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -650,7 +659,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
@@ -535,9 +535,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/dcgm_6:
-    override_scope_name: agent.googleapis.com/dcgm
-    override_scope_version: "1.0"
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -548,6 +545,10 @@ processors:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])
       - set(attributes["uuid"], resource.attributes["gpu.uuid"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/dcgm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -649,7 +650,6 @@ service:
       - metricstransform/dcgm_3
       - metricstransform/dcgm_4
       - transform/dcgm_5
-      - modifyscope/dcgm_6
       - resourcedetection/_global_0
       receivers:
       - dcgm/dcgm

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
@@ -506,9 +506,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/dcgm_6:
-    override_scope_name: agent.googleapis.com/dcgm
-    override_scope_version: "1.0"
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -519,6 +516,10 @@ processors:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])
       - set(attributes["uuid"], resource.attributes["gpu.uuid"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/dcgm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -618,7 +619,6 @@ service:
       - metricstransform/dcgm_3
       - metricstransform/dcgm_4
       - transform/dcgm_5
-      - modifyscope/dcgm_6
       - resourcedetection/_global_0
       receivers:
       - dcgm/dcgm

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
@@ -513,9 +513,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/dcgm_3:
-    override_scope_name: agent.googleapis.com/dcgm
-    override_scope_version: "2.0"
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -526,6 +523,10 @@ processors:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])
       - set(attributes["uuid"], resource.attributes["gpu.uuid"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/dcgm")
+      - set(version, "2.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -591,7 +592,6 @@ service:
       - metricstransform/dcgm_0
       - metricstransform/dcgm_1
       - transform/dcgm_2
-      - modifyscope/dcgm_3
       - resourcedetection/_global_0
       receivers:
       - dcgm/dcgm

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
@@ -484,9 +484,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/dcgm_3:
-    override_scope_name: agent.googleapis.com/dcgm
-    override_scope_version: "2.0"
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -497,6 +494,10 @@ processors:
       - set(attributes["model"], resource.attributes["gpu.model"])
       - set(attributes["gpu_number"], resource.attributes["gpu.number"])
       - set(attributes["uuid"], resource.attributes["gpu.uuid"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/dcgm")
+      - set(version, "2.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -560,7 +561,6 @@ service:
       - metricstransform/dcgm_0
       - metricstransform/dcgm_1
       - transform/dcgm_2
-      - modifyscope/dcgm_3
       - resourcedetection/_global_0
       receivers:
       - dcgm/dcgm

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -473,13 +473,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -601,7 +604,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
@@ -444,13 +444,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -561,7 +564,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
@@ -473,13 +473,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -601,7 +604,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
@@ -444,13 +444,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -561,7 +564,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
@@ -473,13 +473,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -601,7 +604,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
@@ -444,13 +444,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -561,7 +564,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
@@ -473,13 +473,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -601,7 +604,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
@@ -444,13 +444,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -561,7 +564,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +677,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +699,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
@@ -473,13 +473,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -623,7 +626,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
@@ -444,13 +444,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -583,7 +586,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -690,7 +699,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -700,7 +709,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -712,7 +721,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -690,7 +699,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -700,7 +709,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -712,7 +721,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
@@ -473,13 +473,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -603,7 +606,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
@@ -444,13 +444,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -563,7 +566,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -670,7 +679,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -680,7 +689,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -692,7 +701,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
@@ -509,20 +509,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/elasticsearch_3:
-    override_scope_name: agent.googleapis.com/elasticsearch
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/elasticsearch_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/elasticsearch_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/elasticsearch")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -670,7 +679,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -680,7 +689,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -692,7 +701,7 @@ service:
       - normalizesums/elasticsearch_0
       - filter/elasticsearch_1
       - metricstransform/elasticsearch_2
-      - modifyscope/elasticsearch_3
+      - transform/elasticsearch_3
       - resourcedetection/_global_0
       receivers:
       - elasticsearch/elasticsearch

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
@@ -493,9 +493,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/flink_3:
-    override_scope_name: agent.googleapis.com/flink
-    override_scope_version: "1.0"
   normalizesums/flink_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -510,6 +507,10 @@ processors:
       - set(attributes["task_name"], resource.attributes["flink.task.name"])
       - set(attributes["subtask_index"], resource.attributes["flink.subtask.index"])
       - set(attributes["resource_type"], resource.attributes["flink.resource.type"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/flink")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -595,7 +596,6 @@ service:
       - normalizesums/flink_0
       - metricstransform/flink_1
       - transform/flink_2
-      - modifyscope/flink_3
       - resourcedetection/_global_0
       receivers:
       - flinkmetrics/flink

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
@@ -464,9 +464,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/flink_3:
-    override_scope_name: agent.googleapis.com/flink
-    override_scope_version: "1.0"
   normalizesums/flink_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -481,6 +478,10 @@ processors:
       - set(attributes["task_name"], resource.attributes["flink.task.name"])
       - set(attributes["subtask_index"], resource.attributes["flink.subtask.index"])
       - set(attributes["resource_type"], resource.attributes["flink.resource.type"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/flink")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -555,7 +556,6 @@ service:
       - normalizesums/flink_0
       - metricstransform/flink_1
       - transform/flink_2
-      - modifyscope/flink_3
       - resourcedetection/_global_0
       receivers:
       - flinkmetrics/flink

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
@@ -529,15 +529,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/flink_3:
-    override_scope_name: agent.googleapis.com/flink
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/flink_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -553,6 +544,22 @@ processors:
       - set(attributes["task_name"], resource.attributes["flink.task.name"])
       - set(attributes["subtask_index"], resource.attributes["flink.subtask.index"])
       - set(attributes["resource_type"], resource.attributes["flink.resource.type"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/flink")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -662,7 +669,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -672,7 +679,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -684,7 +691,6 @@ service:
       - normalizesums/flink_0
       - metricstransform/flink_1
       - transform/flink_2
-      - modifyscope/flink_3
       - resourcedetection/_global_0
       receivers:
       - flinkmetrics/flink

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
@@ -529,15 +529,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/flink_3:
-    override_scope_name: agent.googleapis.com/flink
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/flink_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
@@ -553,6 +544,22 @@ processors:
       - set(attributes["task_name"], resource.attributes["flink.task.name"])
       - set(attributes["subtask_index"], resource.attributes["flink.subtask.index"])
       - set(attributes["resource_type"], resource.attributes["flink.resource.type"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/flink")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -662,7 +669,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -672,7 +679,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -684,7 +691,6 @@ service:
       - normalizesums/flink_0
       - metricstransform/flink_1
       - transform/flink_2
-      - modifyscope/flink_3
       - resourcedetection/_global_0
       receivers:
       - flinkmetrics/flink

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -573,7 +576,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -533,7 +536,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -573,7 +576,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -533,7 +536,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hadoop_2:
-    override_scope_name: agent.googleapis.com/hadoop
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hadoop_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hadoop_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hadoop")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/hadoop_0
       - metricstransform/hadoop_1
-      - modifyscope/hadoop_2
+      - transform/hadoop_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hadoop

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -476,13 +476,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -580,7 +583,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
@@ -447,13 +447,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -540,7 +543,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
@@ -512,20 +512,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -669,7 +678,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
@@ -512,20 +512,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -669,7 +678,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
@@ -476,13 +476,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -580,7 +583,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
@@ -447,13 +447,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -540,7 +543,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
@@ -512,20 +512,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -669,7 +678,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
@@ -512,20 +512,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/hbase__metrics_2:
-    override_scope_name: agent.googleapis.com/hbase
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/hbase__metrics_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/hbase__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/hbase")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -669,7 +678,7 @@ service:
       processors:
       - normalizesums/hbase__metrics_0
       - metricstransform/hbase__metrics_1
-      - modifyscope/hbase__metrics_2
+      - transform/hbase__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/hbase__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -571,7 +574,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,7 +534,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -573,7 +576,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -533,7 +536,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jetty__metrics_2:
-    override_scope_name: agent.googleapis.com/jetty
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jetty__metrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jetty__metrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jetty")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/jetty__metrics_0
       - metricstransform/jetty__metrics_1
-      - modifyscope/jetty__metrics_2
+      - transform/jetty__metrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jetty__metrics

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -571,7 +574,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,7 +534,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -573,7 +576,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -533,7 +536,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -571,7 +574,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,7 +534,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvm_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvm_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvm_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jvm_0
       - metricstransform/jvm_1
-      - modifyscope/jvm_2
+      - transform/jvm_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvm

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -484,13 +484,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -589,7 +592,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
@@ -455,13 +455,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -549,7 +552,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
@@ -520,20 +520,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -647,7 +656,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -657,7 +666,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
@@ -520,20 +520,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -647,7 +656,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -657,7 +666,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
@@ -484,13 +484,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -589,7 +592,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
@@ -455,13 +455,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -549,7 +552,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
@@ -520,20 +520,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -647,7 +656,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -657,7 +666,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
@@ -520,20 +520,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/kafka_3:
-    override_scope_name: agent.googleapis.com/kafka
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/kafka_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/kafka_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/kafka")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -647,7 +656,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -657,7 +666,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       - filter/kafka_0
       - normalizesums/kafka_1
       - metricstransform/kafka_2
-      - modifyscope/kafka_3
+      - transform/kafka_3
       - resourcedetection/_global_0
       receivers:
       - jmx/kafka

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
@@ -475,13 +475,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/memcached_3:
-    override_scope_name: agent.googleapis.com/memcached
-    override_scope_version: "1.0"
   normalizesums/memcached_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/memcached_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/memcached")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -577,7 +580,7 @@ service:
       - filter/memcached_0
       - normalizesums/memcached_1
       - metricstransform/memcached_2
-      - modifyscope/memcached_3
+      - transform/memcached_3
       - resourcedetection/_global_0
       receivers:
       - memcached/memcached

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
@@ -446,13 +446,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/memcached_3:
-    override_scope_name: agent.googleapis.com/memcached
-    override_scope_version: "1.0"
   normalizesums/memcached_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/memcached_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/memcached")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -537,7 +540,7 @@ service:
       - filter/memcached_0
       - normalizesums/memcached_1
       - metricstransform/memcached_2
-      - modifyscope/memcached_3
+      - transform/memcached_3
       - resourcedetection/_global_0
       receivers:
       - memcached/memcached

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
@@ -511,20 +511,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/memcached_3:
-    override_scope_name: agent.googleapis.com/memcached
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/memcached_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/memcached_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/memcached")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -635,7 +644,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -645,7 +654,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -666,7 +675,7 @@ service:
       - filter/memcached_0
       - normalizesums/memcached_1
       - metricstransform/memcached_2
-      - modifyscope/memcached_3
+      - transform/memcached_3
       - resourcedetection/_global_0
       receivers:
       - memcached/memcached

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
@@ -511,20 +511,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/memcached_3:
-    override_scope_name: agent.googleapis.com/memcached
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/memcached_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/memcached_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/memcached")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -635,7 +644,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -645,7 +654,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -666,7 +675,7 @@ service:
       - filter/memcached_0
       - normalizesums/memcached_1
       - metricstransform/memcached_2
-      - modifyscope/memcached_3
+      - transform/memcached_3
       - resourcedetection/_global_0
       receivers:
       - memcached/memcached

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -575,7 +578,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -535,7 +538,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -634,7 +643,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +653,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -664,7 +673,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -634,7 +643,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +653,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -664,7 +673,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -573,7 +576,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -533,7 +536,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mongodb_2:
-    override_scope_name: agent.googleapis.com/mongodb
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mongodb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mongodb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mongodb")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +671,7 @@ service:
       processors:
       - normalizesums/mongodb_0
       - metricstransform/mongodb_1
-      - modifyscope/mongodb_2
+      - transform/mongodb_2
       - resourcedetection/_global_0
       receivers:
       - mongodb/mongodb

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -489,13 +489,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mysql_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/mysql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mysql_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -615,7 +618,7 @@ service:
       processors:
       - normalizesums/mysql_0
       - metricstransform/mysql_1
-      - modifyscope/mysql_2
+      - transform/mysql_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysql

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
@@ -460,13 +460,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mysql_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/mysql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mysql_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -575,7 +578,7 @@ service:
       processors:
       - normalizesums/mysql_0
       - metricstransform/mysql_1
-      - modifyscope/mysql_2
+      - transform/mysql_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysql

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
@@ -525,20 +525,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/mysql_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mysql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/mysql_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -674,7 +683,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -684,7 +693,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -704,7 +713,7 @@ service:
       processors:
       - normalizesums/mysql_0
       - metricstransform/mysql_1
-      - modifyscope/mysql_2
+      - transform/mysql_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysql

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
@@ -525,20 +525,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/mysql_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mysql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/mysql_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -674,7 +683,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -684,7 +693,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -704,7 +713,7 @@ service:
       processors:
       - normalizesums/mysql_0
       - metricstransform/mysql_1
-      - modifyscope/mysql_2
+      - transform/mysql_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysql

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -489,13 +489,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mysqlmetrics_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/mysqlmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mysqlmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -615,7 +618,7 @@ service:
       processors:
       - normalizesums/mysqlmetrics_0
       - metricstransform/mysqlmetrics_1
-      - modifyscope/mysqlmetrics_2
+      - transform/mysqlmetrics_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysqlmetrics

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
@@ -460,13 +460,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/mysqlmetrics_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/mysqlmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/mysqlmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -575,7 +578,7 @@ service:
       processors:
       - normalizesums/mysqlmetrics_0
       - metricstransform/mysqlmetrics_1
-      - modifyscope/mysqlmetrics_2
+      - transform/mysqlmetrics_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysqlmetrics

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
@@ -525,20 +525,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/mysqlmetrics_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mysqlmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/mysqlmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -674,7 +683,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -684,7 +693,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -704,7 +713,7 @@ service:
       processors:
       - normalizesums/mysqlmetrics_0
       - metricstransform/mysqlmetrics_1
-      - modifyscope/mysqlmetrics_2
+      - transform/mysqlmetrics_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysqlmetrics

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
@@ -525,20 +525,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/mysqlmetrics_2:
-    override_scope_name: agent.googleapis.com/mysql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/mysqlmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/mysqlmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mysql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -674,7 +683,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -684,7 +693,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -704,7 +713,7 @@ service:
       processors:
       - normalizesums/mysqlmetrics_0
       - metricstransform/mysqlmetrics_1
-      - modifyscope/mysqlmetrics_2
+      - transform/mysqlmetrics_2
       - resourcedetection/_global_0
       receivers:
       - mysql/mysqlmetrics

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -569,7 +572,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -529,7 +532,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -658,7 +667,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -658,7 +667,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -569,7 +572,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -529,7 +532,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -658,7 +667,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/nginx_2:
-    override_scope_name: agent.googleapis.com/nginx
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/nginx_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
+  transform/nginx_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/nginx")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -658,7 +667,7 @@ service:
       processors:
       - normalizesums/nginx_0
       - metricstransform/nginx_1
-      - modifyscope/nginx_2
+      - transform/nginx_2
       - resourcedetection/_global_0
       receivers:
       - nginx/nginx

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -494,9 +494,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -507,6 +504,12 @@ processors:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1194,7 +1197,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
@@ -465,9 +465,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -478,6 +475,12 @@ processors:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1154,7 +1157,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -530,26 +530,35 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1245,7 +1254,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1255,7 +1264,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1283,7 +1292,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
@@ -530,26 +530,35 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1245,7 +1254,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1255,7 +1264,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1283,7 +1292,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
@@ -494,9 +494,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -507,6 +504,12 @@ processors:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1194,7 +1197,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
@@ -465,9 +465,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -478,6 +475,12 @@ processors:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1154,7 +1157,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
@@ -530,26 +530,35 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1245,7 +1254,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1255,7 +1264,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1283,7 +1292,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
@@ -530,26 +530,35 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1245,7 +1254,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1255,7 +1264,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1283,7 +1292,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
@@ -494,9 +494,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -507,6 +504,12 @@ processors:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1194,7 +1197,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
@@ -465,9 +465,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -478,6 +475,12 @@ processors:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1154,7 +1157,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
@@ -530,26 +530,35 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1245,7 +1254,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1255,7 +1264,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1283,7 +1292,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
@@ -530,26 +530,35 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/oracledb_2:
-    override_scope_name: agent.googleapis.com/oracledb
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/oracledb_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
     - context: datapoint
       statements:
       - set(time, Now())
+  transform/oracledb_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/oracledb")
+      - set(version, "1.0")
   transform/otel_1:
     error_mode: ignore
     metric_statements:
@@ -1245,7 +1254,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1255,7 +1264,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1283,7 +1292,7 @@ service:
       processors:
       - normalizesums/oracledb_0
       - metricstransform/oracledb_1
-      - modifyscope/oracledb_2
+      - transform/oracledb_2
       - resourcedetection/_global_0
       receivers:
       - sqlquery/oracledb

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -473,9 +473,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -501,6 +498,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -610,7 +611,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
@@ -444,9 +444,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -472,6 +469,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -570,7 +571,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -649,7 +656,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -659,7 +666,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -699,7 +706,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -649,7 +656,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -659,7 +666,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -699,7 +706,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
@@ -473,9 +473,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -501,6 +498,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -612,7 +613,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
@@ -444,9 +444,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -472,6 +469,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -572,7 +573,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -651,7 +658,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -661,7 +668,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -701,7 +708,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -651,7 +658,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -661,7 +668,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -701,7 +708,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -473,9 +473,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -501,6 +498,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -613,7 +614,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
@@ -444,9 +444,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -472,6 +469,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -573,7 +574,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -652,7 +659,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +669,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -702,7 +709,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -652,7 +659,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -662,7 +669,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -702,7 +709,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -473,9 +473,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -501,6 +498,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -616,7 +617,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
@@ -444,9 +444,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -472,6 +469,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -576,7 +577,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -655,7 +662,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -665,7 +672,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -705,7 +712,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
@@ -509,20 +509,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/postgresql_3:
-    override_scope_name: agent.googleapis.com/postgresql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/postgresql_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -544,6 +547,10 @@ processors:
       - set(attributes["index"], resource.attributes["postgresql.index.name"])
       - set(value_int, Int(value_double)) where metric.name == "postgresql.wal.delay"
       - set(metric.name, "postgresql.wal.lag") where metric.name == "postgresql.wal.delay"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/postgresql")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -655,7 +662,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -665,7 +672,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -705,7 +712,6 @@ service:
       - normalizesums/postgresql_0
       - transform/postgresql_1
       - metricstransform/postgresql_2
-      - modifyscope/postgresql_3
       - resourcedetection/_global_0
       receivers:
       - postgresql/postgresql

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -678,7 +684,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -688,7 +694,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -678,7 +684,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -688,7 +694,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -734,7 +740,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -744,7 +750,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -734,7 +740,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -744,7 +750,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +674,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +684,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -668,7 +674,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +684,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -729,7 +735,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -739,7 +745,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -729,7 +735,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -739,7 +745,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -675,7 +681,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -685,7 +691,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -704,7 +710,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -714,7 +720,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -704,7 +710,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -714,7 +720,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -673,7 +679,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -683,7 +689,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -495,16 +495,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -673,7 +679,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -683,7 +689,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -495,6 +492,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -600,7 +601,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -466,6 +463,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -560,7 +561,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +646,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +656,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +696,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +646,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +656,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +696,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -495,6 +492,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -600,7 +601,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -466,6 +463,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -560,7 +561,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +646,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +656,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +696,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +646,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +656,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +696,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -495,6 +492,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -601,7 +602,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -466,6 +463,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -561,7 +562,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -640,7 +647,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -650,7 +657,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +697,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -640,7 +647,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -650,7 +657,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -690,7 +697,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -495,6 +492,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -604,7 +605,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -466,6 +463,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -564,7 +565,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -643,7 +650,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -653,7 +660,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -693,7 +700,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/rabbitmq_3:
-    override_scope_name: agent.googleapis.com/rabbitmq
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/rabbitmq_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,10 @@ processors:
       - set(attributes["queue_name"], resource.attributes["rabbitmq.queue.name"])
       - set(attributes["node_name"], resource.attributes["rabbitmq.node.name"])
       - set(attributes["vhost_name"], resource.attributes["rabbitmq.vhost.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/rabbitmq")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -643,7 +650,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -653,7 +660,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -693,7 +700,6 @@ service:
       - normalizesums/rabbitmq_0
       - metricstransform/rabbitmq_1
       - transform/rabbitmq_2
-      - modifyscope/rabbitmq_3
       - resourcedetection/_global_0
       receivers:
       - rabbitmq/rabbitmq

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
@@ -476,9 +476,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -495,6 +492,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -600,7 +603,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
@@ -447,9 +447,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -466,6 +463,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -560,7 +563,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
@@ -512,20 +512,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +698,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
@@ -512,20 +512,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +698,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -476,9 +476,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -495,6 +492,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -600,7 +603,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
@@ -447,9 +447,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -466,6 +463,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -560,7 +563,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -512,20 +512,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +698,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
@@ -512,20 +512,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/redis_3:
-    override_scope_name: agent.googleapis.com/redis
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/redis_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -538,6 +541,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/redis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/redis")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -639,7 +648,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -649,7 +658,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -689,7 +698,7 @@ service:
       - filter/redis_0
       - normalizesums/redis_1
       - metricstransform/redis_2
-      - modifyscope/redis_3
+      - transform/redis_3
       - resourcedetection/_global_0
       receivers:
       - redis/redis

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -475,9 +475,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/saphana_4:
-    override_scope_name: agent.googleapis.com/saphana
-    override_scope_version: "1.0"
   normalizesums/saphana_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -499,6 +496,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/saphana")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -605,7 +606,6 @@ service:
       - normalizesums/saphana_1
       - metricstransform/saphana_2
       - transform/saphana_3
-      - modifyscope/saphana_4
       - resourcedetection/_global_0
       receivers:
       - saphana/saphana

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
@@ -446,9 +446,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/saphana_4:
-    override_scope_name: agent.googleapis.com/saphana
-    override_scope_version: "1.0"
   normalizesums/saphana_1: {}
   resourcedetection/_global_0:
     detectors:
@@ -470,6 +467,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/saphana")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -565,7 +566,6 @@ service:
       - normalizesums/saphana_1
       - metricstransform/saphana_2
       - transform/saphana_3
-      - modifyscope/saphana_4
       - resourcedetection/_global_0
       receivers:
       - saphana/saphana

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
@@ -511,20 +511,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/saphana_4:
-    override_scope_name: agent.googleapis.com/saphana
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/saphana_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -542,6 +545,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/saphana")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -643,7 +650,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -653,7 +660,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -694,7 +701,6 @@ service:
       - normalizesums/saphana_1
       - metricstransform/saphana_2
       - transform/saphana_3
-      - modifyscope/saphana_4
       - resourcedetection/_global_0
       receivers:
       - saphana/saphana

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
@@ -511,20 +511,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/saphana_4:
-    override_scope_name: agent.googleapis.com/saphana
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/saphana_1: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -542,6 +545,10 @@ processors:
     - context: datapoint
       statements:
       - set(attributes["host"], resource.attributes["saphana.host"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/saphana")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -643,7 +650,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -653,7 +660,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -694,7 +701,6 @@ service:
       - normalizesums/saphana_1
       - metricstransform/saphana_2
       - transform/saphana_3
-      - modifyscope/saphana_4
       - resourcedetection/_global_0
       receivers:
       - saphana/saphana

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/solr_2:
-    override_scope_name: agent.googleapis.com/solr
-    override_scope_version: "1.0"
   normalizesums/solr_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/solr_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/solr")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -592,7 +595,7 @@ service:
       processors:
       - normalizesums/solr_0
       - metricstransform/solr_1
-      - modifyscope/solr_2
+      - transform/solr_2
       - resourcedetection/_global_0
       receivers:
       - jmx/solr

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/solr_2:
-    override_scope_name: agent.googleapis.com/solr
-    override_scope_version: "1.0"
   normalizesums/solr_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/solr_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/solr")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -552,7 +555,7 @@ service:
       processors:
       - normalizesums/solr_0
       - metricstransform/solr_1
-      - modifyscope/solr_2
+      - transform/solr_2
       - resourcedetection/_global_0
       receivers:
       - jmx/solr

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/solr_2:
-    override_scope_name: agent.googleapis.com/solr
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/solr_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/solr_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/solr")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +690,7 @@ service:
       processors:
       - normalizesums/solr_0
       - metricstransform/solr_1
-      - modifyscope/solr_2
+      - transform/solr_2
       - resourcedetection/_global_0
       receivers:
       - jmx/solr

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/solr_2:
-    override_scope_name: agent.googleapis.com/solr
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/solr_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/solr_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/solr")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +690,7 @@ service:
       processors:
       - normalizesums/solr_0
       - metricstransform/solr_1
-      - modifyscope/solr_2
+      - transform/solr_2
       - resourcedetection/_global_0
       receivers:
       - jmx/solr

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -592,7 +595,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -552,7 +555,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +690,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +690,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -592,7 +595,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -552,7 +555,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +690,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/tomcat_2:
-    override_scope_name: agent.googleapis.com/tomcat
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/tomcat_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/tomcat_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/tomcat")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -632,7 +641,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -642,7 +651,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +690,7 @@ service:
       processors:
       - normalizesums/tomcat_0
       - metricstransform/tomcat_1
-      - modifyscope/tomcat_2
+      - transform/tomcat_2
       - resourcedetection/_global_0
       receivers:
       - jmx/tomcat

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/varnish_2:
-    override_scope_name: agent.googleapis.com/varnish
-    override_scope_version: "1.0"
   normalizesums/varnish_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/varnish_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/varnish")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -589,7 +592,7 @@ service:
       processors:
       - normalizesums/varnish_0
       - metricstransform/varnish_1
-      - modifyscope/varnish_2
+      - transform/varnish_2
       - resourcedetection/_global_0
       receivers:
       - varnish/varnish

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/varnish_2:
-    override_scope_name: agent.googleapis.com/varnish
-    override_scope_version: "1.0"
   normalizesums/varnish_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/varnish_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/varnish")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -549,7 +552,7 @@ service:
       processors:
       - normalizesums/varnish_0
       - metricstransform/varnish_1
-      - modifyscope/varnish_2
+      - transform/varnish_2
       - resourcedetection/_global_0
       receivers:
       - varnish/varnish

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/varnish_2:
-    override_scope_name: agent.googleapis.com/varnish
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/varnish_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/varnish_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/varnish")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -629,7 +638,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -639,7 +648,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       processors:
       - normalizesums/varnish_0
       - metricstransform/varnish_1
-      - modifyscope/varnish_2
+      - transform/varnish_2
       - resourcedetection/_global_0
       receivers:
       - varnish/varnish

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/varnish_2:
-    override_scope_name: agent.googleapis.com/varnish
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/varnish_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/varnish_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/varnish")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -629,7 +638,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -639,7 +648,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -678,7 +687,7 @@ service:
       processors:
       - normalizesums/varnish_0
       - metricstransform/varnish_1
-      - modifyscope/varnish_2
+      - transform/varnish_2
       - resourcedetection/_global_0
       receivers:
       - varnish/varnish

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
@@ -513,9 +513,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
@@ -1166,6 +1163,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1277,7 +1278,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
@@ -484,9 +484,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
@@ -1137,6 +1134,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1237,7 +1238,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
@@ -549,20 +549,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,6 +1212,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1314,7 +1321,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1324,7 +1331,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1366,7 +1373,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
@@ -549,20 +549,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,6 +1212,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1314,7 +1321,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1324,7 +1331,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1366,7 +1373,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
@@ -513,9 +513,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
@@ -1166,6 +1163,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1277,7 +1278,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
@@ -484,9 +484,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
@@ -1137,6 +1134,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1237,7 +1238,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
@@ -549,20 +549,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,6 +1212,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1314,7 +1321,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1324,7 +1331,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1366,7 +1373,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
@@ -549,20 +549,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,6 +1212,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1314,7 +1321,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1324,7 +1331,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1366,7 +1373,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
@@ -513,9 +513,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
@@ -1166,6 +1163,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1281,7 +1282,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
@@ -484,9 +484,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
@@ -1137,6 +1134,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1241,7 +1242,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
@@ -549,20 +549,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,6 +1212,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1318,7 +1325,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1328,7 +1335,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1370,7 +1377,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
@@ -549,20 +549,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/vault_5:
-    override_scope_name: agent.googleapis.com/vault
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/vault_3: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,6 +1212,10 @@ processors:
       - set(metric.name, "vault.token.count") where metric.name == "vault_token_count"
       - set(metric.description, "The number of tokens created.") where metric.name == "vault.token.count"
       - set(metric.unit, "{tokens}") where metric.name == "vault.token.count"
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/vault")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -1318,7 +1325,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -1328,7 +1335,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -1370,7 +1377,6 @@ service:
       - metricstransform/vault_2
       - normalizesums/vault_3
       - metricstransform/vault_4
-      - modifyscope/vault_5
       - resourcedetection/_global_0
       receivers:
       - prometheus/vault

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -594,7 +597,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -554,7 +557,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -634,7 +643,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +653,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -683,7 +692,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -634,7 +643,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +653,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -683,7 +692,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -594,7 +597,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -554,7 +557,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -634,7 +643,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +653,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -683,7 +692,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/wildfly_2:
-    override_scope_name: agent.googleapis.com/wildfly
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/wildfly_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/wildfly_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/wildfly")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -634,7 +643,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -644,7 +653,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -683,7 +692,7 @@ service:
       processors:
       - normalizesums/wildfly_0
       - metricstransform/wildfly_1
-      - modifyscope/wildfly_2
+      - transform/wildfly_2
       - resourcedetection/_global_0
       receivers:
       - jmx/wildfly

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -588,7 +591,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -548,7 +551,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -677,7 +686,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -677,7 +686,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
@@ -469,9 +469,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -488,6 +485,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -588,7 +591,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
@@ -440,9 +440,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
@@ -459,6 +456,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -548,7 +551,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -677,7 +686,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
@@ -505,20 +505,23 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: workload.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/zookeeper_2:
-    override_scope_name: agent.googleapis.com/zookeeper
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/zookeeper_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,6 +534,12 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
+  transform/zookeeper_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/zookeeper")
+      - set(version, "1.0")
 receivers:
   hostmetrics/hostmetrics:
     collection_interval: 60s
@@ -628,7 +637,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -638,7 +647,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -677,7 +686,7 @@ service:
       processors:
       - normalizesums/zookeeper_0
       - metricstransform/zookeeper_1
-      - modifyscope/zookeeper_2
+      - transform/zookeeper_2
       - resourcedetection/_global_0
       receivers:
       - zookeeper/zookeeper

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -476,16 +476,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -591,7 +597,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/iis
@@ -600,7 +606,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/mssql

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -476,16 +476,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -591,7 +597,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/iis
@@ -600,7 +606,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/mssql

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -491,16 +491,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -607,7 +613,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -617,7 +623,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -494,16 +494,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -610,7 +616,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -620,7 +626,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -476,16 +476,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -581,7 +587,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/iis
@@ -590,7 +596,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/mssql

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -476,16 +476,22 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -581,7 +587,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/iis
@@ -590,7 +596,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - resourcedetection/_global_0
       receivers:
       - windowsperfcounters/mssql

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/active__directory__ds_2:
-    override_scope_name: agent.googleapis.com/active_directory_ds
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/active__directory__ds_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/active__directory__ds_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/active_directory_ds")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -615,7 +624,7 @@ service:
       processors:
       - normalizesums/active__directory__ds_0
       - metricstransform/active__directory__ds_1
-      - modifyscope/active__directory__ds_2
+      - transform/active__directory__ds_2
       - resourcedetection/_global_0
       receivers:
       - active_directory_ds/active__directory__ds
@@ -637,7 +646,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -647,7 +656,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/active__directory__ds_2:
-    override_scope_name: agent.googleapis.com/active_directory_ds
-    override_scope_version: "1.0"
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/active__directory__ds_0: {}
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/active__directory__ds_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/active_directory_ds")
+      - set(version, "1.0")
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -615,7 +624,7 @@ service:
       processors:
       - normalizesums/active__directory__ds_0
       - metricstransform/active__directory__ds_1
-      - modifyscope/active__directory__ds_2
+      - transform/active__directory__ds_2
       - resourcedetection/_global_0
       receivers:
       - active_directory_ds/active__directory__ds
@@ -637,7 +646,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -647,7 +656,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -515,31 +515,38 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/iis__v2_5:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "2.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/iis__v2_4: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/iis__v2_0:
     metric_statements:
     - context: datapoint
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "2.0")
   transform/iis__v2_1:
     metric_statements:
     - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -648,7 +655,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -658,7 +665,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +688,6 @@ service:
       - groupbyattrs/iis__v2_2
       - metricstransform/iis__v2_3
       - normalizesums/iis__v2_4
-      - modifyscope/iis__v2_5
       - resourcedetection/_global_0
       receivers:
       - iis/iis__v2

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -515,31 +515,38 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/iis__v2_5:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "2.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/iis__v2_4: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/iis__v2_0:
     metric_statements:
     - context: datapoint
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "2.0")
   transform/iis__v2_1:
     metric_statements:
     - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -648,7 +655,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -658,7 +665,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -681,7 +688,6 @@ service:
       - groupbyattrs/iis__v2_2
       - metricstransform/iis__v2_3
       - normalizesums/iis__v2_4
-      - modifyscope/iis__v2_5
       - resourcedetection/_global_0
       receivers:
       - iis/iis__v2

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -482,12 +482,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_5:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "2.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_4: {}
   resourcedetection/_global_0:
     detectors:
@@ -498,11 +492,21 @@ processors:
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "2.0")
   transform/iis_1:
     metric_statements:
     - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -595,7 +599,6 @@ service:
       - groupbyattrs/iis_2
       - metricstransform/iis_3
       - normalizesums/iis_4
-      - modifyscope/iis_5
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -605,7 +608,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -628,7 +631,6 @@ service:
       - groupbyattrs/iis_2
       - metricstransform/iis_3
       - normalizesums/iis_4
-      - modifyscope/iis_5
       - resourcedetection/_global_0
       receivers:
       - iis/iis

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -482,12 +482,6 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_5:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "2.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_4: {}
   resourcedetection/_global_0:
     detectors:
@@ -498,11 +492,21 @@ processors:
       statements:
       - set(attributes["site"], resource.attributes["iis.site"])
       - set(attributes["app_pool"], resource.attributes["iis.application_pool"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "2.0")
   transform/iis_1:
     metric_statements:
     - context: datapoint
       statements:
       - keep_keys(resource.attributes, [])
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -595,7 +599,6 @@ service:
       - groupbyattrs/iis_2
       - metricstransform/iis_3
       - normalizesums/iis_4
-      - modifyscope/iis_5
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -605,7 +608,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -628,7 +631,6 @@ service:
       - groupbyattrs/iis_2
       - metricstransform/iis_3
       - normalizesums/iis_4
-      - modifyscope/iis_5
       - resourcedetection/_global_0
       receivers:
       - iis/iis

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -469,13 +469,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvmmetrics_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvmmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvmmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -571,7 +574,7 @@ service:
       processors:
       - normalizesums/jvmmetrics_0
       - metricstransform/jvmmetrics_1
-      - modifyscope/jvmmetrics_2
+      - transform/jvmmetrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvmmetrics

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
@@ -440,13 +440,16 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/jvmmetrics_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
   normalizesums/jvmmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/jvmmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -531,7 +534,7 @@ service:
       processors:
       - normalizesums/jvmmetrics_0
       - metricstransform/jvmmetrics_1
-      - modifyscope/jvmmetrics_2
+      - transform/jvmmetrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvmmetrics

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvmmetrics_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvmmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvmmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jvmmetrics_0
       - metricstransform/jvmmetrics_1
-      - modifyscope/jvmmetrics_2
+      - transform/jvmmetrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvmmetrics

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
@@ -505,20 +505,29 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/jvmmetrics_2:
-    override_scope_name: agent.googleapis.com/jvm
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
   normalizesums/iis_2: {}
   normalizesums/jvmmetrics_0: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/jvmmetrics_2:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/jvm")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -630,7 +639,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -640,7 +649,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -660,7 +669,7 @@ service:
       processors:
       - normalizesums/jvmmetrics_0
       - metricstransform/jvmmetrics_1
-      - modifyscope/jvmmetrics_2
+      - transform/jvmmetrics_2
       - resourcedetection/_global_0
       receivers:
       - jmx/jvmmetrics

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -508,25 +508,32 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/mssql__v2_3:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "2.0"
   normalizesums/iis_2: {}
   normalizesums/mssql__v2_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/mssql__v2_1:
     metric_statements:
     - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "2.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -635,7 +642,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -645,7 +652,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -666,7 +673,6 @@ service:
       - metricstransform/mssql__v2_0
       - transform/mssql__v2_1
       - normalizesums/mssql__v2_2
-      - modifyscope/mssql__v2_3
       - resourcedetection/_global_0
       receivers:
       - sqlserver/mssql__v2

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -508,25 +508,32 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_1:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "1.0"
-  modifyscope/mssql__v2_3:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "2.0"
   normalizesums/iis_2: {}
   normalizesums/mssql__v2_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
+  transform/mssql_1:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "1.0")
   transform/mssql__v2_1:
     metric_statements:
     - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "2.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -635,7 +642,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -645,7 +652,7 @@ service:
       - googlecloud
       processors:
       - metricstransform/mssql_0
-      - modifyscope/mssql_1
+      - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -666,7 +673,6 @@ service:
       - metricstransform/mssql__v2_0
       - transform/mssql__v2_1
       - normalizesums/mssql__v2_2
-      - modifyscope/mssql__v2_3
       - resourcedetection/_global_0
       receivers:
       - sqlserver/mssql__v2

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -493,22 +493,26 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_3:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "2.0"
   normalizesums/iis_2: {}
   normalizesums/mssql_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/mssql_1:
     metric_statements:
     - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "2.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -603,7 +607,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -615,7 +619,6 @@ service:
       - metricstransform/mssql_0
       - transform/mssql_1
       - normalizesums/mssql_2
-      - modifyscope/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -636,7 +639,6 @@ service:
       - metricstransform/mssql_0
       - transform/mssql_1
       - normalizesums/mssql_2
-      - modifyscope/mssql_3
       - resourcedetection/_global_0
       receivers:
       - sqlserver/mssql

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -493,22 +493,26 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  modifyscope/iis_3:
-    override_scope_name: agent.googleapis.com/iis
-    override_scope_version: "1.0"
-  modifyscope/mssql_3:
-    override_scope_name: agent.googleapis.com/mssql
-    override_scope_version: "2.0"
   normalizesums/iis_2: {}
   normalizesums/mssql_2: {}
   resourcedetection/_global_0:
     detectors:
     - gcp
+  transform/iis_3:
+    metric_statements:
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/iis")
+      - set(version, "1.0")
   transform/mssql_1:
     metric_statements:
     - context: datapoint
       statements:
       - set(attributes["database"], resource.attributes["sqlserver.database.name"])
+    - context: scope
+      statements:
+      - set(name, "agent.googleapis.com/mssql")
+      - set(version, "2.0")
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -603,7 +607,7 @@ service:
       - metricstransform/iis_0
       - casttosum/iis_1
       - normalizesums/iis_2
-      - modifyscope/iis_3
+      - transform/iis_3
       - filter/default__pipeline_iis_0
       - resourcedetection/_global_0
       receivers:
@@ -615,7 +619,6 @@ service:
       - metricstransform/mssql_0
       - transform/mssql_1
       - normalizesums/mssql_2
-      - modifyscope/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
       receivers:
@@ -636,7 +639,6 @@ service:
       - metricstransform/mssql_0
       - transform/mssql_1
       - normalizesums/mssql_2
-      - modifyscope/mssql_3
       - resourcedetection/_global_0
       receivers:
       - sqlserver/mssql

--- a/dev-docs/otel-exporter-types.md
+++ b/dev-docs/otel-exporter-types.md
@@ -29,9 +29,9 @@ are exported to `workload.googleapis.com/...` and have labels named
 scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope)
 associated with each metric.
 
-Built-in Ops Agent receiver types should use the `modifyscope` processor (via
-`otel.ModifyInstrumentationScope`) to set an instrumentation scope of
-`agent.googleapis.com/{receiver_type}`.
+Built-in Ops Agent receiver types should create a metrics `transform` processor (via
+`otel.TransformationMetrics`) with the `otel.SetScopeName` and `otel.SetScopeVersion` queries
+to set an instrumentation scope of `agent.googleapis.com/{receiver_type}`.
 
 The `OTel` exporter handles trace data without any special configuration.
 


### PR DESCRIPTION
## Description
Deprecate the existing `modifyscope` processor within ops-agent and migrate to utilizing the transform processor OTTL for achieving the same functionality.

## Related issue
N/A

## How has this been tested?
Unit Tests & Integration Tests

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.
