### PR TITLE
use cassandra 4.1x on debian 11 x86_64

### DIFF
--- a/integration_test/third_party_apps_test/applications/cassandra/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/cassandra/debian_ubuntu/install
@@ -11,12 +11,10 @@ if [[ "${VERSION_ID}" =~ ^(22|24) || "$(uname -m)" == aarch64 ]]; then
     sudo apt update
     sudo apt install -y openjdk-11-jre cassandra
 else
-    echo "deb https://debian.cassandra.apache.org 22x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-    # Required to install java8 (JVM properties of cassandra 2.2 are incompatible with >9)
-    echo "deb https://archive.debian.org/debian-security stretch/updates main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-
+    echo "deb https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+    
     sudo apt update
-    sudo apt install -y openjdk-8-jre cassandra
+    sudo apt install -y openjdk-11-jre cassandra
 fi
 
 sudo service cassandra start


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
