### PR TITLE
Preserve newlines in Invoke-Program output

### DIFF
--- a/kokoro/scripts/build/build_package.ps1
+++ b/kokoro/scripts/build/build_package.ps1
@@ -24,6 +24,7 @@ $global:ProgressPreference = 'SilentlyContinue'
 #   Example: Invoke-Program git submodule update --init
 function Invoke-Program() {
   $outpluserr = cmd /c $Args 2`>`&1
+  $outpluserr = $outpluserr -join [Environment]::NewLine
   if ( $LastExitCode -ne 0 ) {
     throw "failed: $Args, output: $outpluserr"
   }


### PR DESCRIPTION
## Description
When you send the output of a native command to a variable, you actually get an array of strings, one for each line. By default, when this array is formatted as a string, the elements are joined by a space which makes the output hard to read. This change pre-formats the cmd output as a string by explicitly joining the elements with newlines instead of spaces.

## Related issue
N/A

## How has this been tested?
Let the presubmits run

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
