### PR TITLE
Add makefile support for fine-grained test runs

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -53,7 +53,7 @@ to run the tests on something other than the defaults (`us-central1-b` for
 ZONES and `debian-cloud:debian-11` for `IMAGE_SPECS`).
 
 The above command will run the tests against the stable Ops Agent. To test
-against a pre-built but unreleased agent, you can use add the
+against a pre-built but unreleased agent, you can add the
 `AGENT_PACKAGES_IN_GCS` environment variable onto your command like this:
 
 ```
@@ -74,6 +74,27 @@ Googlers can also provide a `REPO_SUFFIX` to test an agent built by our release 
 When doing so, you may need to supply `ARTIFACT_REGISTRY_REGION=us` as well, once
 b/266410466 is completed.
 
+To run a specific test instead of the entire suite, you can add the
+`INTEGRATION_TEST_FILTER` environment variable onto your command like this:
+
+```
+INTEGRATION_TEST_FILTER=TestDefaultMetricsNoProxy \
+```
+
+This internally gets passed to `go test -test.run=...`, so regexp is also supported. For example, to run two tests at once:
+
+```
+INTEGRATION_TEST_FILTER='(TestDefaultMetricsNoProxy|TestSyslogTCP)' \
+```
+
+To only run the `default` logs test and not the `otel_logging` experiment:
+
+```
+INTEGRATION_TEST_FILTER='TestDefaultMetricsNoProxy/.*/default' \
+```
+
+(Note that the `/.*/` is needed to account for the image spec.)
+
 ## Third Party Apps Test
 
 This test attempts to verify, for each application in `supported_applications.txt`,
@@ -91,16 +112,28 @@ make third_party_apps_test PROJECT=${PROJECT} TRANSFERS_BUCKET=${TRANSFERS_BUCKE
 
 As above, you can supply `AGENT_PACKAGES_IN_GCS` or `REPO_SUFFIX` to test a pre-built agent.
 
-Additionally, to run specific third party applications you can use the command:
-
-```
-go test -v ./integration_test \
-    -tags=integration_test \
-    -test.run="TestThirdPartyApps/.*/(nvml|dcgm)"
-```
-
 Make sure the platform you specify is included in the `IMAGE_SPECS` environment
 variable.
+
+To run specific third party applications you can add
+`THIRD_PARTY_APPS`:
+
+```
+THIRD_PARTY_APPS=nvml \
+```
+
+You can test multiple apps at once:
+
+```
+THIRD_PARTY_APPS='(nvml|dcgm)' \
+```
+
+The default endpoint under test is `googlecloudmonitoring`. To change this, you
+can add `THIRD_PARTY_APPS_ENDPOINT`:
+
+```
+THIRD_PARTY_APPS_ENDPOINT=otlphttp \
+```
 
 ### Testing Flow
 

--- a/tasks.mak
+++ b/tasks.mak
@@ -148,30 +148,45 @@ transformation_test_update: transformation_test
 # these targets. The Makefile will not ascribe defaults for these, since they
 # are specific to different user environments.
 #
-# Defaults are provided for ZONES and PLATFORMS.
+# Defaults are provided for ZONES and IMAGE_SPECS.
 #
 # If you would like to use a custom build you can provide a REPO_SUFFIX or
 # AGENT_PACKAGES_IN_GCS. These targets function fine without either specified.
+#
+# INTEGRATION_TEST_FILTER gets passed directly to -test.run, and lets you
+# specify which integration tests to run. All tests run by default.
+#
+# THIRD_PARTY_APPS lets you specify which apps to run. All apps run by default.
+#
+# THIRD_PARTY_APPS_ENDPOINT controls which endpoint to use and defaults to
+# googlecloudmonitoring. Allowed values are googlecloudmonitoring, otlphttp,
+# or both using (googlecloudmonitoring|otlphttp).
+
 ZONES ?= us-central1-b
-PLATFORMS ?= debian-cloud:debian-11
+IMAGE_SPECS ?= debian-cloud:debian-11
+INTEGRATION_TEST_FILTER ?= '.*'
+THIRD_PARTY_APPS ?= '.*'
+THIRD_PARTY_APPS_ENDPOINT ?= googlecloudmonitoring
 
 .PHONY: integration_tests
 integration_tests:
 	ZONES="${ZONES}" \
-	PLATFORMS="${PLATFORMS}" \
+	IMAGE_SPECS="${IMAGE_SPECS}" \
 	go test -v ./integration_test/ops_agent_test/main_test.go \
-	-test.parallel=1000 \
+	-parallel=1000 \
 	-tags=integration_test \
-	-timeout=4h
+	-timeout=4h \
+	-run="${INTEGRATION_TEST_FILTER}"
 
 .PHONY: third_party_apps_test
 third_party_apps_test:
 	ZONES="${ZONES}" \
-	PLATFORMS="${PLATFORMS}" \
+	IMAGE_SPECS="${IMAGE_SPECS}" \
 	go test -v ./integration_test/third_party_apps_test/main_test.go \
-	-test.parallel=1000 \
+	-parallel=1000 \
 	-tags=integration_test \
-	-timeout=4h
+	-timeout=4h \
+	-run="TestThirdPartyApps/.*/${THIRD_PARTY_APPS_ENDPOINT}/${THIRD_PARTY_APPS}"
 
 ############
 # Precommit


### PR DESCRIPTION
## Description
Add makefile support for fine-grained test runs

## Related issue
http://b/462191335

## How has this been tested?
Ran a bunch of local tests for various combinations of the new variables introduced

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
