### PR TITLE
Replace metrics batch processor with sending queue

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -139,6 +139,19 @@ func otlpExporterForMetrics(userAgent string) otel.Component {
 			"headers": map[string]string{
 				"User-Agent": userAgent,
 			},
+			"sending_queue": map[string]interface{}{
+				"enabled":           true,
+				"queue_size":        12000,
+				"num_consumers":     10,
+				"sizer":             "items",
+				"block_on_overflow": true,
+				"batch": map[string]interface{}{
+					"flush_timeout": "200ms",
+					"min_size":      200,
+					"max_size":      200,
+					"sizer":         "items",
+				},
+			},
 		},
 	}
 }
@@ -259,7 +272,6 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 					"metrics": {
 						otel.GCPProjectID(resource.ProjectName()),
 						otel.MetricStartTime(),
-						otel.BatchProcessor(200, 200, "200ms"),
 					},
 				},
 			},

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1249,7 +1256,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1263,7 +1269,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1278,7 +1283,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1300,7 +1304,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1313,7 +1316,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1330,7 +1332,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1341,7 +1342,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1355,7 +1355,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1203,7 +1210,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1218,7 +1224,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1240,7 +1245,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1253,7 +1257,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1270,7 +1273,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1281,7 +1283,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1295,7 +1296,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1716,7 +1723,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1733,7 +1739,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1748,7 +1753,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1763,7 +1767,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1785,7 +1788,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1798,7 +1800,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1815,7 +1816,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1826,7 +1826,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1840,7 +1839,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1716,7 +1723,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1733,7 +1739,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1748,7 +1753,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1763,7 +1767,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1785,7 +1788,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1798,7 +1800,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1815,7 +1816,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1826,7 +1826,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1840,7 +1839,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1080,7 +1087,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1094,7 +1100,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1109,7 +1114,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1131,7 +1135,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1144,7 +1147,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1161,7 +1163,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1172,7 +1173,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1186,7 +1186,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1034,7 +1041,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1049,7 +1055,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1071,7 +1076,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1084,7 +1088,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1101,7 +1104,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1112,7 +1114,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1126,7 +1127,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1177,7 +1184,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1194,7 +1200,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1209,7 +1214,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1224,7 +1228,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1246,7 +1249,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1259,7 +1261,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1276,7 +1277,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1287,7 +1287,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1301,7 +1300,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -33,6 +33,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -42,10 +53,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1177,7 +1184,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1194,7 +1200,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1209,7 +1214,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1224,7 +1228,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1246,7 +1249,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1259,7 +1261,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1276,7 +1277,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/otlp2_otlpgooglecloudmonitoring:
@@ -1287,7 +1287,6 @@ service:
       - resourcedetection/_global_1
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlpgooglecloudmonitoring
     metrics/otlp_otlp:
