### PR TITLE
[third_party_tests] Set `postgresql-17` to be used with Ubuntu 25.10.

### DIFF
--- a/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/postgresql/debian_ubuntu/install
@@ -4,7 +4,7 @@ source /etc/os-release
 
 postgres_version=16
 
-if [[ "${VERSION_ID}" == 25.04 ]]; then
+if [[ "${VERSION_ID}" == 25.04 || "${VERSION_ID}" == 25.10 ]]; then
   postgres_version=17
 fi
 


### PR DESCRIPTION
## Description
Set `postgresql-17` to be used with Ubuntu 25.10. Missed to add this in https://github.com/GoogleCloudPlatform/ops-agent/pull/2127.

## Related issue
b/450696958

## How has this been tested?
Tested in https://github.com/GoogleCloudPlatform/ops-agent/pull/2111.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
