### PR TITLE
Updated `os_versions` field in `project.yaml`

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -14,7 +14,7 @@
 
 targets:
   bookworm:
-    os_versions: [debian-12]
+    os_versions: [debian-12*]
     package_extension:
       deb
     architectures:
@@ -27,7 +27,7 @@ targets:
           representative:
           - debian-cloud:debian-12-arm64
   bullseye:
-    os_versions: [debian-11]
+    os_versions: [debian-11*]
     package_extension:
       deb
     architectures:
@@ -37,7 +37,7 @@ targets:
           - debian-cloud:debian-11
           - ml-images:common-gpu-debian-11-py310
   centos8:
-    os_versions: [centos-8,rocky-8,rhel-8]
+    os_versions: [centos-8*,rocky-8*,rhel-8*]
     package_extension:
       rpm
     repo_name:
@@ -58,7 +58,7 @@ targets:
           representative:
           - rocky-linux-cloud:rocky-linux-8-optimized-gcp-arm64
   jammy:
-    os_versions: [ubuntu-22.04]
+    os_versions: [ubuntu-22.04*]
     package_extension:
       deb
     architectures:
@@ -77,7 +77,7 @@ targets:
           exhaustive:
           - ubuntu-os-cloud:ubuntu-minimal-2204-lts-arm64
   noble:
-    os_versions: [ubuntu-24.04]
+    os_versions: [ubuntu-24.04*]
     package_extension:
       deb
     architectures:
@@ -94,7 +94,7 @@ targets:
           exhaustive:
           - ubuntu-os-cloud:ubuntu-minimal-2404-lts-arm64
   rockylinux9:
-    os_versions: [rocky-9,rhel-9]
+    os_versions: [rocky-9*,rhel-9*]
     package_extension:
       rpm
     repo_name:
@@ -115,7 +115,7 @@ targets:
           - rhel-cloud:rhel-9-arm64
           - rocky-linux-cloud:rocky-linux-9-optimized-gcp-arm64
   sles12:
-    os_versions: [sles-12]
+    os_versions: [sles-12*]
     package_extension:
       rpm
     architectures:
@@ -126,7 +126,7 @@ targets:
           exhaustive:
           - suse-sap-cloud:sles-12-sp5-sap
   sles15:
-    os_versions: [sles-15]
+    os_versions: [sles-15*]
     package_extension:
       rpm
     architectures:


### PR DESCRIPTION
## Description
This is to make sure UAP matches our supplied version.
UAP uses [filepath.Match](https://critique.corp.google.com/cl/787262322/depot/google3/cloud/cluster/guestplatform/agent_controlplane/continuous_state_enforcement/candidatematcher.go). 

`rocky-9*` is going to match `rocky-9.6`
`ubuntu-22.04*` matches `ubuntu-22.04`

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
