### PR TITLE
[integration_test] Add `RunForEachImageAndFeatureFlag` and improve Otel Logging integration tests.

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -259,17 +259,17 @@ func setExperimentalOtelLoggingInConfig(config string) string {
 
 // SetupOpsAgentWithFeatureFlag configures the VM and the config depending on the selected feature flag.
 func SetupOpsAgentWithFeatureFlag(ctx context.Context, logger *log.Logger, vm *gce.VM, config string, feature string) error {
-	if feature != DefaultFeatureFlag {
+	switch feature {
+	case OtelLoggingFeatureFlag:
+		// Set feature flag in config.
+		if config == "" {
+			config = defaultOtelLoggingConfig()
+		} else {
+			config = setExperimentalOtelLoggingInConfig(config)
+		}
+		// Set experimental feature environment variable.
 		if err := setExperimentalFeatures(ctx, logger, vm, feature); err != nil {
 			return err
-		}
-		switch feature {
-		case OtelLoggingFeatureFlag:
-			if config == "" {
-				config = defaultOtelLoggingConfig()
-			} else {
-				config = setExperimentalOtelLoggingInConfig(config)
-			}
 		}
 	}
 	return agents.SetupOpsAgent(ctx, logger, vm, config)


### PR DESCRIPTION
## Description
Created `RunForEachImageAndFeatureFlag` and other test helper functions. The goal is that followup PR "diffs" to convert an existing test to be an `Otel Logging` test is minimal.

## Related issue
b/416048587

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
