### PR TITLE
[FIX]: Packaging VM can't talk to GCP Metadata server - Part 2

### DIFF
--- a/kokoro/scripts/build/packaging/package.ps1
+++ b/kokoro/scripts/build/packaging/package.ps1
@@ -127,7 +127,6 @@ Write-Host "Applying Network Routing Fix..."
 $gateway = (Get-NetRoute | Where-Object { $_.DestinationPrefix -eq '0.0.0.0/0' } | Sort-Object RouteMetric | Select-Object -ExpandProperty NextHop -First 1)
 $ifIndex = (Get-NetAdapter -InterfaceDescription "Hyper-V Virtual Ethernet*" | Sort-Object | Select-Object -ExpandProperty ifIndex -First 1)
 
-# Using the variable for the route prefix
 New-NetRoute -DestinationPrefix "$MetadataServerIP/32" -InterfaceIndex $ifIndex -NextHop $gateway -ErrorAction SilentlyContinue
 
 # Verify Metadata Connectivity


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Our VM for packaging can't talk to the metadata server and send the `.goo` package to our bucket. Upgrading to gcloud instead of gsutil in hopes it will re-authenticate.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/467401022


## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
