### PR TITLE
Increase RAM for elasticsearch tests

### DIFF
--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -918,8 +918,9 @@ const (
 	SAPHANAImageSpec = "stackdriver-test-143416:sles-15-sp6-sap-saphana"
 	SAPHANAApp       = "saphana"
 
-	OracleDBApp  = "oracledb"
-	AerospikeApp = "aerospike"
+	OracleDBApp      = "oracledb"
+	AerospikeApp     = "aerospike"
+	ElasticsearchApp = "elasticsearch"
 )
 
 // incompatibleOperatingSystem looks at the supported_operating_systems field
@@ -1082,6 +1083,13 @@ func TestThirdPartyApps(t *testing.T) {
 							options.MachineType = "t2a-standard-16"
 						}
 						options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-size=150GB", "--boot-disk-type=pd-ssd")
+					}
+					if strings.Contains(tc.app, ElasticsearchApp) && strings.Contains(options.MachineType, "-standard-2") {
+						// elasticsearch(9) tends to OOM on -standard-2, so go one step up
+						options.MachineType = "e2-highmem-2"
+						if gce.IsARM(tc.imageSpec) {
+							options.MachineType = "t2a-standard-4"
+						}
 					}
 
 					vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)


### PR DESCRIPTION
## Description
elasticsearch tests were found to be OOMing often.

## Related issue
http://b/456444594

## How has this been tested?
Will let presubmits run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
