### PR TITLE
Autogenerated support for plucky x86 64

### DIFF
--- a/kokoro/config/build/presubmit/plucky_x86_64.gcl
+++ b/kokoro/config/build/presubmit/plucky_x86_64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'plucky'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/plucky_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/plucky_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'plucky'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/plucky_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/plucky_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'plucky'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/presubmit/plucky_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/presubmit/plucky_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'plucky'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/plucky_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/release/plucky_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'plucky'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/project.yaml
+++ b/project.yaml
@@ -13,6 +13,16 @@
 # limitations under the License.
 
 targets:
+  plucky:
+    package_extension:
+      deb
+    architectures:
+      x86_64:
+        test_distros:
+          representative:
+          - ubuntu-os-cloud:ubuntu-2504-amd64
+          exhaustive:
+          - ubuntu-os-cloud:ubuntu-minimal-2504-amd64
   trixie:
     os_versions: [debian-13*]
     package_extension:


### PR DESCRIPTION
## Description
Autogenerated support for plucky x86 64


## Related issue
b/411529631

## How has this been tested?
Testing in https://github.com/GoogleCloudPlatform/ops-agent/pull/2120.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
