### PR TITLE
[FIX] Packaging Setting GOPATH

### DIFF
--- a/kokoro/scripts/build/packaging/package.ps1
+++ b/kokoro/scripts/build/packaging/package.ps1
@@ -26,12 +26,21 @@ function Install-Go {
         -ArgumentList "/i $MsiPath /quiet /norestart ALLUSERS=1 INSTALLDIR=$GoInstallDir" `
         -NoNewWindow -Wait
 
-    # Add Go to the path for the current session
-    $env:Path = "$env:Path;$GoInstallDir\bin"
+    # Check after install (Before Refresh)
+    Write-Host "DEBUG: GOPATH after install (before refresh) is: '$env:GOPATH'"
 
-    # Verify installation
+    # Refresh environment
+    # This pulls the new Path (including C:\Go\bin) from the Registry into the current session
+    Write-Host "Refreshing Environment Variables from Registry..."
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+    # Check after refresh
+    Write-Host "DEBUG: GOPATH after refresh is: '$env:GOPATH'"
+
+    # Final Verification
     $InstalledVersion = go version
     Write-Host "Go installed successfully: $InstalledVersion"
+    Write-Host "Final GOPATH is set to: $env:GOPATH"
 }
 
 function Invoke-PackageBuild {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The environment variable `GOPATH` is not in our packaging script which prevents goopack from running. I suspect that the MSI is actually setting the path but the shell hasn't picked up the new variables. 
This issue didn't seem to pop up in the Dockerfile.windows build since when we call `RUN` it loads a new shell.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/467401022

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
