### PR TITLE
[transformation_test] Compare `want` with `standarizedGot` to avoid issues when comparing string literals.

### DIFF
--- a/transformation_test/transformation_test.go
+++ b/transformation_test/transformation_test.go
@@ -196,8 +196,12 @@ func checkOutput(t *testing.T, name string, got []map[string]any) {
 	if err := yaml.Unmarshal(wantBytes, &want); err != nil {
 		t.Fatal(err)
 	}
+	var standarizedGot []map[string]any
+	if err := yaml.Unmarshal(gotBytes, &standarizedGot); err != nil {
+		t.Fatal(err)
+	}
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(standarizedGot, want); diff != "" {
 		t.Fatalf("got(-)/want(+):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Description
Currently "transformation tests" fail in the comparison when there is a tab character in any of the log fields because the `Marshalling` to YAML converts a tab to its "escape sequence" (`\t`) . Proposing the solution to compare `want` with the `Marshalled -> Unmarshalled` (standarized) version of `got` to avoid this.

## Related issue
b/413410475

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
