### PR TITLE
otlp: switch to UTR endpoint

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -123,6 +123,12 @@ func ConvertPipelinesToOtlp(receiverPipelines map[string]otel.ReceiverPipeline) 
 				pipeline.ExporterTypes["logs"] = otel.OTLP_Logs
 			}
 		}
+
+		if _, ok := pipeline.ExporterTypes["traces"]; ok {
+			if pipeline.ExporterTypes["traces"] == otel.OTel {
+				pipeline.ExporterTypes["traces"] = otel.OTLP_Traces
+			}
+		}
 		receiverPipelines[rID] = pipeline
 	}
 }
@@ -169,6 +175,21 @@ func otlpExporterForLogs(userAgent string) otel.Component {
 				},
 				"storage": fileStorageExtensionType,
 			},
+		},
+	}
+}
+
+func otlpExporterForTraces(userAgent string) otel.Component {
+	return otel.Component{
+		Type: "otlp_grpc",
+		Config: map[string]interface{}{
+			"endpoint": "telemetry.googleapis.com:443",
+			// b/485538253: Use pick_first balancer until we can understand why round_robin is failing.
+			"balancer_name": "pick_first",
+			"auth": map[string]interface{}{
+				"authenticator": "googleclientauth",
+			},
+			"user_agent": userAgent,
 		},
 	}
 }
@@ -276,6 +297,17 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 						otel.DisableOtlpRoundTrip(),
 						otel.PreserveInstrumentationScope(),
 						otel.CopyServiceResourceLabels(),
+					},
+				},
+			},
+			otel.OTLP_Traces: {
+				Exporter:       otlpExporterForTraces(userAgent),
+				UsedExtensions: []string{googleClientAuthExtensionType},
+				ProcessorsByType: map[string][]otel.Component{
+					"traces": {
+						// Note: resourcedetection processor is added automatically at the receiver pipeline level in otel/modular.go.
+						otel.GCPProjectID(resource.ProjectName()),
+						otel.BatchProcessor(200, 200, "200ms"),
 					},
 				},
 			},

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -42,6 +42,7 @@ const (
 	GMP
 	OTLP_Metrics
 	OTLP_Logs
+	OTLP_Traces
 	Logging
 )
 const (
@@ -62,6 +63,8 @@ func (t ExporterType) Name() string {
 		return "otlp_metrics"
 	} else if t == OTLP_Logs {
 		return "otlp_logs"
+	} else if t == OTLP_Traces {
+		return "otlp_traces"
 	} else {
 		panic("unknown ExporterType")
 	}

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -863,6 +865,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1385,9 +1392,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -834,6 +836,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1325,9 +1332,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -892,6 +894,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1875,9 +1882,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -892,6 +894,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1875,9 +1882,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -863,6 +865,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1270,9 +1277,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -834,6 +836,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1210,9 +1217,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -892,6 +894,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1760,9 +1767,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -1,12 +1,4 @@
 exporters:
-  googlecloud/otel:
-    metric:
-      instrumentation_library_labels: true
-      prefix: ""
-      resource_filters: []
-      service_resource_labels: true
-      skip_create_descriptor: true
-    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -35,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_traces:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_traces_traces_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -892,6 +894,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_traces_traces_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1760,9 +1767,11 @@ service:
       - otlp/otlp
     traces/traces_otlp_otlp:
       exporters:
-      - googlecloud/otel
+      - otlp_grpc/otlp_traces
       processors:
       - resourcedetection/_global_1
+      - resource/otlp_grpc/otlp_traces_traces_0
+      - batch/otlp_grpc/otlp_traces_traces_1
       receivers:
       - otlp/otlp
   telemetry:

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -64,6 +64,8 @@ import (
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	trace "cloud.google.com/go/trace/apiv1"
+	cloudtrace "cloud.google.com/go/trace/apiv1/tracepb"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
@@ -5192,7 +5194,7 @@ traces:
 	})
 }
 
