### PR TITLE
Update Debian/Ubuntu cassandra tests to 4.1x

### DIFF
--- a/integration_test/third_party_apps_test/applications/cassandra/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/cassandra/debian_ubuntu/install
@@ -1,22 +1,8 @@
 set -e
 
 curl https://downloads.apache.org/cassandra/KEYS --output /etc/apt/trusted.gpg.d/cassandra.asc
-
 source /etc/os-release
-if [[ "${VERSION_ID}" =~ ^(22|24) || "$(uname -m)" == aarch64 ]]; then
-    # Newer versions of Ubuntu can use a newer version of cassandra.
-    # Additionally, cassandra doesn't have arm64 binaries for 2.2x, but does for 4.1x.
-    echo "deb https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-
-    sudo apt update
-    sudo apt install -y openjdk-11-jre cassandra
-else
-    echo "deb https://debian.cassandra.apache.org 22x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-    # Required to install java8 (JVM properties of cassandra 2.2 are incompatible with >9)
-    echo "deb https://archive.debian.org/debian-security stretch/updates main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-
-    sudo apt update
-    sudo apt install -y openjdk-8-jre cassandra
-fi
-
+echo "deb https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+sudo apt update
+sudo apt install -y openjdk-11-jre cassandra
 sudo service cassandra start


### PR DESCRIPTION
## Description
Update Debian/Ubuntu cassandra tests to 4.1x. 2.2x is EOL and starting to fail.

## Related issue
http://b/438157872

## How has this been tested?
Will let presubmits run.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
