### PR TITLE
Update to `otelopscol` commit with opentelemetry release `v1.36.0/v0.130.0`.

### DIFF
--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -128,7 +128,7 @@ expected_metrics:
     monitored_resources: [gce_instance]
     labels:
       - name: operation
-        value_regex: requests|waits|writes
+        value_regex: requests|waits|writes|fsyncs
   - type: workload.googleapis.com/mysql.operations
     value_type: INT64
     kind: CUMULATIVE

--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -71,6 +71,9 @@ expected_metrics:
     value_type: INT64
     kind: GAUGE
     monitored_resources: [gce_instance]
+    labels:
+      - name: performance_counter_object_name
+        value_regex: .*
   - type: workload.googleapis.com/sqlserver.page.split.rate
     value_type: DOUBLE
     kind: GAUGE

--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -110,7 +110,7 @@ expected_metrics:
     monitored_resources: [gce_instance]
     labels:
       - name: operation
-        value_regex: requests|waits|writes
+        value_regex: requests|waits|writes|fsyncs
   - type: workload.googleapis.com/mysql.operations
     value_type: INT64
     kind: CUMULATIVE

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -154,7 +154,7 @@ expected_metrics:
     monitored_resources: [gce_instance]
     labels:
       - name: operation
-        value_regex: requests|waits|writes
+        value_regex: requests|waits|writes|fsyncs
       - name: instrumentation_source
         value_regex: agent.googleapis.com/mysql
   - type: workload.googleapis.com/mysql.operations

--- a/transformation_test/testdata/ops_agent_test-TestLogEntrySpecialFields/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestLogEntrySpecialFields/output_otel.yaml
@@ -1,5 +1,5 @@
 - collector_errors:
-  - caller: internal/base_exporter.go:116
+  - caller: internal/base_exporter.go:117
     error: "could not process attribute gcp.source_location: json: cannot unmarshal string into Go struct field LogEntrySourceLocation.line of type int64"
     level: error
     msg: Exporting failed. Rejecting data. Try enabling sending_queue to survive temporary failures.
@@ -7,34 +7,37 @@
     otelcol.component.kind: exporter
     otelcol.signal: logs
     rejected_items: 1.0
-    resource: {}
+    resource:
+      service.instance.id: test-service-instance-id
+      service.name: otelopscol
+      service.version: ""
     stacktrace: |-
       go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*BaseExporter).Send
-        go.opentelemetry.io/collector/exporter@v0.126.0/exporterhelper/internal/base_exporter.go:116
+        go.opentelemetry.io/collector/exporter@v0.130.0/exporterhelper/internal/base_exporter.go:117
       go.opentelemetry.io/collector/exporter/exporterhelper.NewLogsRequest.newConsumeLogs.func1
-        go.opentelemetry.io/collector/exporter@v0.126.0/exporterhelper/logs.go:176
+        go.opentelemetry.io/collector/exporter@v0.130.0/exporterhelper/logs.go:191
       go.opentelemetry.io/collector/consumer.ConsumeLogsFunc.ConsumeLogs
-        go.opentelemetry.io/collector/consumer@v1.32.0/logs.go:27
+        go.opentelemetry.io/collector/consumer@v1.36.0/logs.go:27
       go.opentelemetry.io/collector/internal/fanoutconsumer.(*logsConsumer).ConsumeLogs
-        go.opentelemetry.io/collector/internal/fanoutconsumer@v0.126.0/logs.go:62
+        go.opentelemetry.io/collector/internal/fanoutconsumer@v0.130.0/logs.go:62
       go.opentelemetry.io/collector/processor/processorhelper.NewLogs.func1
-        go.opentelemetry.io/collector/processor/processorhelper@v0.126.0/logs.go:66
+        go.opentelemetry.io/collector/processor/processorhelper@v0.130.0/logs.go:66
       go.opentelemetry.io/collector/consumer.ConsumeLogsFunc.ConsumeLogs
-        go.opentelemetry.io/collector/consumer@v1.32.0/logs.go:27
+        go.opentelemetry.io/collector/consumer@v1.36.0/logs.go:27
       go.opentelemetry.io/collector/processor/processorhelper.NewLogs.func1
-        go.opentelemetry.io/collector/processor/processorhelper@v0.126.0/logs.go:66
+        go.opentelemetry.io/collector/processor/processorhelper@v0.130.0/logs.go:66
       go.opentelemetry.io/collector/consumer.ConsumeLogsFunc.ConsumeLogs
-        go.opentelemetry.io/collector/consumer@v1.32.0/logs.go:27
+        go.opentelemetry.io/collector/consumer@v1.36.0/logs.go:27
       go.opentelemetry.io/collector/consumer.ConsumeLogsFunc.ConsumeLogs
-        go.opentelemetry.io/collector/consumer@v1.32.0/logs.go:27
+        go.opentelemetry.io/collector/consumer@v1.36.0/logs.go:27
       go.opentelemetry.io/collector/internal/fanoutconsumer.(*logsConsumer).ConsumeLogs
-        go.opentelemetry.io/collector/internal/fanoutconsumer@v0.126.0/logs.go:62
+        go.opentelemetry.io/collector/internal/fanoutconsumer@v0.130.0/logs.go:62
       github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/consumerretry.(*logsConsumer).ConsumeLogs