-func TestOTLPTraces(t *testing.T) {
+func TestOTLPTracesLegacy(t *testing.T) {
 	t.Parallel()
 	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
@@ -5237,6 +5239,111 @@ metrics:
 		}
 		if _, err := gce.WaitForTrace(ctx, logger, vm, options); err != nil {
 			t.Error(err)
+		}
+	})
+}
+
+func TestOTLPTraces(t *testing.T) {
+	t.Parallel()
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
+		t.Parallel()
+		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
+		otlpConfig := `
+global:
+  otlp_exporter: true
+combined:
+  receivers:
+    otlp:
+      type: otlp
+traces:
+  service:
+    pipelines:
+      otlp:
+        receivers:
+        - otlp
+metrics:
+  service:
+    pipelines:
+`
+		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate trace traffic with dummy app
+		traceFile, err := testdataDir.Open(path.Join("testdata", "otlp", "traces.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer traceFile.Close()
+		if err := installGolang(ctx, logger, vm); err != nil {
+			t.Fatal(err)
+		}
+		if err = runGoCode(ctx, logger, vm, traceFile); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify the new flow trace has arrived in GCE.
+		// We filter for "host.id" since the agent's host-level resource detection processor
+		// appends host information (like host.id, which matches vm.ID) onto the trace resource attributes.
+		options := gce.WaitForTraceOptions{
+			Window: time.Hour,
+			Filters: []string{
+				fmt.Sprintf("+host.id:%d", vm.ID),
+			},
+		}
+		traceVal, err := gce.WaitForTrace(ctx, logger, vm, options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// gce.WaitForTrace only performs a lightweight check to ensure trace arrival and returns
+		// a shell structure containing only the Project ID and Trace ID. It does not fetch full
+		// span labels or trace metadata. To retrieve complete attributes (like custom resource
+		// and span attributes) for assertions, we must instantiate a cloud trace client and
+		// request full trace details using the retrieved Trace ID.
+		client, err := trace.NewClient(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+		fullTrace, err := client.GetTrace(ctx, &cloudtrace.GetTraceRequest{
+			ProjectId: vm.Project,
+			TraceId:   traceVal.TraceId,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify that none of the spans have the legacy g.co attribute.
+		// Also verify span and resource attributes.
+		var foundResourceAttr, foundSpanAttr bool
+		for _, span := range fullTrace.Spans {
+			t.Logf("Span %q labels: %v", span.Name, span.Labels)
+			if span.Labels != nil {
+				if _, ok := span.Labels["g.co/r/gce_instance/instance_id"]; ok {
+					t.Errorf("Unexpected legacy attribute g.co/r/gce_instance/instance_id found in span %q", span.Name)
+				}
+				if val, ok := span.Labels["custom.resource.attribute"]; ok {
+					if val == "my-resource-value" {
+						foundResourceAttr = true
+					} else {
+						t.Errorf("Expected custom.resource.attribute to be 'my-resource-value', got %q", val)
+					}
+				}
+				if val, ok := span.Labels["custom.span.attribute"]; ok {
+					if val == "my-span-value" {
+						foundSpanAttr = true
+					} else {
+						t.Errorf("Expected custom.span.attribute to be 'my-span-value', got %q", val)
+					}
+				}
+			}
+		}
+
+		if !foundResourceAttr {
+			t.Error("Resource attribute 'custom.resource.attribute' not found in trace spans")
+		}
+		if !foundSpanAttr {
+			t.Error("Span attribute 'custom.span.attribute' not found in trace spans")
 		}
 	})
 }

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5315,35 +5315,36 @@ metrics:
 
 		// Verify that none of the spans have the legacy g.co attribute.
 		// Also verify span and resource attributes.
-		var foundResourceAttr, foundSpanAttr bool
+		var foundSpan bool
 		for _, span := range fullTrace.Spans {
 			t.Logf("Span %q labels: %v", span.Name, span.Labels)
-			if span.Labels != nil {
+			if span.Name == "test_trace" {
+				foundSpan = true
+				if span.Labels == nil {
+					t.Errorf("Span %q has no labels", span.Name)
+					continue
+				}
 				if _, ok := span.Labels["g.co/r/gce_instance/instance_id"]; ok {
 					t.Errorf("Unexpected legacy attribute g.co/r/gce_instance/instance_id found in span %q", span.Name)
 				}
 				if val, ok := span.Labels["custom.resource.attribute"]; ok {
-					if val == "my-resource-value" {
-						foundResourceAttr = true
-					} else {
+					if val != "my-resource-value" {
 						t.Errorf("Expected custom.resource.attribute to be 'my-resource-value', got %q", val)
 					}
+				} else {
+					t.Error("Resource attribute 'custom.resource.attribute' not found in span")
 				}
 				if val, ok := span.Labels["custom.span.attribute"]; ok {
-					if val == "my-span-value" {
-						foundSpanAttr = true
-					} else {
+					if val != "my-span-value" {
 						t.Errorf("Expected custom.span.attribute to be 'my-span-value', got %q", val)
 					}
+				} else {
+					t.Error("Span attribute 'custom.span.attribute' not found in span")
 				}
 			}
 		}
-
-		if !foundResourceAttr {
-			t.Error("Resource attribute 'custom.resource.attribute' not found in trace spans")
-		}
-		if !foundSpanAttr {
-			t.Error("Span attribute 'custom.span.attribute' not found in trace spans")
+		if !foundSpan {
+			t.Error("Expected span 'test_trace' not found in trace")
 		}
 	})
 }

--- a/integration_test/ops_agent_test/testdata/otlp/traces.go
+++ b/integration_test/ops_agent_test/testdata/otlp/traces.go
@@ -6,7 +6,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"

--- a/integration_test/ops_agent_test/testdata/otlp/traces.go
+++ b/integration_test/ops_agent_test/testdata/otlp/traces.go
@@ -5,21 +5,30 @@ import (
 	"log"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func installTraceExportPipeline(ctx context.Context) (func(context.Context) error, error) {
-	client := otlptracegrpc.NewClient(otlptracegrpc.WithInsecure())
-	exporter, err := otlptrace.New(ctx, client)
+	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	r, err := resource.New(ctx,
+		resource.WithAttributes(
+			attribute.String("custom.resource.attribute", "my-resource-value"),
+		),
+	)
 	if err != nil {
 		return nil, err
 	}
 	tracerProvider := trace.NewTracerProvider(
 		trace.WithBatcher(exporter),
-		trace.WithResource(resource.Default()),
+		trace.WithResource(r),
 	)
 	otel.SetTracerProvider(tracerProvider)
 	return tracerProvider.Shutdown, nil
@@ -30,15 +39,15 @@ func main() {
 
 	shutdown, err := installTraceExportPipeline(ctx)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Could not install trace pipeline: %v", err)
 	}
-
 	defer func() {
 		if err := shutdown(ctx); err != nil {
-			log.Fatal(err)
+			log.Fatalf("Could not shutdown trace pipeline: %v", err)
 		}
 	}()
 
-	ctx, span := otel.Tracer("test_tracer").Start(ctx, "test_trace")
+	ctx, span := otel.Tracer("test_tracer", oteltrace.WithInstrumentationVersion("v1.2.3")).Start(ctx, "test_trace")
+	span.SetAttributes(attribute.String("custom.span.attribute", "my-span-value"))
 	span.End()
 }


### PR DESCRIPTION
Adds option to send traces to UTR endpoint instead. No-op by default.