### PR TITLE
Reduce soak test disk size

### DIFF
--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -132,7 +132,7 @@ func mainErr() error {
 			// periodically.
 			"osconfig-disabled-features": "tasks",
 		},
-		ExtraCreateArguments: []string{"--boot-disk-size=4000GB"},
+		ExtraCreateArguments: []string{"--boot-disk-size=200GB"},
 	}
 	vm, err := gce.CreateInstance(ctx, logger, options)
 	if err != nil {


### PR DESCRIPTION
## Description
4TB is overkill; we rotate logs and never use more than about 90 GB on either Ubuntu or Windows.

## Related issue
N/A

## How has this been tested?
Will let presubmits/nightlies run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
