### PR TITLE
Adding api_request_count self-metric when running otlp exporter

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -75,6 +75,7 @@ var grpcToStringStatus = map[string]string{
 	"13": "INTERNAL",
 	"14": "UNAVAILABLE",
 	"15": "DATA_LOSS",
+	"16": "UNAUTHENTICATED",
 }
 
 func (r AgentSelfMetrics) AddSelfMetricsPipelines(receiverPipelines map[string]otel.ReceiverPipeline, pipelines map[string]otel.Pipeline, ctx context.Context) {

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/linux-gpu/otel.yaml
@@ -605,6 +605,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/linux/otel.yaml
@@ -576,6 +576,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/windows-2012/otel.yaml
@@ -641,6 +641,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlphttp/golden/windows/otel.yaml
@@ -641,6 +641,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -592,6 +592,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -563,6 +563,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -628,6 +628,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -628,6 +628,8 @@ processors:
           value: "14"
         - new_value: DATA_LOSS
           value: "15"
+        - new_value: UNAUTHENTICATED
+          value: "16"
         - new_value: UNKNOWN
           value: "2"
         - new_value: INVALID_ARGUMENT


### PR DESCRIPTION
## Description
This adds api_request_count when using the otlp exporter instead of the GCM/GMP.
The metric used by the previous exporters is not present in the otlp exporter.

## Related issue
b/481750163

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
