### PR TITLE
Revert "[Testing] Replace sql-std-2019-win-2019 with 2019 on 2022 + 2022 on 2019"

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -209,7 +209,7 @@ targets:
           representative:
           - windows-cloud:windows-2016-core
           - windows-cloud:windows-2025
-          - windows-sql-cloud:sql-std-2019-win-2022
+          - windows-sql-cloud:sql-std-2019-win-2019
           - windows-sql-cloud:sql-std-2022-win-2025
           exhaustive:
           - windows-cloud:windows-2016
@@ -218,5 +218,4 @@ targets:
           - windows-cloud:windows-2019-core
           - windows-cloud:windows-2022-core
           - windows-cloud:windows-2025-core
-          - windows-sql-cloud:sql-std-2022-win-2019
           - windows-sql-cloud:sql-std-2022-win-2022


### PR DESCRIPTION
Reverts GoogleCloudPlatform/ops-agent#2116

The issue with `sql-std-2019-win-2019` is resolved and trying to reduce the number of tested windows images.