### PR TITLE
Remove opensuse-leap from tests

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -187,7 +187,7 @@ targets:
           exhaustive:
           - suse-sap-cloud:sles-12-sp5-sap
   sles15:
-    os_versions: [sles-15*, opensuse-leap-15*]
+    os_versions: [sles-15*]
     package_extension:
       rpm
     architectures:
@@ -199,16 +199,12 @@ targets:
           - suse-cloud:sles-15-sp6
           - suse-sap-cloud:sles-15-sp6-sap
           - suse-sap-cloud:sles-15-sp7-sap
-          - opensuse-cloud:opensuse-leap
-          - opensuse-cloud=opensuse-leap-15-6-v20250724-x86-64
       aarch64:
         test_distros:
           representative:
           - suse-cloud:sles-15-arm64
           exhaustive:
           - suse-cloud:sles-15-sp6-arm64
-          - opensuse-cloud:opensuse-leap-arm64
-          - opensuse-cloud=opensuse-leap-15-6-v20250724-arm64 
   windows:
     package_extension:
       goo


### PR DESCRIPTION
## Description
opensuse-leap images (<= 15.x) are all deprecated on GCE, so remove them from the tests. We will bring them back when we add support for 16.x.

## Related issue
N/A

## How has this been tested?
Will let presubmits run

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
