### PR TITLE
Add more debug logging for UAP test flake

### DIFF
--- a/cmd/ops_agent_uap_plugin/plugin.go
+++ b/cmd/ops_agent_uap_plugin/plugin.go
@@ -146,16 +146,15 @@ func main() {
 		if err := os.RemoveAll(address); err != nil {
 			// Unix sockets must be unlinked (listener.Close()) before
 			// being reused again. If file already exist bind can fail.
-			fmt.Fprintf(os.Stderr, "Failed to remove %q: %v\n", address, err)
-			os.Exit(1)
+			log.Fatalf("Failed to remove %q: %v\n", address, err)
 		}
 	}
 
 	listener, err := net.Listen(protocol, address)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to start listening on %q using %q: %v\n", address, protocol, err)
-		os.Exit(1)
+		log.Fatalf("Failed to start listening on %q using %q: %v\n", address, protocol, err)
 	}
+	log.Printf("Listening on %q using %q\n", address, protocol)
 	defer listener.Close()
 
 	// This is the grpc server in communication with the Guest Agent.
@@ -167,11 +166,14 @@ func main() {
 	// offered mean Guest Agent was successful in installing/launching the plugin
 	// & will manage the lifecycle (start, stop, or revision change) here onwards.
 	pb.RegisterGuestAgentPluginServer(server, ps)
+	log.Println("Registered plugin server")
+
 	reflection.Register(server)
+	log.Println("Registered service reflection service")
 	if err := server.Serve(listener); err != nil {
-		fmt.Fprintf(os.Stderr, "Exiting, cannot continue serving: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Exiting, cannot continue serving: %v\n", err)
 	}
+	log.Println("Exiting")
 }
 
 func runSubAgentCommand(ctx context.Context, cancelAndSetError CancelContextAndSetPluginErrorFunc, cmd *exec.Cmd, runCommand RunCommandFunc, wg *sync.WaitGroup) {

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -217,6 +217,8 @@ func getOpsAgentLogFilesList(imageSpec string) []string {
 			gce.SyslogLocation(imageSpec),
 			OpsAgentConfigPath(imageSpec),
 			"~/uap_plugin_out.log",
+			"~/uap_plugin_ps.log",
+			"~/uap_plugin_ports.log",
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/google-cloud-ops-agent/health-checks.log",
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/google-cloud-ops-agent/subagents/logging-module.log",
 			"/var/lib/google-guest-agent/agent_state/plugins/ops-agent-plugin/log/google-cloud-ops-agent/subagents/metrics-module.log",
@@ -872,6 +874,16 @@ func StartOpsAgentPluginServer(ctx context.Context, logger *log.Logger, vm *gce.
 
 	if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo nohup ~/%s --address=localhost:%s --errorlogfile=errorlog.txt --protocol=tcp > ~/uap_plugin_out.log 2>&1 &", OpsAgentPluginEntryPointName, port)); err != nil {
 		return fmt.Errorf("StartOpsAgentPluginServer() failed to start the ops agent plugin: %v", err)
+	}
+	// TODO(b/456444594): just some printf debugging
+	for _, cmd := range []string{
+		"sleep 5",
+		fmt.Sprintf("ps ax | grep %s > ~/uap_plugin_ps.log", OpsAgentPluginEntryPointName),
+		"ss -tulpn > ~/uap_plugin_ports.log",
+	} {
+		if out, err := gce.RunRemotely(ctx, logger, vm, cmd); err != nil {
+			logger.Printf("StartOpsAgentPluginServer() failed to capture debugging info (non-fatal):\nstdout+stderr=%s\n%s\nerr=%v\n", out.Stdout, out.Stderr, err)
+		}
 	}
 	return nil
 


### PR DESCRIPTION
## Description
Add more debug logging for UAP test flake

## Related issue
http://b/456444594

## How has this been tested?
Will let presubmits run

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
