### PR TITLE
integration_test: Fix `TestAppHubLogLabels` flakes.

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5488,6 +5488,9 @@ func TestAppHubLogLabels(t *testing.T) {
 			}
 		})
 
+		// Wait after "Setup Apphub #2" to make sure Manage Instance Group is registered in AppHub.
+		time.Sleep(30 * time.Second)
+
 		if err := agents.SetupOpsAgent(ctx, logger, migVM.VM, ""); err != nil {
 			t.Fatal(err)
 		}

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5472,7 +5472,7 @@ func TestAppHubLogLabels(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Wait after "Setup Apphub #2" to make sure Manage Instance Group is registered in AppHub.
+		// Wait after "Setup Apphub #2" to make sure the Managed Instance Group is registered in AppHub.
 		time.Sleep(15 * time.Second)
 
 		t.Cleanup(func() {

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5472,6 +5472,9 @@ func TestAppHubLogLabels(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Wait after "Setup Apphub #2" to make sure Manage Instance Group is registered in AppHub.
+		time.Sleep(15 * time.Second)
+
 		t.Cleanup(func() {
 			// Setup Apphub #3 : Delete apphub workload.
 			deleteAppHubWorkloadArgs := []string{
@@ -5487,9 +5490,6 @@ func TestAppHubLogLabels(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
-
-		// Wait after "Setup Apphub #2" to make sure Manage Instance Group is registered in AppHub.
-		time.Sleep(30 * time.Second)
 
 		if err := agents.SetupOpsAgent(ctx, logger, migVM.VM, ""); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Description
Adding a small fix to `TestAppHubLogLabels` to address recurrent flakes on `Ops Agent integration test (Debian 12 Bookworm x86_64 UAP Plugin)`. 

Explanation : Sometimes the "test log" is not correctly labeled by Google Cloud Logging as associated with an AppHub workload. This probably happens because the "test log" is generated very soon after registering the "workload" (aka. the test Managed Instance Group) in AppHub.

## Related issue
b/354756009

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
