### PR TITLE
[Testing] Update GPU driver to CUDA 13.1.1 for Ubuntu/Debian

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -37,8 +37,9 @@ case $DEVICE_CODE in
             # cuda-12-6 is the latest version that supports Debian 11
             sudo apt -y install cuda-12-6
         else
-            sudo apt -y install nvidia-driver-575
-            sudo apt -y install cuda-12-9
+            sudo apt -y install nvidia-driver-pinning-590.48.01
+            sudo apt -y install cuda-drivers
+            sudo apt -y install cuda-toolkit-13-1
         fi
         ;;
 esac

--- a/integration_test/third_party_apps_test/applications/dcgm/exercise
+++ b/integration_test/third_party_apps_test/applications/dcgm/exercise
@@ -1,6 +1,22 @@
 set -e
 
-# Run the bandwidthTest demo with a large range to create a process that uses
-# GPU for a period that is longer than default collection interval of 60s
-/usr/local/cuda/extras/demo_suite/bandwidthTest --memory=pinned --mode=range \
-  --start=1024 --end=20480 --increment=1
+# Run a CUDA program to create a process that uses GPU for a period that is 
+# longer than default collection interval of 60s
+if [ -x "/usr/local/cuda/extras/demo_suite/bandwidthTest" ]; then
+  # bandwidthTest from the CUDA demo package is available with CUDA 12 and earlier
+  echo "Found bandwidthTest. Running..."
+  /usr/local/cuda/extras/demo_suite/bandwidthTest --memory=pinned --mode=range \
+    --start=1024 --end=20480 --increment=1
+else
+  # For CUDA 13+: 
+  # demos are no longer available as a package but require compiling from 
+  # GitHub source.
+  # bandwidthTest is also replaced by https://github.com/nvidia/nvbandwidth 
+  # which has dependencies such as Boost.
+  # Use gpu-burn instead - easy to compile and run. 
+  echo "CUDA 13+ environment detected. Using gpu-burn..."
+  git clone --depth 1 https://github.com/wilicc/gpu-burn
+  cd gpu-burn
+  make
+  ./gpu_burn -d 180
+fi

--- a/integration_test/third_party_apps_test/applications/dcgmv1/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgmv1/debian_ubuntu/install
@@ -37,8 +37,9 @@ case $DEVICE_CODE in
             # cuda-12-6 is the latest version that supports Debian 11
             sudo apt -y install cuda-12-6
         else
-            sudo apt -y install nvidia-driver-575
-            sudo apt -y install cuda-12-9
+            sudo apt -y install nvidia-driver-pinning-590.48.01
+            sudo apt -y install cuda-drivers
+            sudo apt -y install cuda-toolkit-13-1
         fi
         ;;
 esac

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -37,8 +37,9 @@ case $DEVICE_CODE in
             # cuda-12-6 is the latest version that supports Debian 11
             sudo apt -y install cuda-12-6
         else
-            sudo apt -y install nvidia-driver-575
-            sudo apt -y install cuda-12-9
+            sudo apt -y install nvidia-driver-pinning-590.48.01
+            sudo apt -y install cuda-drivers
+            sudo apt -y install cuda-toolkit-13-1
         fi
         ;;
 esac

--- a/integration_test/third_party_apps_test/applications/nvml/exercise
+++ b/integration_test/third_party_apps_test/applications/nvml/exercise
@@ -1,6 +1,22 @@
 set -e
 
-# Run the bandwidthTest demo with a large range to create a process that uses
-# GPU for a period that is longer than default collection interval of 60s
-/usr/local/cuda/extras/demo_suite/bandwidthTest --memory=pinned --mode=range \
-  --start=1024 --end=20480 --increment=1
+# Run a CUDA program to create a process that uses GPU for a period that is 
+# longer than default collection interval of 60s
+if [ -x "/usr/local/cuda/extras/demo_suite/bandwidthTest" ]; then
+  # bandwidthTest from the CUDA demo package is available with CUDA 12 and earlier
+  echo "Found bandwidthTest. Running..."
+  /usr/local/cuda/extras/demo_suite/bandwidthTest --memory=pinned --mode=range \
+    --start=1024 --end=20480 --increment=1
+else
+  # For CUDA 13+: 
+  # demos are no longer available as a package but require compiling from 
+  # GitHub source.
+  # bandwidthTest is also replaced by https://github.com/nvidia/nvbandwidth 
+  # which has dependencies such as Boost.
+  # Use gpu-burn instead - easy to compile and run. 
+  echo "CUDA 13+ environment detected. Using gpu-burn..."
+  git clone --depth 1 https://github.com/wilicc/gpu-burn
+  cd gpu-burn
+  make
+  ./gpu_burn -d 180
+fi


### PR DESCRIPTION
## Description
The new Ubuntu 2404 image has a newer kernel, so we need to upgrade the CUDA/Nvidia driver. 
- Upgrade from 12.9 to the newest 13.1.1;
- With CUDA 13.1, it has a new method to pin to a specific version of the driver; 
- With CUDA 13+, the demo app we use to generate load is no longer available from the repo; replaced with a simple gpu app;
- Keep other distros unchanged for now to first unblock tests - only updated Ubuntu/Debian. 

## Related issue
[b/486139680](http://b/486139680)

## How has this been tested?
Integration tests passing. 

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