-        github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal@v0.126.0/consumerretry/logs.go:37
+        github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal@v0.130.0/consumerretry/logs.go:37
       github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter.(*receiver).consumeEntries
-        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.126.0/adapter/receiver.go:59
+        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.130.0/adapter/receiver.go:59
       github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper.(*BatchingLogEmitter).flusher
-        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.126.0/operator/helper/emitter.go:171
+        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.130.0/operator/helper/emitter.go:171
   - caller: consumerretry/logs.go:39
     error: "could not process attribute gcp.source_location: json: cannot unmarshal string into Go struct field LogEntrySourceLocation.line of type int64"
     level: error
@@ -42,14 +45,17 @@
     otelcol.component.id: filelog/input
     otelcol.component.kind: receiver
     otelcol.signal: logs
-    resource: {}
+    resource:
+      service.instance.id: test-service-instance-id
+      service.name: otelopscol
+      service.version: ""
     stacktrace: |-
       github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/consumerretry.(*logsConsumer).ConsumeLogs
-        github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal@v0.126.0/consumerretry/logs.go:39
+        github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal@v0.130.0/consumerretry/logs.go:39
       github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter.(*receiver).consumeEntries
-        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.126.0/adapter/receiver.go:59
+        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.130.0/adapter/receiver.go:59
       github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper.(*BatchingLogEmitter).flusher
-        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.126.0/operator/helper/emitter.go:171
+        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.130.0/operator/helper/emitter.go:171
   - caller: adapter/receiver.go:61
     error: "could not process attribute gcp.source_location: json: cannot unmarshal string into Go struct field LogEntrySourceLocation.line of type int64"
     level: error
@@ -57,9 +63,12 @@
     otelcol.component.id: filelog/input
     otelcol.component.kind: receiver
     otelcol.signal: logs
-    resource: {}
+    resource:
+      service.instance.id: test-service-instance-id
+      service.name: otelopscol
+      service.version: ""
     stacktrace: |-
       github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter.(*receiver).consumeEntries
-        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.126.0/adapter/receiver.go:61
+        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.130.0/adapter/receiver.go:61
       github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper.(*BatchingLogEmitter).flusher
-        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.126.0/operator/helper/emitter.go:171
+        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.130.0/operator/helper/emitter.go:171

--- a/transformation_test/testdata/test_timezone/output_otel.yaml
+++ b/transformation_test/testdata/test_timezone/output_otel.yaml
@@ -22,13 +22,16 @@
     timestamp: now
   partialSuccess: true
 - collector_errors:
-  - caller: ottl@v0.126.0/parser.go:395
-    error: "parsing time \"unparsable time\" as \"2006-01-02T15:04\": cannot parse \"unparsable time\" as \"2006\""
+  - caller: ottl@v0.130.0/parser.go:410
+    error: "parsing time \"unparsable time\" as \"%Y-%m-%dT%H:%M\": cannot parse \"unparsable time\" as \"%Y\""
     level: warn
     msg: failed to execute statement
     otelcol.component.id: transform/input_0
     otelcol.component.kind: processor
     otelcol.pipeline.id: logs/input
     otelcol.signal: logs
-    resource: {}
+    resource:
+      service.instance.id: test-service-instance-id
+      service.name: otelopscol
+      service.version: ""
     statement: set(log.cache["__time_valid"], true) where ((log.body != nil and log.body["time"] != nil) and Time(log.body["time"], "%Y-%m-%dT%H:%M") != nil)

--- a/transformation_test/transformation_test.go
+++ b/transformation_test/transformation_test.go
@@ -512,6 +512,13 @@ func (transformationConfig transformationTest) runOTelTestInner(t *testing.T, na
 			if ok {
 				log["stacktrace"] = sanitizeStacktrace(t, stacktrace)
 			}
+			// Set "service.instance.id" to "test-service-instance-id" since it is a generated "uuid".
+			if resource, ok := log["resource"].(map[string]any); ok {
+				if _, ok := resource["service.instance.id"].(string); ok {
+					resource["service.instance.id"] = "test-service-instance-id"
+					log["resource"] = resource
+				}
+			}
 		}
 	})
 


### PR DESCRIPTION
## Description
Update to `otelopscol` commit with opentelemetry release `v1.36.0/v0.130.0`. This brings several changes required Otel Logging related tasks (b/409351024, b/424478327, b/424474019).

Details :
- In latest version, the mysql receiver adds a new possible value ("operation = fsyncs") to the `log_operations` metric.
  - Updating tests accordingly to consider this value.
  - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41175.
- In the latest version, a new label `performance_counter_object_name` was added to the `sqlserver.page.life_expectancy` metric.
  - Updating tests accordingly to consider this value.
  - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40359
- Updated `transformation_test` goldens accordingly. 
- Sanitized the output to set a fixed `service.instance.id` since in this release it is reported as a UUID which changes every time the test is run. 
  - See https://github.com/open-telemetry/opentelemetry-collector/pull/13111.
  - See https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/.

## Related issue
b/409351024
b/424478327
b/424474019

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
