### PR TITLE
[FIX]Fixing packaging permission issue.

### DIFF
--- a/kokoro/scripts/build/packaging/package.ps1
+++ b/kokoro/scripts/build/packaging/package.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = "Stop"
+$global:ProgressPreference = 'SilentlyContinue'
 
 $GoVersion = "1.24.11"
 $GoInstallerUrl = "https://go.dev/dl/go$GoVersion.windows-amd64.msi"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Packaging script failing with access denied command. Found an old fix at: b/239180590

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/467401022

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
