### PR TITLE
[soak test] Remove VM name "invalid characters"  in `feature_label`.

### DIFF
--- a/kokoro/scripts/test/start_soak_test.sh
+++ b/kokoro/scripts/test/start_soak_test.sh
@@ -29,8 +29,6 @@ source kokoro/scripts/utils/louhi.sh
 # For soak tests run by Louhi
 populate_env_vars_from_louhi_tag_if_present
 
-FEATURE="otel_logging"
-
 # Ops Agent feature label
 feature_label=${FEATURE:+-${FEATURE//_/-}}
 
@@ -51,6 +49,6 @@ done
 
 LOG_RATE=${LOG_RATE-1000} \
 LOG_SIZE_IN_BYTES=${LOG_SIZE_IN_BYTES-1000} \
-VM_NAME="${VM_NAME:-github-soak-test${feature_label}-${KOKORO_BUILD_ID}}" \
+VM_NAME="${VM_NAME:-github-soak-test-${KOKORO_BUILD_ID}}" \
 TTL="${TTL:-30m}" \
   go run -tags=integration_test .


### PR DESCRIPTION
## Description
Remove VM name "invalid characters" (like underscores `_` ) in `feature_label`.

## Related issue
b/467066419

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
