### PR TITLE
Adding more time for AppHub to be ready

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5486,7 +5486,7 @@ func TestAppHubLogLabels(t *testing.T) {
 		}
 
 		// Wait after "Setup Apphub #2" to make sure the Managed Instance Group is registered in AppHub.
-		time.Sleep(15 * time.Second)
+		time.Sleep(60 * time.Second)
 
 		t.Cleanup(func() {
 			// Setup Apphub #3 : Delete apphub workload.


### PR DESCRIPTION
## Description
This increases the sleep time to give AppHub a few extra seconds.

## Related issue
b/444243574

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
