### PR TITLE
[FIX]: Windows Packaging - Adding GOPATH manually

### DIFF
--- a/kokoro/scripts/build/packaging/package.ps1
+++ b/kokoro/scripts/build/packaging/package.ps1
@@ -26,21 +26,19 @@ function Install-Go {
         -ArgumentList "/i $MsiPath /quiet /norestart ALLUSERS=1 INSTALLDIR=$GoInstallDir" `
         -NoNewWindow -Wait
 
-    # Check after install (Before Refresh)
-    Write-Host "DEBUG: GOPATH after install (before refresh) is: '$env:GOPATH'"
+    # Add Go binary to the path for the current session
+    $env:Path = "$env:Path;$GoInstallDir\bin"
 
-    # Refresh environment
-    # This pulls the new Path (including C:\Go\bin) from the Registry into the current session
-    Write-Host "Refreshing Environment Variables from Registry..."
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+    # Manually set GOPATH
+    $env:GOPATH = "$HOME\go"
 
-    # Check after refresh
-    Write-Host "DEBUG: GOPATH after refresh is: '$env:GOPATH'"
+    # GOPATH\bin to the path for the current session
+    $env:Path = "$env:Path;$env:GOPATH\bin"
 
-    # Final Verification
+    # Verify installation
     $InstalledVersion = go version
     Write-Host "Go installed successfully: $InstalledVersion"
-    Write-Host "Final GOPATH is set to: $env:GOPATH"
+    Write-Host "GOPATH manually set to: $env:GOPATH"
 }
 
 function Invoke-PackageBuild {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Trying out #2160 didn't work and broke git instead. This PR manually adds the GOPATH

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->
b/467401022

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
