### PR TITLE
Adding gce.project_id when using otlp exporter

### DIFF
--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -596,3 +596,9 @@ func MetricStartTime() Component {
 		Config: map[string]string{"strategy": "subtract_initial_point"},
 	}
 }
+
+func GCEProjectID(projectID string) Component {
+	return MetricsTransform(
+		AddLabel("gce.project_id", projectID),
+	)
+}

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -597,8 +597,8 @@ func MetricStartTime() Component {
 	}
 }
 
-func GCEProjectID(projectID string) Component {
-	return MetricsTransform(
-		AddLabel("gce.project_id", projectID),
+func CloudAccountID(projectID string) Component {
+	return ResourceTransform(
+		map[string]string{"cloud.account.id": projectID}, false,
 	)
 }

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -597,8 +597,8 @@ func MetricStartTime() Component {
 	}
 }
 
-func CloudAccountID(projectID string) Component {
+func GCPProjectID(projectID string) Component {
 	return ResourceTransform(
-		map[string]string{"cloud.account.id": projectID}, false,
+		map[string]string{"gcp.project_id": projectID}, false,
 	)
 }

--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -91,6 +91,7 @@ func (r PrometheusMetrics) Pipelines(ctx context.Context) ([]otel.ReceiverPipeli
 	metrics_components := []otel.Component{otel.GroupByGMPAttrs_OTTL()}
 	if exp_otlp_exporter {
 		metrics_components = append(metrics_components, otel.MetricStartTime())
+		metrics_components = append(metrics_components, otel.GCEProjectID(resource.ProjectName()))
 	}
 	return []otel.ReceiverPipeline{{
 		Receiver: prometheusToOtelComponent(r),

--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -91,7 +91,7 @@ func (r PrometheusMetrics) Pipelines(ctx context.Context) ([]otel.ReceiverPipeli
 	metrics_components := []otel.Component{otel.GroupByGMPAttrs_OTTL()}
 	if exp_otlp_exporter {
 		metrics_components = append(metrics_components, otel.MetricStartTime())
-		metrics_components = append(metrics_components, otel.CloudAccountID(resource.ProjectName()))
+		metrics_components = append(metrics_components, otel.GCPProjectID(resource.ProjectName()))
 	}
 	return []otel.ReceiverPipeline{{
 		Receiver: prometheusToOtelComponent(r),

--- a/confgenerator/prometheus.go
+++ b/confgenerator/prometheus.go
@@ -91,7 +91,7 @@ func (r PrometheusMetrics) Pipelines(ctx context.Context) ([]otel.ReceiverPipeli
 	metrics_components := []otel.Component{otel.GroupByGMPAttrs_OTTL()}
 	if exp_otlp_exporter {
 		metrics_components = append(metrics_components, otel.MetricStartTime())
-		metrics_components = append(metrics_components, otel.GCEProjectID(resource.ProjectName()))
+		metrics_components = append(metrics_components, otel.CloudAccountID(resource.ProjectName()))
 	}
 	return []otel.ReceiverPipeline{{
 		Receiver: prometheusToOtelComponent(r),

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -462,11 +462,11 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/prometheus_2:
-    transforms:
-    - action: add_label
-      new_label: gce.project_id
-      new_value: test-project
+  resource/prometheus_2:
+    attributes:
+    - action: insert
+      key: cloud.account.id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -645,7 +645,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
-      - metricstransform/prometheus_2
+      - resource/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -465,7 +465,7 @@ processors:
   resource/prometheus_2:
     attributes:
     - action: insert
-      key: cloud.account.id
+      key: gcp.project_id
       value: test-project
   resourcedetection/_global_0:
     detectors:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -462,6 +462,11 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  metricstransform/prometheus_2:
+    transforms:
+    - action: add_label
+      new_label: gce.project_id
+      new_value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -640,6 +645,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
+      - metricstransform/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -436,7 +436,7 @@ processors:
   resource/prometheus_2:
     attributes:
     - action: insert
-      key: cloud.account.id
+      key: gcp.project_id
       value: test-project
   resourcedetection/_global_0:
     detectors:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -433,6 +433,11 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  metricstransform/prometheus_2:
+    transforms:
+    - action: add_label
+      new_label: gce.project_id
+      new_value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -600,6 +605,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
+      - metricstransform/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -433,11 +433,11 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/prometheus_2:
-    transforms:
-    - action: add_label
-      new_label: gce.project_id
-      new_value: test-project
+  resource/prometheus_2:
+    attributes:
+    - action: insert
+      key: cloud.account.id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -605,7 +605,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
-      - metricstransform/prometheus_2
+      - resource/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -498,6 +498,11 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  metricstransform/prometheus_2:
+    transforms:
+    - action: add_label
+      new_label: gce.project_id
+      new_value: test-project
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -735,6 +740,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
+      - metricstransform/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -498,12 +498,12 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/prometheus_2:
-    transforms:
-    - action: add_label
-      new_label: gce.project_id
-      new_value: test-project
   normalizesums/iis_2: {}
+  resource/prometheus_2:
+    attributes:
+    - action: insert
+      key: cloud.account.id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -740,7 +740,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
-      - metricstransform/prometheus_2
+      - resource/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -502,7 +502,7 @@ processors:
   resource/prometheus_2:
     attributes:
     - action: insert
-      key: cloud.account.id
+      key: gcp.project_id
       value: test-project
   resourcedetection/_global_0:
     detectors:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -498,6 +498,11 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
+  metricstransform/prometheus_2:
+    transforms:
+    - action: add_label
+      new_label: gce.project_id
+      new_value: test-project
   normalizesums/iis_2: {}
   resourcedetection/_global_0:
     detectors:
@@ -735,6 +740,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
+      - metricstransform/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -498,12 +498,12 @@ processors:
       include: ^(.*)$$
       match_type: regexp
       new_name: agent.googleapis.com/$${1}
-  metricstransform/prometheus_2:
-    transforms:
-    - action: add_label
-      new_label: gce.project_id
-      new_value: test-project
   normalizesums/iis_2: {}
+  resource/prometheus_2:
+    attributes:
+    - action: insert
+      key: cloud.account.id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -740,7 +740,7 @@ service:
       processors:
       - transform/prometheus_0
       - metricstarttime/prometheus_1
-      - metricstransform/prometheus_2
+      - resource/prometheus_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -502,7 +502,7 @@ processors:
   resource/prometheus_2:
     attributes:
     - action: insert
-      key: cloud.account.id
+      key: gcp.project_id
       value: test-project
   resourcedetection/_global_0:
     detectors:


### PR DESCRIPTION
## Description
This adds the required gce.project_id label when exporting metrics to the otlphttp endpoint.

## Related issue
b/437100213

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
