### PR TITLE
[make] Clean `otelopscol` build in `clean_submodules`.

### DIFF
--- a/tasks.mak
+++ b/tasks.mak
@@ -52,6 +52,7 @@ otelopscol_local: dist/opt/google-cloud-ops-agent/subagents/opentelemetry-collec
 
 .PHONY: clean_submodules
 clean_submodules:
+	cd submodules/opentelemetry-operations-collector/otelopscol/ && make clean
 	rm -rf dist
 
 ############


### PR DESCRIPTION
## Description
Clean `otelopscol` build in `clean_submodules`.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
