### PR TITLE
Nest temp files under a non-root directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	buf.build/go/protoyaml v0.3.1
 	cloud.google.com/go/secretmanager v1.15.0
 	github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20251223185908-b86a27592ed0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0
 	go.opentelemetry.io/collector/pdata v1.12.0
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1v
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228 h1:K6GHKAI+PB91Fm+KEwX4q6s6xzZ/+BkOi8Kjxh0tJ6U=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228/go.mod h1:31SvkAl6ORtir1odRpTl92XpTtn52GnBAHPtCKDSePo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20251223185908-b86a27592ed0 h1:CIMnnXe+bzBJZTYZDhWnWZ3hIPGUoP3XzuEyFtPqPFY=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20251223185908-b86a27592ed0/go.mod h1:hmqK+hsg2z+Xo/Yz16sNxb6TZX+q0KxKsrgYzdpV0P8=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef h1:v2hZ/3wkAB/9TvEqqE3zjlVsqozs4rzZ4zqvW/9YPLQ=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef/go.mod h1:hmqK+hsg2z+Xo/Yz16sNxb6TZX+q0KxKsrgYzdpV0P8=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 h1:UQUsRi8WTzhZntp5313l+CHIAT95ojUI2lpP/ExlZa4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 h1:owcC2UnmsZycprQ5RfRgjydWhuoxg71LUfyiQdijZuM=

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -85,7 +85,7 @@ var testdataDir embed.FS
 
 func logPathForImage(imageSpec string) string {
 	if gce.IsWindows(imageSpec) {
-		return `C:\mylog`
+		return `C:\tmp\mylog`
 	}
 	return "/tmp/mylog"
 }
@@ -1963,11 +1963,11 @@ func TestLogFilePathLabel(t *testing.T) {
 			t.Fatalf("error uploading log: %v", err)
 		}
 
-		// In Windows the generated log_file_path "C:\mylog_1" uses a backslash.
+		// In Windows the generated log_file_path "C:\tmp\mylog_1" uses a backslash.
 		// When constructing the query in WaithForLog the backslashes are escaped so
-		// replacing with two backslahes correctly queries for "C:\mylog_1" label.
+		// replacing with two backslahes correctly queries for "C:\tmp\mylog_1" label.
 		if gce.IsWindows(imageSpec) {
-			file1 = strings.Replace(file1, `\`, `\\`, 1)
+			file1 = strings.Replace(file1, `\`, `\\`, -1)
 		}
 
 		// Expect to see log with label added.

--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -68,7 +68,7 @@ var (
 	logSizeInBytes   = os.Getenv("LOG_SIZE_IN_BYTES")
 	logRate          = os.Getenv("LOG_RATE")
 	logPath          = "/tmp/tail_file"
-	logGeneratorPath = "/log_generator.py"
+	logGeneratorPath = "/tmp/log_generator.py"
 
 	ttl    = os.Getenv("TTL")
 	distro = os.Getenv("DISTRO")


### PR DESCRIPTION
## Description
The gce testing package has migrated to using gcloud instead of Cloud Tools for PowerShell. gcloud is unable to write to files directly under C:\ on Windows, even if the file already exists, so use non-root paths instead.

## Related issue
http://b/476396302

## How has this been tested?
Tests passed on a branched upstream gce package, which is now merged, so we'll now let the presubmits run against the gce package from master

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
