### PR TITLE
Update image version for opensuse-leap-15-6 due to image deprecation

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -143,7 +143,7 @@ targets:
           - suse-sap-cloud:sles-15-sp7-sap
           - opensuse-cloud:opensuse-leap
           - opensuse-cloud=opensuse-leap-15-5-v20250110-x86-64
-          - opensuse-cloud=opensuse-leap-15-6-v20250130-x86-64
+          - opensuse-cloud=opensuse-leap-15-6-v20250724-x86-64
       aarch64:
         test_distros:
           representative:
@@ -152,7 +152,7 @@ targets:
           - suse-cloud:sles-15-sp6-arm64
           - opensuse-cloud:opensuse-leap-arm64
           - opensuse-cloud=opensuse-leap-15-5-v20250110-arm64
-          - opensuse-cloud=opensuse-leap-15-6-v20250130-arm64
+          - opensuse-cloud=opensuse-leap-15-6-v20250724-arm64 
   windows:
     package_extension:
       goo


### PR DESCRIPTION
Update images that no longer exist.