### PR TITLE
Add OTel support to `parse_multiline`

### DIFF
--- a/confgenerator/logging_receivers.go
+++ b/confgenerator/logging_receivers.go
@@ -200,10 +200,12 @@ func (r LoggingReceiverFilesMixin) Components(ctx context.Context, tag string) [
 func (r LoggingReceiverFilesMixin) Pipelines(ctx context.Context) ([]otel.ReceiverPipeline, error) {
 	operators := []map[string]any{}
 	receiver_config := map[string]any{
-		"include":           r.IncludePaths,
-		"exclude":           r.ExcludePaths,
-		"start_at":          "beginning",
-		"include_file_name": false,
+		"include":                       r.IncludePaths,
+		"exclude":                       r.ExcludePaths,
+		"start_at":                      "beginning",
+		"include_file_name":             false,
+		"preserve_leading_whitespaces":  true,
+		"preserve_trailing_whitespaces": true,
 	}
 	if i := r.WildcardRefreshInterval; i != nil {
 		receiver_config["poll_interval"] = i.String()

--- a/transformation_test/testdata/logging_processor-apache-access/output_otel.yaml
+++ b/transformation_test/testdata/logging_processor-apache-access/output_otel.yaml
@@ -49,8 +49,7 @@
         zone: test-zone
       type: gce_instance
     timestamp: 2021-08-26T16:51:22Z
-  - jsonPayload:
-      gzip_ratio: ""
+  - jsonPayload: {}
     labels:
       compute.googleapis.com/resource_name: hostname
       logging.googleapis.com/instrumentation_source: agent.googleapis.com/apache_access
@@ -60,5 +59,5 @@
         instance_id: test-instance-id
         zone: test-zone
       type: gce_instance
-    timestamp: 2021-08-26T16:53:05Z
+    timestamp: now
   partialSuccess: true

--- a/transformation_test/testdata/logging_processor-apache-error/output_otel.yaml
+++ b/transformation_test/testdata/logging_processor-apache-error/output_otel.yaml
@@ -60,7 +60,7 @@
       client: 127.0.0.1
       errorCode: ""
       level: error
-      message: "client denied by server configuration: /export/home/live/ap/htdocs/test"
+      message: "client denied by server configuration: /export/home/live/ap/htdocs/test "
       module: ""
       pid: ""
       tid: ""

--- a/transformation_test/testdata/logging_processor-jetty-access/output_otel.yaml
+++ b/transformation_test/testdata/logging_processor-jetty-access/output_otel.yaml
@@ -48,9 +48,7 @@
         zone: test-zone
       type: gce_instance
     timestamp: 2021-08-26T16:50:15Z
-  - jsonPayload:
-      gzip_ratio: ""
-      user: admin
+  - jsonPayload: {}
     labels:
       compute.googleapis.com/resource_name: hostname
       logging.googleapis.com/instrumentation_source: agent.googleapis.com/jetty_access
@@ -60,5 +58,5 @@
         instance_id: test-instance-id
         zone: test-zone
       type: gce_instance
-    timestamp: 2021-08-26T16:51:22Z
+    timestamp: now
   partialSuccess: true

--- a/transformation_test/testdata/logging_processor-redis/output_otel.yaml
+++ b/transformation_test/testdata/logging_processor-redis/output_otel.yaml
@@ -358,7 +358,7 @@
     timestamp: 2025-07-19T02:08:05.267Z
   - jsonPayload:
       level: "*"
-      message: "<search> gc: ON, prefix min length: 2, min word length to stem: 4, prefix max expansions: 200, query timeout (ms): 500, timeout policy: return, cursor read size: 1000, cursor max idle (ms): 300000, max doctable size: 1000000, max number of search results:  1000000,"
+      message: "<search> gc: ON, prefix min length: 2, min word length to stem: 4, prefix max expansions: 200, query timeout (ms): 500, timeout policy: return, cursor read size: 1000, cursor max idle (ms): 300000, max doctable size: 1000000, max number of search results:  1000000, "
       pid: 1
       role: master
       roleChar: M

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/config.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/config.yaml
@@ -1,0 +1,9 @@
+- type: parse_multiline
+  match_any:
+  - type: language_exceptions
+    language: go
+  - type: language_exceptions
+    language: java
+  - type: language_exceptions
+    language: python
+

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/input.log
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/input.log
@@ -1,0 +1,57 @@
+2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+goroutine 24 [running]:
+net/http.(*conn).serve.func1(0xc00007eaa0)
+	/usr/local/go/src/net/http/server.go:1746 +0xd0
+panic(0x12472a0, 0x12ece10)
+	/usr/local/go/src/runtime/panic.go:513 +0x1b9
+main.doPanic(0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/Users/ingvar/src/go/src/httppanic.go:8 +0x39
+net/http.HandlerFunc.ServeHTTP(0x12be2e8, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:1964 +0x44
+net/http.(*ServeMux).ServeHTTP(0x14a17a0, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:2361 +0x127
+net/http.serverHandler.ServeHTTP(0xc000085040, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:2741 +0xab
+net/http.(*conn).serve(0xc00007eaa0, 0x12f10a0, 0xc00008a780)
+	/usr/local/go/src/net/http/server.go:1847 +0x646
+created by net/http.(*Server).Serve
+	/usr/local/go/src/net/http/server.go:2851 +0x2f5
+Traceback (most recent call last):
+  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+    rv = self.handle_exception(request, response, e)
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+    return get()
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+    raise Exception('spam', 'eggs')
+Exception: ('spam', 'eggs')
+2023-07-09 00:00:00,000 ERROR    some_app custom string prefix to the exception: Traceback (most recent call last):
+  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+    rv = self.handle_exception(request, response, e)
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+    return get()
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+    raise Exception('spam', 'eggs')
+Exception: ('spam', 'eggs')
+java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+	at java.util.Optional.ifPresent(Optional.java:159)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.base/java.lang.Thread.run(Thread.java:748)
+Caused by: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+	... 12 more
+Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/output_fluentbit.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/output_fluentbit.yaml
@@ -1,0 +1,57 @@
+- entries:
+  - jsonPayload:
+      message: |-
+        2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+        goroutine 24 [running]:
+        net/http.(*conn).serve.func1(0xc00007eaa0)
+        	/usr/local/go/src/net/http/server.go:1746 +0xd0
+        panic(0x12472a0, 0x12ece10)
+        	/usr/local/go/src/runtime/panic.go:513 +0x1b9
+        main.doPanic(0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/Users/ingvar/src/go/src/httppanic.go:8 +0x39
+        net/http.HandlerFunc.ServeHTTP(0x12be2e8, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/usr/local/go/src/net/http/server.go:1964 +0x44
+        net/http.(*ServeMux).ServeHTTP(0x14a17a0, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/usr/local/go/src/net/http/server.go:2361 +0x127
+        net/http.serverHandler.ServeHTTP(0xc000085040, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/usr/local/go/src/net/http/server.go:2741 +0xab
+        net/http.(*conn).serve(0xc00007eaa0, 0x12f10a0, 0xc00008a780)
+        	/usr/local/go/src/net/http/server.go:1847 +0x646
+        created by net/http.(*Server).Serve
+        	/usr/local/go/src/net/http/server.go:2851 +0x2f5
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        Traceback (most recent call last):
+          File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+            rv = self.handle_exception(request, response, e)
+          File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+            return get()
+          File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+            raise Exception('spam', 'eggs')
+        Exception: ('spam', 'eggs')
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        2023-07-09 00:00:00,000 ERROR    some_app custom string prefix to the exception: Traceback (most recent call last):
+          File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+            rv = self.handle_exception(request, response, e)
+          File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+            return get()
+          File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+            raise Exception('spam', 'eggs')
+        Exception: ('spam', 'eggs')
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  partialSuccess: true
+  resource:
+    labels: {}
+    type: gce_instance

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileGolangJavaPython/output_otel.yaml
@@ -1,0 +1,1 @@
+- config_error: "processor \"processor0\" has invalid configuration: unsupported in otel"

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/config.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/config.yaml
@@ -1,0 +1,4 @@
+- type: parse_multiline
+  match_any:
+  - type: language_exceptions
+    language: java

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/input.log
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/input.log
@@ -1,0 +1,55 @@
+Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+  at com.my.app.Object.do$a1(MakeLog.java:50)
+  at java.lang.Thing.call(Thing.java:10)
+javax.servlet.ServletException: Something bad happened
+    at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:60)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+    at com.example.myproject.ExceptionHandlerFilter.doFilter(ExceptionHandlerFilter.java:28)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+    at com.example.myproject.OutputBufferFilter.doFilter(OutputBufferFilter.java:33)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+    at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
+    at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
+    at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
+    at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
+    at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)
+    at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
+    at org.mortbay.jetty.Server.handle(Server.java:326)
+    at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
+    at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:943)
+    at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)
+    at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
+    at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
+    at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
+    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
+Caused by: com.example.myproject.MyProjectServletException
+    at com.example.myproject.MyServlet.doPost(MyServlet.java:169)
+    at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
+    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
+    at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
+    at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:30)
+    ... 27 common frames omitted
+java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+	at java.util.Optional.ifPresent(Optional.java:159)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.base/java.lang.Thread.run(Thread.java:748)
+Caused by: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+	... 12 more
+Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/output_fluentbit.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/output_fluentbit.yaml
@@ -1,0 +1,49 @@
+- entries:
+  - jsonPayload:
+      message: |-
+        Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+          at com.my.app.Object.do$a1(MakeLog.java:50)
+          at java.lang.Thing.call(Thing.java:10)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        javax.servlet.ServletException: Something bad happened
+            at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:60)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at com.example.myproject.ExceptionHandlerFilter.doFilter(ExceptionHandlerFilter.java:28)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at com.example.myproject.OutputBufferFilter.doFilter(OutputBufferFilter.java:33)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
+            at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
+            at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
+            at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
+            at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)
+            at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
+            at org.mortbay.jetty.Server.handle(Server.java:326)
+            at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
+            at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:943)
+            at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)
+            at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
+            at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
+            at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
+            at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
+        Caused by: com.example.myproject.MyProjectServletException
+            at com.example.myproject.MyServlet.doPost(MyServlet.java:169)
+            at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
+            at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
+            at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
+            at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:30)
+            ... 27 common frames omitted
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  partialSuccess: true
+  resource:
+    labels: {}
+    type: gce_instance

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJava/output_otel.yaml
@@ -1,0 +1,68 @@
+- entries:
+  - jsonPayload:
+      message: |-
+        Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+          at com.my.app.Object.do$a1(MakeLog.java:50)
+          at java.lang.Thing.call(Thing.java:10)
+        javax.servlet.ServletException: Something bad happened
+            at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:60)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at com.example.myproject.ExceptionHandlerFilter.doFilter(ExceptionHandlerFilter.java:28)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at com.example.myproject.OutputBufferFilter.doFilter(OutputBufferFilter.java:33)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
+            at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
+            at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
+            at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
+            at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)
+            at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
+            at org.mortbay.jetty.Server.handle(Server.java:326)
+            at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
+            at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:943)
+            at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)
+            at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
+            at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
+            at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
+            at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
+        Caused by: com.example.myproject.MyProjectServletException
+            at com.example.myproject.MyServlet.doPost(MyServlet.java:169)
+            at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
+            at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
+            at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
+            at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:30)
+            ... 27 common frames omitted
+        java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
+          nested exception is:
+        com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+        	at java.util.Optional.ifPresent(Optional.java:159)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+        	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+        	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+        	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+        	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+        	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+        	at java.base/java.lang.Thread.run(Thread.java:748)
+        Caused by: javax.mail.SendFailedException: Invalid Addresses;
+          nested exception is:
+        com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+        	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+        	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+        	... 12 more
+        Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/my-log-name
+    resource:
+      labels:
+        instance_id: test-instance-id
+        zone: test-zone
+      type: gce_instance
+    timestamp: now
+  partialSuccess: true

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/config.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/config.yaml
@@ -1,0 +1,6 @@
+- type: parse_multiline
+  match_any:
+    - type: language_exceptions
+      language: java
+    - type: language_exceptions
+      language: python

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/input.log
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/input.log
@@ -1,0 +1,87 @@
+Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+  at com.my.app.Object.do$a1(MakeLog.java:50)
+  at java.lang.Thing.call(Thing.java:10)
+Traceback (most recent call last):
+  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+    rv = self.handle_exception(request, response, e)
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+    return get()
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+    raise Exception('spam', 'eggs')
+Exception: ('spam', 'eggs')
+javax.servlet.ServletException: Something bad happened
+    at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:60)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+    at com.example.myproject.ExceptionHandlerFilter.doFilter(ExceptionHandlerFilter.java:28)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+    at com.example.myproject.OutputBufferFilter.doFilter(OutputBufferFilter.java:33)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+    at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
+    at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
+    at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
+    at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
+    at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)
+    at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
+    at org.mortbay.jetty.Server.handle(Server.java:326)
+    at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
+    at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:943)
+    at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)
+    at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
+    at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
+    at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
+    at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
+Caused by: com.example.myproject.MyProjectServletException
+    at com.example.myproject.MyServlet.doPost(MyServlet.java:169)
+    at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
+    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
+    at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
+    at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
+    at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:30)
+    ... 27 common frames omitted
+java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+	at java.util.Optional.ifPresent(Optional.java:159)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.base/java.lang.Thread.run(Thread.java:748)
+Caused by: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+	... 12 more
+Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+Traceback (most recent call last):
+  File "/test/exception.py", line 21, in <module>
+    conn.request("GET", "/")
+  File "/usr/lib/python3.10/http/client.py", line 1282, in request
+    self._send_request(method, url, body, headers, encode_chunked)
+  File "/usr/lib/python3.10/http/client.py", line 1328, in _send_request
+    self.endheaders(body, encode_chunked=encode_chunked)
+  File "/usr/lib/python3.10/http/client.py", line 1277, in endheaders
+    self._send_output(message_body, encode_chunked=encode_chunked)
+  File "/usr/lib/python3.10/http/client.py", line 1037, in _send_output
+    self.send(msg)
+  File "/usr/lib/python3.10/http/client.py", line 975, in send
+    self.connect()
+  File "/usr/lib/python3.10/http/client.py", line 941, in connect
+    self.sock = self._create_connection(
+  File "/usr/lib/python3.10/socket.py", line 824, in create_connection
+    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
+  File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
+    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
+socket.gaierror: [Errno -2] Name or service not known
+Traceback (most recent call last):
+  File "/usr/local/google/home/lujieduan/source/test/exception.py", line 11, in <module>
+    '2' + 2
+TypeError: can only concatenate str (not "int") to str

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/output_fluentbit.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/output_fluentbit.yaml
@@ -1,0 +1,128 @@
+- entries:
+  - jsonPayload:
+      message: |-
+        Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
+          at com.my.app.Object.do$a1(MakeLog.java:50)
+          at java.lang.Thing.call(Thing.java:10)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        Traceback (most recent call last):
+          File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+            rv = self.handle_exception(request, response, e)
+          File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+            return get()
+          File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+            raise Exception('spam', 'eggs')
+        Exception: ('spam', 'eggs')
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        javax.servlet.ServletException: Something bad happened
+            at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:60)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at com.example.myproject.ExceptionHandlerFilter.doFilter(ExceptionHandlerFilter.java:28)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at com.example.myproject.OutputBufferFilter.doFilter(OutputBufferFilter.java:33)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
+            at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
+            at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
+            at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
+            at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
+            at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)
+            at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
+            at org.mortbay.jetty.Server.handle(Server.java:326)
+            at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
+            at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:943)
+            at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)
+            at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
+            at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
+            at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
+            at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
+        Caused by: com.example.myproject.MyProjectServletException
+            at com.example.myproject.MyServlet.doPost(MyServlet.java:169)
+            at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
+            at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
+            at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
+            at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
+            at com.example.myproject.OpenSessionInViewFilter.doFilter(OpenSessionInViewFilter.java:30)
+            ... 27 common frames omitted
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
+          nested exception is:
+        com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+        	at java.util.Optional.ifPresent(Optional.java:159)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+        	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+        	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+        	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+        	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+        	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+        	at java.base/java.lang.Thread.run(Thread.java:748)
+        Caused by: javax.mail.SendFailedException: Invalid Addresses;
+          nested exception is:
+        com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+        	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+        	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+        	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+        	... 12 more
+        Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        Traceback (most recent call last):
+          File "/test/exception.py", line 21, in <module>
+            conn.request("GET", "/")
+          File "/usr/lib/python3.10/http/client.py", line 1282, in request
+            self._send_request(method, url, body, headers, encode_chunked)
+          File "/usr/lib/python3.10/http/client.py", line 1328, in _send_request
+            self.endheaders(body, encode_chunked=encode_chunked)
+          File "/usr/lib/python3.10/http/client.py", line 1277, in endheaders
+            self._send_output(message_body, encode_chunked=encode_chunked)
+          File "/usr/lib/python3.10/http/client.py", line 1037, in _send_output
+            self.send(msg)
+          File "/usr/lib/python3.10/http/client.py", line 975, in send
+            self.connect()
+          File "/usr/lib/python3.10/http/client.py", line 941, in connect
+            self.sock = self._create_connection(
+          File "/usr/lib/python3.10/socket.py", line 824, in create_connection
+            for res in getaddrinfo(host, port, 0, SOCK_STREAM):
+          File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
+            for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
+        socket.gaierror: [Errno -2] Name or service not known
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: |-
+        Traceback (most recent call last):
+          File "/usr/local/google/home/lujieduan/source/test/exception.py", line 11, in <module>
+            '2' + 2
+        TypeError: can only concatenate str (not "int") to str
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  partialSuccess: true
+  resource:
+    labels: {}
+    type: gce_instance

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileJavaPython/output_otel.yaml
@@ -1,0 +1,1 @@
+- config_error: "processor \"processor0\" has invalid configuration: unsupported in otel"

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/config.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/config.yaml
@@ -1,0 +1,5 @@
+# Only configured to match Go; Python and Java should show up as multiple lines.
+- type: parse_multiline
+  match_any:
+  - type: language_exceptions
+    language: go

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/input.log
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/input.log
@@ -1,0 +1,49 @@
+2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+goroutine 24 [running]:
+net/http.(*conn).serve.func1(0xc00007eaa0)
+	/usr/local/go/src/net/http/server.go:1746 +0xd0
+panic(0x12472a0, 0x12ece10)
+	/usr/local/go/src/runtime/panic.go:513 +0x1b9
+main.doPanic(0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/Users/ingvar/src/go/src/httppanic.go:8 +0x39
+net/http.HandlerFunc.ServeHTTP(0x12be2e8, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:1964 +0x44
+net/http.(*ServeMux).ServeHTTP(0x14a17a0, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:2361 +0x127
+net/http.serverHandler.ServeHTTP(0xc000085040, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:2741 +0xab
+net/http.(*conn).serve(0xc00007eaa0, 0x12f10a0, 0xc00008a780)
+	/usr/local/go/src/net/http/server.go:1847 +0x646
+created by net/http.(*Server).Serve
+	/usr/local/go/src/net/http/server.go:2851 +0x2f5
+Traceback (most recent call last):
+  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
+    rv = self.handle_exception(request, response, e)
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
+    return get()
+  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
+    raise Exception('spam', 'eggs')
+Exception: ('spam', 'eggs')
+java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+	at java.util.Optional.ifPresent(Optional.java:159)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.base/java.lang.Thread.run(Thread.java:748)
+Caused by: javax.mail.SendFailedException: Invalid Addresses;
+  nested exception is:
+com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied
+	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+	... 12 more
+Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/output_fluentbit.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/output_fluentbit.yaml
@@ -1,0 +1,215 @@
+- entries:
+  - jsonPayload:
+      message: |-
+        2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+        goroutine 24 [running]:
+        net/http.(*conn).serve.func1(0xc00007eaa0)
+        	/usr/local/go/src/net/http/server.go:1746 +0xd0
+        panic(0x12472a0, 0x12ece10)
+        	/usr/local/go/src/runtime/panic.go:513 +0x1b9
+        main.doPanic(0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/Users/ingvar/src/go/src/httppanic.go:8 +0x39
+        net/http.HandlerFunc.ServeHTTP(0x12be2e8, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/usr/local/go/src/net/http/server.go:1964 +0x44
+        net/http.(*ServeMux).ServeHTTP(0x14a17a0, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/usr/local/go/src/net/http/server.go:2361 +0x127
+        net/http.serverHandler.ServeHTTP(0xc000085040, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+        	/usr/local/go/src/net/http/server.go:2741 +0xab
+        net/http.(*conn).serve(0xc00007eaa0, 0x12f10a0, 0xc00008a780)
+        	/usr/local/go/src/net/http/server.go:1847 +0x646
+        created by net/http.(*Server).Serve
+        	/usr/local/go/src/net/http/server.go:2851 +0x2f5
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "Traceback (most recent call last):"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "  File \"/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py\", line 1535, in __call__"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "    rv = self.handle_exception(request, response, e)"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 17, in start"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "    return get()"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 5, in get"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "    raise Exception('spam', 'eggs')"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "Exception: ('spam', 'eggs')"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "java.lang.RuntimeException: javax.mail.SendFailedException: Invalid Addresses;"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "  nested exception is:"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:236)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:285)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.lambda$sendSingleEmail$3(AutomaticEmailFacade.java:254)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at java.util.Optional.ifPresent(Optional.java:159)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:253)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendSingleEmail(AutomaticEmailFacade.java:249)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.email.EmailSender.lambda$notifyPerson$0(EmailSender.java:80)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.util.ManagedExecutor.lambda$execute$0(ManagedExecutor.java:36)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.util.RequestContextActivator.lambda$withRequestContext$0(RequestContextActivator.java:36)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at java.base/java.lang.Thread.run(Thread.java:748)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "Caused by: javax.mail.SendFailedException: Invalid Addresses;"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "  nested exception is:"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	at com.nethunt.crm.api.server.adminsync.AutomaticEmailFacade.sendWithSmtp(AutomaticEmailFacade.java:229)
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: 	... 12 more
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EMAIL_ADDRESS]>... Relaying denied"
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  partialSuccess: true
+  resource:
+    labels: {}
+    type: gce_instance

--- a/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestParseMultilineFileMissingParser/output_otel.yaml
@@ -1,0 +1,1 @@
+- config_error: "processor \"processor0\" has invalid configuration: unsupported in otel"

--- a/transformation_test/transformation_test.go
+++ b/transformation_test/transformation_test.go
@@ -503,7 +503,8 @@ func (transformationConfig transformationTest) runOTelTestInner(t *testing.T, na
 			msg, _ := log["msg"].(string)
 			if strings.HasPrefix(msg, "Consuming files") {
 				consumingCount += 1
-				if consumingCount == 2 {
+				// Wait for a second poll to give processors a chance to flush.
+				if consumingCount == 3 {
 					// We've processed the entire input file. Signal the collector to stop.
 					if err := cmd.Process.Signal(os.Interrupt); err != nil {
 						t.Errorf("failed to signal process: %v", err)


### PR DESCRIPTION
## Description
DRAFT: Needs go and python support to be implemented.

This PR enables `parse_multiline` for OTel. It requires https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/pull/405 to be merged for access to the `recombine` operator.

This also fixes our OTel support to preserve leading and trailing whitespace on log lines, which makes it match fluent-bit's behavior better. This causes (correct) changes in existing transformation test output.

## Related issue
b/413446918

## How has this been tested?
`go test ./transformation_test`

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
