### PR TITLE
Transform Hex strings to integers

### DIFF
--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -155,8 +155,11 @@ func (p ParserShared) TypesStatements() (ottl.Statements, error) {
 		case "float":
 			out = out.Append(a.Set(ottl.ToFloat(a)))
 		case "hex":
-			// TODO: Not exposed in OTTL
-			fallthrough
+			// The strtoull C function is used in Fluent Bit to parse hexadecimal strings: https://github.com/fluent/fluent-bit/blob/a20a127f1b5ae70706bac0dac45fbc6abde4ad27/src/flb_parser.c#L1319
+			// strtoull parses strings into an unsigned long long integer, which is equivalent to an int64 in Go. It also accepts hexadecimal strings with a leading "0x" prefix and trailing whitespace. Additionally, it accepts a leading "+" or "-" sign.
+			// However, ottl.ParseInt(a, 16) only parses hexadecimal strings without a leading "0x" prefix (e.g., "AF111", "-123F") and does not allow trailing whitespace. It does accept a leading "+" or "-" sign.
+			// ottl.ParseInt also parses the string to an int64.
+			out = out.Append(a.Set(ottl.ParseInt(a, 16)))
 		default:
 			return nil, fmt.Errorf("type %q not supported for field %s", fieldType, m)
 		}

--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -156,9 +156,9 @@ func (p ParserShared) TypesStatements() (ottl.Statements, error) {
 			out = out.Append(a.Set(ottl.ToFloat(a)))
 		case "hex":
 			// The strtoull C function is used in Fluent Bit to parse hexadecimal strings: https://github.com/fluent/fluent-bit/blob/a20a127f1b5ae70706bac0dac45fbc6abde4ad27/src/flb_parser.c#L1319
-			// strtoull parses strings into an unsigned long long integer, which is equivalent to an int64 in Go. It also accepts hexadecimal strings with a leading "0x" prefix and trailing whitespace. Additionally, it accepts a leading "+" or "-" sign.
+			// strtoull parses strings into an unsigned long long integer, which is equivalent to an uint64 in Go. It also accepts hexadecimal strings with a leading "0x" prefix and trailing whitespace. Additionally, it accepts a leading "+" or "-" sign.
 			// However, ottl.ParseInt(a, 16) only parses hexadecimal strings without a leading "0x" prefix (e.g., "AF111", "-123F") and does not allow trailing whitespace. It does accept a leading "+" or "-" sign.
-			// ottl.ParseInt also parses the string to an int64.
+			// ottl.ParseInt parses the string to an int64.
 			out = out.Append(a.Set(ottl.ParseInt(a, 16)))
 		default:
 			return nil, fmt.Errorf("type %q not supported for field %s", fieldType, m)


### PR DESCRIPTION
## Description
Used `ottl.ParseInt(hexString, 16)` to convert certain hex strings to `int64`. Hex strings without `0x` prefix, e.g: "AFFFF", "+123C" , "-1b1b" are converted to `int64` with `ottl.ParseInt(hexString, 16)`

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/424478327
## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