@@ -1301,7 +1300,6 @@ service:
       - metricstransform/otlp_4
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlp/otlp
     traces/traces_otlp_otlp:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1219,7 +1226,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1233,7 +1239,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1248,7 +1253,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1270,7 +1274,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1283,7 +1286,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1300,7 +1302,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1173,7 +1180,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1188,7 +1194,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1210,7 +1215,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1223,7 +1227,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1240,7 +1243,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1686,7 +1693,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1703,7 +1709,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1718,7 +1723,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1733,7 +1737,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1755,7 +1758,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1768,7 +1770,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1785,7 +1786,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1686,7 +1693,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1703,7 +1709,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1718,7 +1723,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1733,7 +1737,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1755,7 +1758,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1768,7 +1770,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1785,7 +1786,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1170,7 +1177,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1184,7 +1190,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1199,7 +1204,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1221,7 +1225,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1234,7 +1237,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1251,7 +1253,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1124,7 +1131,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1139,7 +1145,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1161,7 +1166,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1174,7 +1178,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1191,7 +1194,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1637,7 +1644,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1654,7 +1660,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1669,7 +1674,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1684,7 +1688,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1706,7 +1709,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1719,7 +1721,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1736,7 +1737,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1637,7 +1644,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1654,7 +1660,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1669,7 +1674,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1684,7 +1688,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1706,7 +1709,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1719,7 +1721,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1736,7 +1737,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1137,7 +1144,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1151,7 +1157,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1166,7 +1171,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1188,7 +1192,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1201,7 +1204,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1218,7 +1220,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1091,7 +1098,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1106,7 +1112,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1128,7 +1133,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1141,7 +1145,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1158,7 +1161,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1604,7 +1611,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1621,7 +1627,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1636,7 +1641,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1651,7 +1655,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1673,7 +1676,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1686,7 +1688,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1703,7 +1704,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1604,7 +1611,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1621,7 +1627,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1636,7 +1641,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1651,7 +1655,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1673,7 +1676,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1686,7 +1688,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1703,7 +1704,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1081,7 +1088,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1095,7 +1101,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1110,7 +1115,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1132,7 +1136,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1145,7 +1148,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1162,7 +1164,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1035,7 +1042,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1050,7 +1056,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1072,7 +1077,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1085,7 +1089,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1102,7 +1105,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1660,7 +1667,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1677,7 +1683,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1692,7 +1697,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1707,7 +1711,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1729,7 +1732,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1742,7 +1744,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1759,7 +1760,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1660,7 +1667,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1677,7 +1683,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1692,7 +1697,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1707,7 +1711,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1729,7 +1732,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1742,7 +1744,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1759,7 +1760,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1081,7 +1088,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1095,7 +1101,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1110,7 +1115,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1132,7 +1136,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1145,7 +1148,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1162,7 +1164,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1035,7 +1042,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1050,7 +1056,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1072,7 +1077,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1085,7 +1089,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1102,7 +1105,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1548,7 +1555,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1565,7 +1571,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1580,7 +1585,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1595,7 +1599,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1617,7 +1620,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1630,7 +1632,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1647,7 +1648,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1548,7 +1555,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1565,7 +1571,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1580,7 +1585,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1595,7 +1599,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1617,7 +1620,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1630,7 +1632,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1647,7 +1648,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1086,7 +1093,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1100,7 +1106,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1115,7 +1120,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1137,7 +1141,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1150,7 +1153,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1167,7 +1169,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1040,7 +1047,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1055,7 +1061,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1077,7 +1082,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1090,7 +1094,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1107,7 +1110,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1553,7 +1560,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1570,7 +1576,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1585,7 +1590,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1600,7 +1604,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1622,7 +1625,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1635,7 +1637,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1652,7 +1653,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1553,7 +1560,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1570,7 +1576,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1585,7 +1590,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1600,7 +1604,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1622,7 +1625,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1635,7 +1637,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1652,7 +1653,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1174,7 +1181,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1188,7 +1194,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1203,7 +1208,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1225,7 +1229,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1238,7 +1241,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1255,7 +1257,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1128,7 +1135,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1143,7 +1149,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1165,7 +1170,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1178,7 +1182,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1195,7 +1198,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1641,7 +1648,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1658,7 +1664,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1673,7 +1678,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1688,7 +1692,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1710,7 +1713,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1723,7 +1725,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1740,7 +1741,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1641,7 +1648,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1658,7 +1664,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1673,7 +1678,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1688,7 +1692,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1710,7 +1713,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1723,7 +1725,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1740,7 +1741,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1388,7 +1395,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1402,7 +1408,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1417,7 +1422,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1439,7 +1443,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1452,7 +1455,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1469,7 +1471,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1342,7 +1349,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1357,7 +1363,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1379,7 +1384,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1392,7 +1396,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1409,7 +1412,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1855,7 +1862,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1872,7 +1878,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1887,7 +1892,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1902,7 +1906,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1924,7 +1927,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1937,7 +1939,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1954,7 +1955,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1855,7 +1862,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1872,7 +1878,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1887,7 +1892,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1902,7 +1906,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1924,7 +1927,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1937,7 +1939,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1954,7 +1955,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1747,7 +1754,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1761,7 +1767,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1776,7 +1781,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1798,7 +1802,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1811,7 +1814,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1828,7 +1830,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1701,7 +1708,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1716,7 +1722,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1738,7 +1743,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1751,7 +1755,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1768,7 +1771,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -2214,7 +2221,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -2231,7 +2237,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -2246,7 +2251,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -2261,7 +2265,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -2283,7 +2286,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -2296,7 +2298,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -2313,7 +2314,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -2214,7 +2221,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -2231,7 +2237,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -2246,7 +2251,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -2261,7 +2265,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -2283,7 +2286,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -2296,7 +2298,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -2313,7 +2314,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1359,7 +1366,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1373,7 +1379,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1388,7 +1393,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1410,7 +1414,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1423,7 +1426,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1440,7 +1442,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1313,7 +1320,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1328,7 +1334,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1350,7 +1355,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1363,7 +1367,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1380,7 +1383,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1826,7 +1833,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1843,7 +1849,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1858,7 +1863,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1873,7 +1877,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1895,7 +1898,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1908,7 +1910,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1925,7 +1926,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1826,7 +1833,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1843,7 +1849,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1858,7 +1863,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1873,7 +1877,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1895,7 +1898,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1908,7 +1910,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1925,7 +1926,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1197,7 +1204,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1211,7 +1217,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1226,7 +1231,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1248,7 +1252,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1261,7 +1264,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1278,7 +1280,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1151,7 +1158,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1166,7 +1172,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1188,7 +1193,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1201,7 +1205,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1218,7 +1221,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1294,7 +1301,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1311,7 +1317,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1326,7 +1331,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1341,7 +1345,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1363,7 +1366,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1376,7 +1378,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1393,7 +1394,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1294,7 +1301,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1311,7 +1317,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1326,7 +1331,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1341,7 +1345,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1363,7 +1366,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1376,7 +1378,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1393,7 +1394,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1106,7 +1113,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1120,7 +1126,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1135,7 +1140,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1157,7 +1161,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1170,7 +1173,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1187,7 +1189,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1060,7 +1067,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1075,7 +1081,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1097,7 +1102,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1110,7 +1114,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1127,7 +1130,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1017,7 +1024,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1031,7 +1037,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1046,7 +1051,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1068,7 +1072,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1081,7 +1084,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1098,7 +1100,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1110,7 +1111,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -971,7 +978,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -986,7 +992,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1008,7 +1013,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1021,7 +1025,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1038,7 +1041,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1050,7 +1052,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1114,7 +1121,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1131,7 +1137,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1146,7 +1151,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1161,7 +1165,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1183,7 +1186,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1196,7 +1198,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1213,7 +1214,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1225,7 +1225,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1114,7 +1121,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1131,7 +1137,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1146,7 +1151,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1161,7 +1165,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1183,7 +1186,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1196,7 +1198,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1213,7 +1214,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1225,7 +1225,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1059,7 +1066,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_hostmetrics_1:
