### PR TITLE
soak_test: Set a `hyperdisk-balanced` drive for soak tests.

### DIFF
--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -125,14 +125,14 @@ func mainErr() error {
 		ImageSpec:   distro,
 		TimeToLive:  ttl,
 		Name:        vmName,
-		MachineType: "e2-standard-16",
+		MachineType: "c4-standard-16",
 		Metadata: map[string]string{
 			// This is to avoid Windows updates and reboots (b/295165549), and
 			// also to avoid throughput blips when the OS Config agent runs
 			// periodically.
 			"osconfig-disabled-features": "tasks",
 		},
-		ExtraCreateArguments: []string{"--boot-disk-size=400GB", "--boot-disk-type=hyperdisk-balanced"},
+		ExtraCreateArguments: []string{"--boot-disk-size=200GB", "--boot-disk-type=hyperdisk-balanced"},
 	}
 	vm, err := gce.CreateInstance(ctx, logger, options)
 	if err != nil {


### PR DESCRIPTION
## Description
Fluent-bit in soak tests after https://github.com/GoogleCloudPlatform/ops-agent/pull/2005 seems to struggle and stop processing completely logs after 5 minutes. It never recovers.

Increasing the drive size to `4000GB` fixes the issue (maybe due to availability issues, see https://cloud.google.com/compute/docs/disks#hd-vs-pd), but also setting `hyperdisk-balanced` seems to fix the issue. Also set the VM to a `c4-standard-16` to be able to set `hyperdisk-balanced`.

## Related issue
b/446162456

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
