### PR TITLE
Force test VMs to run in same zone as kokoro worker

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -143,6 +143,17 @@ if [[ -n "${PLATFORMS:-}" ]]; then
   IMAGE_SPECS="${PLATFORMS}"
 fi
 
+# TODO(b/502589964): force test VMs to run in the same zone as the kokoro worker.
+# The worker is not guaranteed to run in a zone where ARM machines are available,
+# so don't do this for ARM tests.
+if [[ "${ARCH:-}" != "aarch64" ]]; then
+  ZONE_METADATA=$(curl -s -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/zone)
+  if [[ $? -eq 0 ]] && [[ -n "$ZONE_METADATA" ]]; then
+    ZONE_METADATA="${ZONE_METADATA%/}"
+    export ZONES="${ZONE_METADATA##*/}"
+  fi
+fi
+
 set_image_specs
 set_zones
 


### PR DESCRIPTION
## Description
Force test VMs to run in same zone as kokoro worker, which seems like it might mitigate the random SSH connection timeouts we've been seeing.

## Related issue
http://b/502589964

## How has this been tested?
Presubmits

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
