### PR TITLE
Removed empty Apply method

### DIFF
--- a/cmd/ops_agent_uap_plugin/plugin_test.go
+++ b/cmd/ops_agent_uap_plugin/plugin_test.go
@@ -22,10 +22,9 @@ import (
 
 	"buf.build/go/protoyaml" // Import the protoyaml-go package
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
+	pb "github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin/google_guest_agent/plugin"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
-
-	pb "github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin/google_guest_agent/plugin"
 	spb "google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/cmd/ops_agent_uap_plugin/service_linux.go
+++ b/cmd/ops_agent_uap_plugin/service_linux.go
@@ -30,9 +30,8 @@ import (
 	"sync"
 	"syscall"
 
-	"google.golang.org/grpc/status"
-
 	pb "github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin/google_guest_agent/plugin"
+	"google.golang.org/grpc/status"
 )
 
 const (


### PR DESCRIPTION
## Description
Removed the empty `Apply` method to allow it to fall back to the implementation in `UnimplementedGuestAgentPluginServer`.

## Related issue
b/446922922

## How has this been tested?


## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
