### PR TITLE
Updating opentelemetry-operantions-collector to bring googleclientauth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -815,7 +815,7 @@ ARG OPENJDK_MAJOR_VERSION
 RUN set -x; apt-get update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
 		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential cmake bison flex file libsystemd-dev tzdata \
+		build-essential cmake bison flex file libsystemd-dev \
 		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip
 
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -815,7 +815,7 @@ ARG OPENJDK_MAJOR_VERSION
 RUN set -x; apt-get update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
 		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential cmake bison flex file libsystemd-dev \
+		build-essential cmake bison flex file libsystemd-dev tzdata \
 		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip
 
 SHELL ["/bin/bash", "-c"]

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -183,7 +183,7 @@ RUN ln -fs /usr/lib/systemd /lib/systemd` + installJava + installCMake,
 		install_packages: `RUN set -x; apt-get update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
 		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential cmake bison flex file libsystemd-dev tzdata \
+		build-essential cmake bison flex file libsystemd-dev \
 		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "ubuntu-jammy",

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -183,7 +183,7 @@ RUN ln -fs /usr/lib/systemd /lib/systemd` + installJava + installCMake,
 		install_packages: `RUN set -x; apt-get update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
 		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
-		build-essential cmake bison flex file libsystemd-dev \
+		build-essential cmake bison flex file libsystemd-dev tzdata \
 		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "ubuntu-jammy",


### PR DESCRIPTION
## Description
The otlphttp exporter needs googleclientauth to be able to send metrics to that endpoint.
## Related issue

b/435217364

## How has this been tested?

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
