### PR TITLE
Removing opensuse-leap-15-5, as it's been deprecated

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -142,7 +142,6 @@ targets:
           - suse-sap-cloud:sles-15-sp6-sap
           - suse-sap-cloud:sles-15-sp7-sap
           - opensuse-cloud:opensuse-leap
-          - opensuse-cloud=opensuse-leap-15-5-v20250110-x86-64
           - opensuse-cloud=opensuse-leap-15-6-v20250724-x86-64
       aarch64:
         test_distros:
@@ -151,7 +150,6 @@ targets:
           exhaustive:
           - suse-cloud:sles-15-sp6-arm64
           - opensuse-cloud:opensuse-leap-arm64
-          - opensuse-cloud=opensuse-leap-15-5-v20250110-arm64
           - opensuse-cloud=opensuse-leap-15-6-v20250724-arm64 
   windows:
     package_extension:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
