### PR TITLE
Refactor experimental features to internal package

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel/ottl"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 )
 
 // AgentSelfMetrics provides the agent.googleapis.com/agent/ metrics.
@@ -181,7 +182,7 @@ func (r AgentSelfMetrics) OtelPipelineProcessors(ctx context.Context) []otel.Com
 		`metric.name == "` + durationCountMetric + `" and (not IsMatch(datapoint.attributes["grpc_target"], "monitoring.googleapis"))`,
 	})
 
-	expOtlpExporter := experimentsFromContext(ctx)["otlp_exporter"]
+	expOtlpExporter := experiments.FromContext(ctx)["otlp_exporter"]
 	var extraTransforms []map[string]interface{}
 	if expOtlpExporter {
 		durationMetric = "rpc_client_call_duration"
@@ -292,7 +293,7 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 		otel.AggregateLabels("sum", "response_code"),
 	)
 
-	expOtlpExporter := experimentsFromContext(ctx)["otlp_exporter"]
+	expOtlpExporter := experiments.FromContext(ctx)["otlp_exporter"]
 	if expOtlpExporter {
 		durationMetric = "rpc_client_call_duration"
 		durationCountMetric = "rpc_client_call_duration_count"

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 )
 
@@ -98,7 +99,7 @@ func ConvertGCMSystemExporterToOtlpExporter(pipeline otel.ReceiverPipeline, ctx 
 }
 
 func ConvertToOtlpExporter(pipeline otel.ReceiverPipeline, ctx context.Context, isPrometheus bool, isSystem bool) otel.ReceiverPipeline {
-	expOtlpExporter := experimentsFromContext(ctx)["otlp_exporter"]
+	expOtlpExporter := experiments.FromContext(ctx)["otlp_exporter"]
 	if !expOtlpExporter {
 		return pipeline
 	}

--- a/confgenerator/confgenerator_test.go
+++ b/confgenerator/confgenerator_test.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/self_metrics"
 	"github.com/goccy/go-yaml"
@@ -243,10 +244,10 @@ func getTestsInDir(t *testing.T, testDir string) []string {
 func generateConfigs(pc platformConfig, testDir string) (got map[string]string, err error) {
 	ctx := pc.platform.TestContext(context.Background())
 
-	var experiments map[string]bool
+	var enabledExperiments map[string]bool
 	if features, err := os.ReadFile(filepath.Join("testdata", testDir, "EXPERIMENTAL_FEATURES")); err == nil {
-		experiments = confgenerator.ParseExperimentalFeatures(string(features))
-		ctx = confgenerator.ContextWithExperiments(ctx, experiments)
+		enabledExperiments = experiments.ParseExperimentalFeatures(string(features))
+		ctx = experiments.ContextWithExperiments(ctx, enabledExperiments)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
@@ -333,19 +334,19 @@ func generateConfigs(pc platformConfig, testDir string) (got map[string]string, 
 	got["enabled_receivers_otlp.json"] = string(generatedEnabledReceiversOTLPJSON)
 
 	// If the confgenerator test is designed to test the otel_logging experiment, generate an OTEL config with both otlp_exporter and otel_logging enabled.
-	if len(experiments) == 1 && experiments["otel_logging"] {
-		generateOtelConfigWithOtlpExporterEnabled(got, experiments, pc, testDir, otelGeneratedConfig)
+	if len(enabledExperiments) == 1 && enabledExperiments["otel_logging"] {
+		generateOtelConfigWithOtlpExporterEnabled(got, pc, testDir, otelGeneratedConfig)
 	}
 
 	return
 }
 
-func generateOtelConfigWithOtlpExporterEnabled(got map[string]string, experiments map[string]bool, pc platformConfig, testDir string, otelGeneratedConfig string) {
+func generateOtelConfigWithOtlpExporterEnabled(got map[string]string, pc platformConfig, testDir string, otelGeneratedConfig string) {
 	experimentsOtlp := map[string]bool{
 		"otlp_exporter": true,
 		"otel_logging":  true,
 	}
-	ctxOtlp := confgenerator.ContextWithExperiments(pc.platform.TestContext(context.Background()), experimentsOtlp)
+	ctxOtlp := experiments.ContextWithExperiments(pc.platform.TestContext(context.Background()), experimentsOtlp)
 
 	mergedUcOtlp, err := confgenerator.MergeConfFiles(
 		ctxOtlp,

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/filter"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/set"
@@ -1090,9 +1091,9 @@ func (uc *UnifiedConfig) loggingPipelines(ctx context.Context) ([]PipelineInstan
 		return nil, err
 	}
 	platformDefaultConfig := BuiltInConfStructs[platform.FromContext(ctx).Name()].Logging
-	exp_otlp := experimentsFromContext(ctx)["otlp_logging"]
+	exp_otlp := experiments.FromContext(ctx)["otlp_logging"]
 	// N.B. Temporarily gate the "auto" otel logging behind an experiment flag.
-	exp_otel := experimentsFromContext(ctx)["otel_logging"]
+	exp_otel := experiments.FromContext(ctx)["otel_logging"]
 	force_otel := l.Service.OTelLogging
 	var out []PipelineInstance
 	for _, pID := range otel.SortedKeys(l.Service.Pipelines) {

--- a/confgenerator/experimental.go
+++ b/confgenerator/experimental.go
@@ -17,9 +17,8 @@ package confgenerator
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -36,38 +35,10 @@ import (
 // intentionally left empty.
 var requiredFeatureForType = map[string]string{}
 
-var enabledExperimentalFeatures map[string]bool
-
-func ParseExperimentalFeatures(features string) map[string]bool {
-	out := map[string]bool{}
-	for _, f := range strings.Split(features, ",") {
-		out[strings.TrimSpace(f)] = true
-	}
-	return out
-}
-
-func init() {
-	enabledExperimentalFeatures = ParseExperimentalFeatures(os.Getenv("EXPERIMENTAL_FEATURES"))
-}
-
-type experimentsKeyType struct{}
-
-var experimentsKey = experimentsKeyType{}
-
-func ContextWithExperiments(ctx context.Context, experiments map[string]bool) context.Context {
-	return context.WithValue(ctx, experimentsKey, experiments)
-}
-
-func experimentsFromContext(ctx context.Context) map[string]bool {
-	if features := ctx.Value(experimentsKey); features != nil {
-		return features.(map[string]bool)
-	}
-	return enabledExperimentalFeatures
-}
 
 func registerExperimentalValidations(v *validator.Validate) {
 	v.RegisterValidationCtx("experimental", func(ctx context.Context, fl validator.FieldLevel) bool {
-		return fl.Field().IsZero() || experimentsFromContext(ctx)[fl.Param()]
+		return fl.Field().IsZero() || experiments.FromContext(ctx)[fl.Param()]
 	})
 	v.RegisterStructValidationCtx(componentValidator, ConfigComponent{})
 }
@@ -78,7 +49,7 @@ func componentValidator(ctx context.Context, sl validator.StructLevel) {
 		return
 	}
 	feature, ok := requiredFeatureForType[comp.Type]
-	if !ok || experimentsFromContext(ctx)[feature] {
+	if !ok || experiments.FromContext(ctx)[feature] {
 		return
 	}
 	sl.ReportError(comp, "type", "Type", "experimental", comp.Type)

--- a/confgenerator/experimental.go
+++ b/confgenerator/experimental.go
@@ -35,7 +35,6 @@ import (
 // intentionally left empty.
 var requiredFeatureForType = map[string]string{}
 
-
 func registerExperimentalValidations(v *validator.Validate) {
 	v.RegisterValidationCtx("experimental", func(ctx context.Context, fl validator.FieldLevel) bool {
 		return fl.Field().IsZero() || experiments.FromContext(ctx)[fl.Param()]

--- a/confgenerator/feature_tracking.go
+++ b/confgenerator/feature_tracking.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 )
 
 var (
@@ -475,7 +477,7 @@ func getSelfLogCollection(uc *UnifiedConfig) Feature {
 
 func getOtlpExporterExperimentConfig(ctx context.Context) []Feature {
 	featureEnabled := "false"
-	if experimentsFromContext(ctx)["otlp_exporter"] {
+	if experiments.FromContext(ctx)["otlp_exporter"] {
 		featureEnabled = "true"
 	}
 

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package experiments
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+var enabledExperimentalFeatures map[string]bool
+
+// ParseExperimentalFeatures parses a comma-separated list of features.
+func ParseExperimentalFeatures(features string) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range strings.Split(features, ",") {
+		out[strings.TrimSpace(f)] = true
+	}
+	return out
+}
+
+func init() {
+	enabledExperimentalFeatures = ParseExperimentalFeatures(os.Getenv("EXPERIMENTAL_FEATURES"))
+}
+
+type experimentsKeyType struct{}
+
+var experimentsKey = experimentsKeyType{}
+
+// ContextWithExperiments returns a new context with the given experiments enabled.
+func ContextWithExperiments(ctx context.Context, experiments map[string]bool) context.Context {
+	return context.WithValue(ctx, experimentsKey, experiments)
+}
+
+// FromContext returns the enabled experiments from the context, or the default enabled ones from the environment.
+func FromContext(ctx context.Context) map[string]bool {
+	if features := ctx.Value(experimentsKey); features != nil {
+		return features.(map[string]bool)
+	}
+	return enabledExperimentalFeatures
+}
+
+// IsEnabled returns true if the given feature is enabled in the context.
+func IsEnabled(ctx context.Context, feature string) bool {
+	return FromContext(ctx)[feature]
+}

--- a/internal/self_metrics/self_metrics_test.go
+++ b/internal/self_metrics/self_metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/apps"
 	_ "github.com/GoogleCloudPlatform/ops-agent/apps"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/self_metrics"
 	"gotest.tools/v3/assert"
 )
@@ -83,7 +84,7 @@ func TestEnabledReceiversDefaultConfig(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := confgenerator.ContextWithExperiments(context.Background(), confgenerator.ParseExperimentalFeatures(test.experimentalFeatures))
+			ctx := experiments.ContextWithExperiments(context.Background(), experiments.ParseExperimentalFeatures(test.experimentalFeatures))
 			eR, err := self_metrics.CountEnabledReceivers(ctx, test.config)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, eR, test.enabledReceivers)

--- a/transformation_test/otlp_helpers_test.go
+++ b/transformation_test/otlp_helpers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/goccy/go-yaml"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
@@ -27,7 +28,7 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 	pi.RID = "my-log-name"
 	pi.Backend = confgenerator.BackendOTel
 
-	ctx = confgenerator.ContextWithExperiments(ctx, map[string]bool{"otlp_exporter": true})
+	ctx = experiments.ContextWithExperiments(ctx, map[string]bool{"otlp_exporter": true})
 
 	rps, pls, err := pi.OTelComponents(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description
Just refactoring experimental feature package to internal
This will allow us to call it from other places without creating a circular dependency.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
