### PR TITLE
Prototype Option 2: Component-Specific Configuration for Metrics Ports

### DIFF
--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -224,8 +224,8 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 	agentSelfMetrics := AgentSelfMetrics{
 		MetricsVersionLabel: metricVersionLabel,
 		LoggingVersionLabel: loggingVersionLabel,
-		FluentBitPort:       fluentbit.MetricsPort,
-		OtelPort:            otel.MetricsPort,
+		FluentBitPort:       int(uc.GetFluentBitMetricsPort()),
+		OtelPort:            int(uc.GetOtelMetricsPort()),
 		OtelRuntimeDir:      outDir,
 	}
 	agentSelfMetrics.AddSelfMetricsPipelines(receiverPipelines, pipelines, ctx)
@@ -238,6 +238,7 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 		LogLevel:          uc.getOTelLogLevel(),
 		ReceiverPipelines: receiverPipelines,
 		Pipelines:         pipelines,
+		MetricsPort:       uc.GetOtelMetricsPort(),
 		Exporters: map[otel.ExporterType]otel.ExporterComponents{
 			otel.System: {
 				Exporter: googleCloudExporter(userAgent, false, false),
@@ -608,7 +609,7 @@ func (uc *UnifiedConfig) generateFluentbitComponents(ctx context.Context, userAg
 		out = append(out, addGceMetadataAttributesProcessor(ctx).Components(ctx, "*", "*.default-data-proc.gce_metadata")...)
 	}
 	out = append(out, uc.generateSelfLogsComponents(ctx, userAgent)...)
-	out = append(out, fluentbit.MetricsOutputComponent())
+	out = append(out, fluentbit.MetricsOutputComponent(uc.GetFluentBitMetricsPort()))
 
 	return out, nil
 }

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -66,6 +66,20 @@ func (uc *UnifiedConfig) HasCombined() bool {
 	return uc.Combined != nil
 }
 
+func (uc *UnifiedConfig) GetFluentBitMetricsPort() uint16 {
+	if uc == nil || uc.Logging == nil {
+		return fluentbit.MetricsPort
+	}
+	return uc.Logging.Service.GetMetricsPort()
+}
+
+func (uc *UnifiedConfig) GetOtelMetricsPort() uint16 {
+	if uc == nil || uc.Metrics == nil {
+		return otel.MetricsPort
+	}
+	return uc.Metrics.Service.GetMetricsPort()
+}
+
 func (uc *UnifiedConfig) DeepCopy(ctx context.Context) (*UnifiedConfig, error) {
 	toYaml, err := yaml.Marshal(uc)
 	if err != nil {
@@ -588,8 +602,16 @@ func (m *loggingProcessorMap) UnmarshalYAML(ctx context.Context, unmarshal func(
 type LoggingService struct {
 	Compress    string               `yaml:"compress,omitempty" validate:"omitempty,oneof=gzip,experimental=log_compression"`
 	LogLevel    string               `yaml:"log_level,omitempty" validate:"omitempty,oneof=error warn info debug trace"`
-	Pipelines   map[string]*Pipeline `validate:"dive,keys,startsnotwith=lib:"`
+	Pipelines   map[string]*Pipeline `yaml:"pipelines" validate:"dive,keys,startsnotwith=lib:"`
 	OTelLogging *bool                `yaml:"experimental_otel_logging,omitempty" validate:"omitempty"`
+	MetricsPort uint16               `yaml:"metrics_port,omitempty" validate:"omitempty,gte=1,lte=65535"`
+}
+
+func (ls *LoggingService) GetMetricsPort() uint16 {
+	if ls == nil || ls.MetricsPort == 0 {
+		return fluentbit.MetricsPort
+	}
+	return ls.MetricsPort
 }
 
 type Pipeline struct {
@@ -833,8 +855,16 @@ func (m *metricsProcessorMap) UnmarshalYAML(ctx context.Context, unmarshal func(
 }
 
 type MetricsService struct {
-	LogLevel  string               `yaml:"log_level,omitempty" validate:"omitempty,oneof=error warn info debug"`
-	Pipelines map[string]*Pipeline `yaml:"pipelines" validate:"dive,keys,startsnotwith=lib:"`
+	LogLevel    string               `yaml:"log_level,omitempty" validate:"omitempty,oneof=error warn info debug"`
+	Pipelines   map[string]*Pipeline `yaml:"pipelines" validate:"dive,keys,startsnotwith=lib:"`
+	MetricsPort uint16               `yaml:"metrics_port,omitempty" validate:"omitempty,gte=1,lte=65535"`
+}
+
+func (ms *MetricsService) GetMetricsPort() uint16 {
+	if ms == nil || ms.MetricsPort == 0 {
+		return otel.MetricsPort
+	}
+	return ms.MetricsPort
 }
 
 type Traces struct {

--- a/confgenerator/confmerger.go
+++ b/confgenerator/confmerger.go
@@ -91,6 +91,9 @@ func mergeConfigs(original, overrides *UnifiedConfig) {
 			if overrides.Logging.Service.Compress != "" {
 				original.Logging.Service.Compress = overrides.Logging.Service.Compress
 			}
+			if overrides.Logging.Service.MetricsPort != 0 {
+				original.Logging.Service.MetricsPort = overrides.Logging.Service.MetricsPort
+			}
 			for name, pipeline := range overrides.Logging.Service.Pipelines {
 				// skips logging.service.pipelines.*.exporters
 				pipeline.ExporterIDs = nil
@@ -125,6 +128,9 @@ func mergeConfigs(original, overrides *UnifiedConfig) {
 		if overrides.Metrics.Service != nil {
 			if overrides.Metrics.Service.LogLevel != "info" {
 				original.Metrics.Service.LogLevel = overrides.Metrics.Service.LogLevel
+			}
+			if overrides.Metrics.Service.MetricsPort != 0 {
+				original.Metrics.Service.MetricsPort = overrides.Metrics.Service.MetricsPort
 			}
 			for name, pipeline := range overrides.Metrics.Service.Pipelines {
 				// skips metrics.service.pipelines.*.exporters

--- a/confgenerator/fluentbit/metrics.go
+++ b/confgenerator/fluentbit/metrics.go
@@ -29,7 +29,7 @@ func MetricsInputComponent() Component {
 	}
 }
 
-func MetricsOutputComponent() Component {
+func MetricsOutputComponent(port uint16) Component {
 	return Component{
 		Kind: "OUTPUT",
 		Config: map[string]string{
@@ -37,7 +37,7 @@ func MetricsOutputComponent() Component {
 			"Name":  "prometheus_exporter",
 			"Match": "*",
 			"host":  "0.0.0.0",
-			"port":  strconv.Itoa(MetricsPort),
+			"port":  strconv.Itoa(int(port)),
 		},
 	}
 }

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -133,12 +133,20 @@ type ModularConfig struct {
 	Pipelines         map[string]Pipeline
 	Exporters         map[ExporterType]ExporterComponents
 	Extensions        map[string]Component
+	MetricsPort       uint16
 
 	// Test-only options:
 	// Don't generate any self-metrics
 	DisableMetrics bool
 	// Emit collector logs as JSON
 	JSONLogs bool
+}
+
+func (c ModularConfig) getMetricsPort() uint16 {
+	if c.MetricsPort == 0 {
+		return MetricsPort
+	}
+	return c.MetricsPort
 }
 
 // Generate an OT YAML config file for c.
@@ -171,7 +179,7 @@ func (c ModularConfig) Generate(ctx context.Context) (string, error) {
 						"exporter": map[string]interface{}{
 							"prometheus": map[string]interface{}{
 								"host": "0.0.0.0",
-								"port": MetricsPort,
+								"port": c.getMetricsPort(),
 
 								// See https://docs.datadoghq.com/opentelemetry/migrate/collector_0_120_0/#changes-to-prometheus-server-reader-defaults for why these fields are needed.
 								// See https://github.com/open-telemetry/opentelemetry-collector/pull/11611/files#diff-150d72bc611b4b0de17f646768979b15936f820a029cafa91c4037d50ae47e5a for the actual upstream otel code changes.

--- a/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/linux-gpu/error
+++ b/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/linux-gpu/error
@@ -1,4 +1,4 @@
-[24:21] "Pipelines[lib:pipeline_1]" must not start with "lib:"
+[24:21] "pipelines[lib:pipeline_1]" must not start with "lib:"
   21 |       - /var/log/syslog
   22 |   service:
   23 |     pipelines:

--- a/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/linux/error
+++ b/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/linux/error
@@ -1,4 +1,4 @@
-[24:21] "Pipelines[lib:pipeline_1]" must not start with "lib:"
+[24:21] "pipelines[lib:pipeline_1]" must not start with "lib:"
   21 |       - /var/log/syslog
   22 |   service:
   23 |     pipelines:

--- a/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/windows-2012/error
+++ b/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/windows-2012/error
@@ -1,4 +1,4 @@
-[24:21] "Pipelines[lib:pipeline_1]" must not start with "lib:"
+[24:21] "pipelines[lib:pipeline_1]" must not start with "lib:"
   21 |       - /var/log/syslog
   22 |   service:
   23 |     pipelines:

--- a/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/windows/error
+++ b/confgenerator/testdata/goldens/invalid-logging-pipeline_reserved_id_prefix/golden/windows/error
@@ -1,4 +1,4 @@
-[24:21] "Pipelines[lib:pipeline_1]" must not start with "lib:"
+[24:21] "pipelines[lib:pipeline_1]" must not start with "lib:"
   21 |       - /var/log/syslog
   22 |   service:
   23 |     pipelines:


### PR DESCRIPTION
This commit implements the prototype for component-specific port configuration in the Ops Agent. It allows users to set independent metrics ports for Fluent Bit and OpenTelemetry Collector in their respective service blocks in config.yaml.

- Added MetricsPort field to LoggingService and MetricsService.
- Updated confgenerator to use these ports.
- Fixed mergeConfigs to copy MetricsPort.
- Updated tests and golden files.

TAG=agy
CONV=062b1ae6-6d88-486e-a584-a82f970e5ae4

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
