### PR TITLE
[tests] Create `parse_regex_optional_groups` transformation test.

### DIFF
--- a/transformation_test/testdata/logging_processor-parse_regex_optional_groups/config.yaml
+++ b/transformation_test/testdata/logging_processor-parse_regex_optional_groups/config.yaml
@@ -1,5 +1,4 @@
 - type: parse_regex
   field: message
-  regex: ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>host.*)? (?<ident>[^ ]+) (?<pid>[n0-9]+) (?<msgid>[^ ]+) (?<extradata>.*) (?<message>.*)$
-  time_key: time
+  regex: ^(?<always>\S+) (?<empty>\S*) (?<optional>\S+)? (?<name>.+)$
   time_format: "%Y-%m-%dT%H:%M:%S%z"

--- a/transformation_test/testdata/logging_processor-parse_regex_optional_groups/input.log
+++ b/transformation_test/testdata/logging_processor-parse_regex_optional_groups/input.log
@@ -1,3 +1,5 @@
-<13>1 2006-01-02T15:04:05+0700  my_app_id n n n 
-<14>1 2006-01-02T15:03:05+0700 host_name my_app_id n n  qqqqrrrr
-<15>1 2006-01-02T15:04:05+0700 vm_name_1 my_app_id n n n 
+first second third all fields present
+first second  optional field missing
+first  third empty field missing
+first   optional and empty fields missing
+   always, optional and empty missing

--- a/transformation_test/testdata/logging_processor-parse_regex_optional_groups/output_fluentbit.yaml
+++ b/transformation_test/testdata/logging_processor-parse_regex_optional_groups/output_fluentbit.yaml
@@ -1,27 +1,38 @@
 - entries:
   - jsonPayload:
-      extradata: "n"
-      ident: my_app_id
-      msgid: "n"
-      pid: "n"
-      pri: "13"
+      always: first
+      empty: second
+      name: all fields present
+      optional: third
     labels:
       compute.googleapis.com/resource_name: hostname
     logName: projects/my-project/logs/transformation_test
-    timestamp: 2006-01-02T08:04:05.000000000Z
+    timestamp: now
   - jsonPayload:
-      host: host_name
-      ident: my_app_id
-      message: qqqqrrrr
-      msgid: "n"
-      pid: "n"
-      pri: "14"
+      always: first
+      empty: second
+      name: optional field missing
     labels:
       compute.googleapis.com/resource_name: hostname
     logName: projects/my-project/logs/transformation_test
-    timestamp: 2006-01-02T08:03:05.000000000Z
+    timestamp: now
   - jsonPayload:
-      message: "<15>1 2006-01-02T15:04:05+0700 vm_name_1 my_app_id n n n "
+      always: first
+      name: empty field missing
+      optional: third
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      always: first
+      name: optional and empty fields missing
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/transformation_test
+    timestamp: now
+  - jsonPayload:
+      message: "   always, optional and empty missing"
     labels:
       compute.googleapis.com/resource_name: hostname
     logName: projects/my-project/logs/transformation_test

--- a/transformation_test/testdata/logging_processor-parse_regex_optional_groups/output_otel.yaml
+++ b/transformation_test/testdata/logging_processor-parse_regex_optional_groups/output_otel.yaml
@@ -1,10 +1,9 @@
 - entries:
   - jsonPayload:
-      extradata: "n"
-      ident: my_app_id
-      msgid: "n"
-      pid: "n"
-      pri: "13"
+      always: first
+      empty: second
+      name: all fields present
+      optional: third
     labels:
       compute.googleapis.com/resource_name: hostname
     logName: projects/my-project/logs/my-log-name
@@ -13,14 +12,11 @@
         instance_id: test-instance-id
         zone: test-zone
       type: gce_instance
-    timestamp: 2006-01-02T08:04:05Z
+    timestamp: now
   - jsonPayload:
-      host: host_name
-      ident: my_app_id
-      message: qqqqrrrr
-      msgid: "n"
-      pid: "n"
-      pri: "14"
+      always: first
+      empty: second
+      name: optional field missing
     labels:
       compute.googleapis.com/resource_name: hostname
     logName: projects/my-project/logs/my-log-name
@@ -29,9 +25,34 @@
         instance_id: test-instance-id
         zone: test-zone
       type: gce_instance
-    timestamp: 2006-01-02T08:03:05Z
+    timestamp: now
   - jsonPayload:
-      message: "<15>1 2006-01-02T15:04:05+0700 vm_name_1 my_app_id n n n "
+      always: first
+      name: empty field missing
+      optional: third
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/my-log-name
+    resource:
+      labels:
+        instance_id: test-instance-id
+        zone: test-zone
+      type: gce_instance
+    timestamp: now
+  - jsonPayload:
+      always: first
+      name: optional and empty fields missing
+    labels:
+      compute.googleapis.com/resource_name: hostname
+    logName: projects/my-project/logs/my-log-name
+    resource:
+      labels:
+        instance_id: test-instance-id
+        zone: test-zone
+      type: gce_instance
+    timestamp: now
+  - jsonPayload:
+      message: "   always, optional and empty missing"
     labels:
       compute.googleapis.com/resource_name: hostname
     logName: projects/my-project/logs/my-log-name


### PR DESCRIPTION
## Description
Created `logging_processor-parse_regex_optional_groups` transformation test to verify the behaviour of `parse_regex` with an example of optional capture groups.

## Related issue
b/409351024

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [x] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