@@ -1073,7 +1079,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
     metrics/fluentbit:
@@ -1088,7 +1093,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1110,7 +1114,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1123,7 +1126,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1140,7 +1142,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1152,7 +1153,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=linux;ShortName=linux_platform;ShortVersion=linux_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   cumulativetodelta/loggingmetrics_4:
     include:
       match_type: strict
@@ -1013,7 +1020,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/fluentbit:
@@ -1028,7 +1034,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1050,7 +1055,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1063,7 +1067,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1080,7 +1083,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1092,7 +1094,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1156,7 +1163,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1173,7 +1179,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1188,7 +1193,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1203,7 +1207,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1225,7 +1228,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1238,7 +1240,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1255,7 +1256,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1267,7 +1267,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -6,16 +6,23 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   googleclientauth: {}
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1156,7 +1163,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1173,7 +1179,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1188,7 +1193,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1203,7 +1207,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1225,7 +1228,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1238,7 +1240,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1255,7 +1256,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/prometheus__pipeline_prometheus:
@@ -1267,7 +1267,6 @@ service:
       - metricstransform/prometheus_2
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -2074,7 +2081,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -2091,7 +2097,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -2106,7 +2111,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -2121,7 +2125,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -2143,7 +2146,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -2156,7 +2158,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -2173,7 +2174,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -2074,7 +2081,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -2091,7 +2097,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -2106,7 +2111,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -2121,7 +2125,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -2143,7 +2146,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -2156,7 +2158,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -2173,7 +2174,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1658,7 +1665,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1675,7 +1681,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1690,7 +1695,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1705,7 +1709,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1727,7 +1730,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1740,7 +1742,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1757,7 +1758,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
@@ -25,6 +25,17 @@ exporters:
     endpoint: telemetry.googleapis.com:443
     headers:
       User-Agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+    sending_queue:
+      batch:
+        flush_timeout: 200ms
+        max_size: 200
+        min_size: 200
+        sizer: items
+      block_on_overflow: true
+      enabled: true
+      num_consumers: 10
+      queue_size: 12000
+      sizer: items
 extensions:
   file_storage:
     create_directory: true
@@ -34,10 +45,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  batch/otlp_grpc/otlp_metrics_metrics_2:
-    send_batch_max_size: 200
-    send_batch_size: 200
-    timeout: 200ms
   casttosum/iis_1:
     metrics:
     - agent.googleapis.com/iis/network/transferred_bytes_count
@@ -1658,7 +1665,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
     metrics/default__pipeline_iis:
@@ -1675,7 +1681,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
@@ -1690,7 +1695,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1705,7 +1709,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/loggingmetrics:
@@ -1727,7 +1730,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
     metrics/opsagent:
@@ -1740,7 +1742,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - otlpjsonfile/ops_agent
     metrics/otel:
@@ -1757,7 +1758,6 @@ service:
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metricstarttime/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - prometheus/agent_prometheus
   telemetry:


### PR DESCRIPTION
## Description
This adds a sending_queue to the metric otlp_grpc metrics exporter.

## Related issue
b/485613604

## How has this been tested?
Integration tests.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
