### PR TITLE
Fix missing sudo

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -1303,7 +1303,7 @@ func verifyRPMPackageSigned(ctx context.Context, logger *log.Logger, vm *gce.VM,
 	// Assumes the Ops Agent was set up using the install script (with REPO_SUFFIX).
 	// Since the script has already added the repository to the VM, we only need
 	// to download the package.
-	command := "dnf download google-cloud-ops-agent"
+	command := "sudo dnf download google-cloud-ops-agent"
 	rpmPath := "./*.rpm"
 	if gce.IsSUSEImageSpec(vm.ImageSpec) {
 		command = "sudo zypper --pkg-cache-dir=$(pwd) download google-cloud-ops-agent"


### PR DESCRIPTION
## Description
This should fix the RHUI permission issue in our nightlies.

## Related issue
N/A

## How has this been tested?
Signing is hard to test in presubmits, so I reproduced the issue manually on a RHEL 8 VM and verified that sudo made it go away:

```
$ dnf download zlib
Google Compute Engine                                                                                                                                                                                                                                                                         45 kB/s | 9.6 kB     00:00    
Google Cloud SDK                                                                                                                                                                                                                                                                              43 MB/s | 154 MB     00:03    
Red Hat CodeReady Linux Builder for RHEL 8 ARM 64 (Debug RPMs) from RHUI                                                                                                                                                                                                                     0.0  B/s |   0  B     00:00    
Errors during downloading metadata for repository 'rhui-codeready-builder-for-rhel-8-aarch64-rhui-debug-rpms':
  - Curl error (58): Problem with the local SSL certificate for https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel8/rhui/8/aarch64/codeready-builder/debug [could not load PEM client certificate, OpenSSL error error:0200100D:system library:fopen:Permission denied, (no key found, wrong pass phrase, or wrong file format?)]
Error: Failed to download metadata for repo 'rhui-codeready-builder-for-rhel-8-aarch64-rhui-debug-rpms': Cannot prepare internal mirrorlist: Curl error (58): Problem with the local SSL certificate for https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel8/rhui/8/aarch64/codeready-builder/debug [could not load PEM client certificate, OpenSSL error error:0200100D:system library:fopen:Permission denied, (no key found, wrong pass phrase, or wrong file format?)]

$ sudo dnf download zlib
Google Compute Engine                                                                                                                                                                                                                                                                         49 kB/s | 9.6 kB     00:00    
Google Cloud SDK                                                                                                                                                                                                                                                                              43 MB/s | 154 MB     00:03    
Red Hat CodeReady Linux Builder for RHEL 8 ARM 64 (Debug RPMs) from RHUI                                                                                                                                                                                                                      73 MB/s |  38 MB     00:00    
Red Hat CodeReady Linux Builder for RHEL 8 ARM 64 (RPMs) from RHUI                                                                                                                                                                                                                            45 MB/s | 8.0 MB     00:00  
...
```

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
