### PR TITLE
Ubuntu 26.04 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1227,6 +1227,106 @@ COPY --from=noble-build /google-cloud-ops-agent*.deb /
 COPY --from=noble-build /google-cloud-ops-agent-plugin*.tar.gz /
 
 # ======================================
+# Build Ops Agent for ubuntu-resolute
+# ======================================
+
+FROM ubuntu:resolute AS resolute-build-base
+ARG OPENJDK_MAJOR_VERSION
+
+RUN set -x; apt-get update && \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
+		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
+		build-essential cmake bison flex file libsystemd-dev systemd-dev tzdata \
+		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip debhelper
+
+SHELL ["/bin/bash", "-c"]
+
+# Install golang
+ARG TARGETARCH
+ARG GO_VERSION
+ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+
+FROM resolute-build-base AS resolute-build-otel
+WORKDIR /work
+# Download golang deps
+COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
+RUN cd submodules/opentelemetry-operations-collector && go mod download
+
+COPY ./submodules/opentelemetry-java-contrib submodules/opentelemetry-java-contrib
+# Install gradle. The first invocation of gradlew does this
+RUN cd submodules/opentelemetry-java-contrib && ./gradlew --no-daemon -Djdk.lang.Process.launchMechanism=vfork tasks
+COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
+COPY ./builds/otel.sh .
+RUN \
+    unset OTEL_TRACES_EXPORTER && \
+    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
+    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
+    ./otel.sh /work/cache/
+
+FROM resolute-build-base AS resolute-build-fluent-bit
+WORKDIR /work
+COPY ./submodules/fluent-bit submodules/fluent-bit
+COPY ./builds/fluent_bit.sh .
+RUN ./fluent_bit.sh /work/cache/
+
+
+FROM resolute-build-base AS resolute-build-systemd
+WORKDIR /work
+COPY ./systemd systemd
+COPY ./builds/systemd.sh .
+RUN ./systemd.sh /work/cache/
+
+
+FROM resolute-build-base AS resolute-build-golang-base
+WORKDIR /work
+COPY go.mod go.sum ./
+# Fetch dependencies
+RUN go mod download
+COPY confgenerator confgenerator
+COPY apps apps
+COPY internal internal
+
+
+FROM resolute-build-golang-base AS resolute-build-wrapper
+WORKDIR /work
+COPY cmd/agent_wrapper cmd/agent_wrapper
+COPY ./builds/agent_wrapper.sh .
+RUN ./agent_wrapper.sh /work/cache/
+
+
+FROM resolute-build-golang-base AS resolute-build
+WORKDIR /work
+COPY . /work
+
+# Run the build script once to build the ops agent engine to a cache
+RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
+WORKDIR /tmp/cache_run/golang
+RUN ./pkg/deb/build.sh &> /dev/null || true
+WORKDIR /work
+
+COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
+COPY --from=resolute-build-otel /work/cache /work/cache
+COPY --from=resolute-build-fluent-bit /work/cache /work/cache
+COPY --from=resolute-build-systemd /work/cache /work/cache
+COPY --from=resolute-build-wrapper /work/cache /work/cache
+RUN ./pkg/deb/build.sh
+
+COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
+COPY ./builds/ops_agent_plugin.sh .
+RUN ./ops_agent_plugin.sh /work/cache/
+RUN ./pkg/plugin/build.sh /work/cache resolute
+
+
+FROM scratch AS resolute
+COPY --from=resolute-build /tmp/google-cloud-ops-agent.tgz /google-cloud-ops-agent-ubuntu-resolute.tgz
+COPY --from=resolute-build /google-cloud-ops-agent*.deb /
+COPY --from=resolute-build /google-cloud-ops-agent-plugin*.tar.gz /
+
+# ======================================
 # Build Ops Agent for ubuntu-questing
 # ======================================
 
@@ -1338,4 +1438,5 @@ COPY --from=sles15 /* /
 COPY --from=sles16 /* /
 COPY --from=jammy /* /
 COPY --from=noble /* /
+COPY --from=resolute /* /
 COPY --from=questing /* /

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -235,6 +235,18 @@ RUN ln -fs /usr/lib/systemd /lib/systemd` + installJava + installCMake,
 		package_extension: "deb",
 	},
 	{
+		from_image:  "ubuntu:resolute",
+		target_name: "resolute",
+		install_packages: `RUN set -x; apt-get update && \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
+		autoconf libtool libcurl4-openssl-dev libltdl-dev libssl-dev libyajl-dev \
+		build-essential cmake bison flex file libsystemd-dev systemd-dev tzdata \
+		devscripts cdbs pkg-config openjdk-${OPENJDK_MAJOR_VERSION}-jdk zip debhelper`,
+		package_build:     "RUN ./pkg/deb/build.sh",
+		tar_distro_name:   "ubuntu-resolute",
+		package_extension: "deb",
+	},
+	{
 		from_image:  "ubuntu:questing",
 		target_name: "questing",
 		install_packages: `RUN set -x; apt-get update && \

--- a/integration_test/third_party_apps_test/applications/aerospike/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/aerospike/metadata.yaml
@@ -175,4 +175,6 @@ platforms_to_skip:
   - ml-images:common-cu129-ubuntu-2404-nvidia-580 # 24.04 only has Aerospike 7.2.0+
   - ubuntu-os-cloud:ubuntu-2510-amd64 # aerospike not available for 25.10 yet: https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0/
   - ubuntu-os-cloud:ubuntu-2510-arm64 # aerospike not available for 25.10 yet: https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0/
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64 # 26.04 only has Aerospike 7.2.0+
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64 # 26.04 only has Aerospike 7.2.0+
 public_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/aerospike

--- a/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/couchdb/metadata.yaml
@@ -77,6 +77,8 @@ platforms_to_skip:
   - ubuntu-os-cloud:ubuntu-2404-lts-arm64
   - ubuntu-os-cloud:ubuntu-2510-amd64 # couchdb not available for 25.10 yet: https://docs.couchdb.org/en/stable/install/unix.html
   - ubuntu-os-cloud:ubuntu-2510-arm64
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64
   - debian-cloud:debian-12
   - debian-cloud:debian-12-arm64
   # couchdb does not support Debian 13 yet: https://apache.jfrog.io/ui/native/couchdb-deb/dists/.

--- a/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mariadb/metadata.yaml
@@ -64,6 +64,8 @@ platforms_to_skip:
   - suse-cloud:sles-15-arm64
   - ubuntu-os-cloud:ubuntu-2510-amd64 # Possible support in the future
   - ubuntu-os-cloud:ubuntu-2510-arm64 # Possible support in the future
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64  # Ubuntu 26.04 ships MariaDB 11.8
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64  # Ubuntu 26.04 ships MariaDB 11.8
 supported_app_version: ["10.1.X through 10.7.X", ""] # Indicate multiple versions.
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages

--- a/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb/metadata.yaml
@@ -45,6 +45,8 @@ platforms_to_skip:
   - rocky-linux-cloud:rocky-linux-10-optimized-gcp-arm64
   - ubuntu-os-cloud:ubuntu-2510-amd64
   - ubuntu-os-cloud:ubuntu-2510-arm64
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64  # MongoDB hasn't support Ubuntu 26.04 yet
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64  # MongoDB hasn't support Ubuntu 26.04 yet
 supported_app_version: ["2.6", "3.x", "4.x", "5.0", "6.0"]
 expected_metrics:
   - type: workload.googleapis.com/mongodb.cache.operations

--- a/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mongodb3.6/metadata.yaml
@@ -59,6 +59,8 @@ platforms_to_skip:
   - ml-images:common-cu129-ubuntu-2404-nvidia-580
   - ubuntu-os-cloud:ubuntu-2510-amd64
   - ubuntu-os-cloud:ubuntu-2510-arm64
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64
 supported_app_version: ["2.6", "3.0+", "4.0+", "5.0"]
 expected_metrics:
   - type: workload.googleapis.com/mongodb.cache.operations

--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -42,6 +42,8 @@ platforms_to_skip:
   - suse-sap-cloud:sles-12-sp5-sap
   - ubuntu-os-cloud:ubuntu-2510-amd64 # MySQL is not available on Ubuntu 25.10 yet
   - ubuntu-os-cloud:ubuntu-2510-arm64 # MySQL is not available on Ubuntu 25.10 yet
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64 # MySQL is not available on Ubuntu 26.04 yet
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64 # MySQL is not available on Ubuntu 26.04 yet
 supported_app_version: ["5.7", "8.0"]
 expected_metrics:
   - type: workload.googleapis.com/mysql.buffer_pool_data_pages

--- a/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql5.7/metadata.yaml
@@ -64,6 +64,8 @@ platforms_to_skip:
   - ubuntu-os-cloud:ubuntu-2204-lts-arm64
   - ubuntu-os-cloud:ubuntu-2404-lts-amd64
   - ubuntu-os-cloud:ubuntu-2404-lts-arm64
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64
   - ml-images:common-cu129-ubuntu-2404-nvidia-580
   - ubuntu-os-cloud:ubuntu-2510-amd64
   - ubuntu-os-cloud:ubuntu-2510-arm64

--- a/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/oracledb/metadata.yaml
@@ -76,6 +76,8 @@ platforms_to_skip:
   - ml-images:common-cu129-ubuntu-2404-nvidia-580
   - ubuntu-os-cloud:ubuntu-2510-amd64
   - ubuntu-os-cloud:ubuntu-2510-arm64
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64
 supported_app_version: ["12.2", "18c", "19c", "21c"]
 expected_metrics:
   - type: workload.googleapis.com/oracle.backup.latest

--- a/integration_test/third_party_apps_test/applications/rabbitmq/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/rabbitmq/debian_ubuntu/install
@@ -23,6 +23,9 @@ case $VERSION_ID in
   24.04|25.10)
     echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu noble main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
     ;;
+  26.04)
+    echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu resolute main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+    ;;
   # debian
   11)
     echo "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/rabbitmq.list

--- a/integration_test/third_party_apps_test/applications/vault/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/vault/metadata.yaml
@@ -75,6 +75,8 @@ platforms_to_skip:
   - rocky-linux-cloud:rocky-linux-10-optimized-gcp-arm64
   - ubuntu-os-cloud:ubuntu-2510-amd64 # vault not available for 25.10 yet: https://www.hashicorp.com/en/official-packaging-guide
   - ubuntu-os-cloud:ubuntu-2510-arm64 # vault not available for 25.10 yet: https://www.hashicorp.com/en/official-packaging-guide
+  - ubuntu-os-cloud:ubuntu-2604-lts-amd64 # vault not available for 26.04 yet: https://www.hashicorp.com/en/official-packaging-guide
+  - ubuntu-os-cloud:ubuntu-2604-lts-arm64 # vault not available for 26.04 yet: https://www.hashicorp.com/en/official-packaging-guide
 supported_app_version: ["1.6+"]
 expected_metrics:
   - type: workload.googleapis.com/vault.core.request.count

--- a/kokoro/config/build/presubmit/resolute_aarch64.gcl
+++ b/kokoro/config/build/presubmit/resolute_aarch64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'resolute'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/build/presubmit/resolute_x86_64.gcl
+++ b/kokoro/config/build/presubmit/resolute_x86_64.gcl
@@ -1,0 +1,10 @@
+import '../common.gcl' as common
+
+config build = common.build {
+  params {
+    environment {
+      DISTRO = 'resolute'
+      PKGFORMAT = 'deb'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/resolute_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/resolute_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/resolute_aarch64_uap_plugin.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/resolute_aarch64_uap_plugin.gcl
@@ -1,0 +1,11 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'aarch64'
+      IS_OPS_AGENT_UAP_PLUGIN = 'true'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/resolute_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/resolute_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/presubmit/resolute_x86_64_uap_plugin.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/resolute_x86_64_uap_plugin.gcl
@@ -1,0 +1,11 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'x86_64'
+      IS_OPS_AGENT_UAP_PLUGIN = 'true'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/resolute_aarch64.gcl
+++ b/kokoro/config/test/ops_agent/release/resolute_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/ops_agent/release/resolute_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/resolute_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.ops_agent_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/presubmit/resolute_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/presubmit/resolute_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/presubmit/resolute_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/presubmit/resolute_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/resolute_aarch64.gcl
+++ b/kokoro/config/test/third_party_apps/release/resolute_aarch64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'aarch64'
+    }
+  }
+}

--- a/kokoro/config/test/third_party_apps/release/resolute_x86_64.gcl
+++ b/kokoro/config/test/third_party_apps/release/resolute_x86_64.gcl
@@ -1,0 +1,10 @@
+import 'common.gcl' as common
+
+config build = common.third_party_apps_test {
+  params {
+    environment {
+      TARGET = 'resolute'
+      ARCH = 'x86_64'
+    }
+  }
+}

--- a/project.yaml
+++ b/project.yaml
@@ -126,6 +126,23 @@ targets:
           - ubuntu-os-cloud:ubuntu-2404-lts-arm64
           exhaustive:
           - ubuntu-os-cloud:ubuntu-minimal-2404-lts-arm64
+  resolute:
+    os_versions: [ubuntu-26.04*]
+    package_extension:
+      deb
+    architectures:
+      x86_64:
+        test_distros:
+          representative:
+          - ubuntu-os-cloud:ubuntu-2604-lts-amd64
+          exhaustive:
+          - ubuntu-os-cloud:ubuntu-minimal-2604-lts-amd64
+      aarch64:
+        test_distros:
+          representative:
+          - ubuntu-os-cloud:ubuntu-2604-lts-arm64
+          exhaustive:
+          - ubuntu-os-cloud:ubuntu-minimal-2604-lts-arm64
   rockylinux9:
     os_versions: [centos-9*,rocky-9*,rhel-9*]
     package_extension:


### PR DESCRIPTION
## Description

Add support for Ubuntu 26.04. The build configuration is mostly copied from Ubuntu 24.04, except that `systemd-dev` is added to the build base as pkg-config needs it (the same change as Debian 13 Trixie).

## Related issue


## How has this been tested?

### Integration Tests

```bash
#!/bin/bash

export PROJECT=my-gcp-project
export TRANSFERS_BUCKET=my-test-bucket
export ZONES=asia-east1-b
export IMAGE_SPECS=ubuntu-os-cloud:ubuntu-2604-lts-amd64
export AGENT_PACKAGES_IN_GCS=gs://my-test-bucket/ops-agent-build/ubuntu/resolute
export NETWORK_NAME=default
export INSTANCE_SIZE=e2-standard-2

make integration_tests \
    PROJECT=${PROJECT} \
    TRANSFERS_BUCKET=${TRANSFERS_BUCKET} \
    ZONES=${ZONES} \
    IMAGE_SPECS=${IMAGE_SPECS} \
    AGENT_PACKAGES_IN_GCS=${AGENT_PACKAGES_IN_GCS} \
    NETWORK_NAME=${NETWORK_NAME} \
    INSTANCE_SIZE=${INSTANCE_SIZE}  \
    INTEGRATION_TEST_FILTER=".*" &> >(tee test.log)
```

<details>
<summary>Test Result</summary>

* Failed Tests:
    * `TestAppHubLogLabels`
    * `TestDefaultMetricsNoProxy`
    * `TestOTLPMetricsGCM`
    * `TestOTLPMetricsGMP`
    * `TestPrometheusMetrics`
* Skipped Tests:
    * `TestCustomStringConfigReceivedFromUAP`
    * `TestDefaultMetricsWithProxy`
    * `TestInvalidStringConfigReceivedFromUAP`
    * `TestKillChildJobsWhenPluginServerProcessTerminates`
    * `TestNetworkHealthCheck`
    * `TestOpsAgentSigning`
    * `TestOTLPLogsWithOtlpExporter`
    * `TestParsingFailureCheck`
    * `TestPluginGetStatusReturnsHealthyStatusOnSuccessfulOpsAgentStart`
    * `TestPluginGetStatusReturnsRPCErrorOnSubAgentTerminationWithNonZeroCode`
    * `TestPortsAndAPIHealthChecks`
    * `TestUpgradeOpsAgent`
    * `TestWindowsEventLog`
    * `TestWindowsEventLogV`
    * `TestWindowsEventLogWithNonDefaultTimeZone`
    * `TestWindowsLoggingAgentConflict`
    * `TestWindowsMonitoringAgentConflict`

</details>

<details>
<summary>Test Logs</summary>

```
ZONES="asia-east1-b" \
IMAGE_SPECS="ubuntu-os-cloud:ubuntu-2604-lts-amd64" \
go test -v ./integration_test/ops_agent_test/main_test.go \
-parallel=1000 \
-tags=integration_test \
-timeout=4h \
-run=".*"
2026/04/24 10:57:57 exit code: 0
2026/04/24 10:57:57 stdout+stderr: Generating public/private rsa key pair.
Your identification has been saved in /tmp/ssh_keys3560830802/gce_testing_key
Your public key has been saved in /tmp/ssh_keys3560830802/gce_testing_key.pub
The key fingerprint is:
SHA256:vL+GV0ASL+VN6rmJ7/ABN2f7SJlmXQHHhmle2kUCVGA test_user
The key's randomart image is:
+---[RSA 3072]----+
|        ....E=*o.|
|        .+.= +o=.|
|        .o+ + =..|
|       . o.. o ..|
|        S =.o   .|
|         = *.= . |
|        +.+.B .  |
|        .=o= o   |
|         +*.. .  |
+----[SHA256]-----+
2026/04/24 10:57:57 Detailed logs are in /tmp/1731616225
=== RUN   TestParseMultilineFileJava
=== PAUSE TestParseMultilineFileJava
=== RUN   TestParseMultilineFileJavaPython
=== PAUSE TestParseMultilineFileJavaPython
=== RUN   TestParseMultilineFileGolangJavaPython
=== PAUSE TestParseMultilineFileGolangJavaPython
=== RUN   TestParseMultilineFileMissingParser
=== PAUSE TestParseMultilineFileMissingParser
=== RUN   TestCustomLogFile
=== PAUSE TestCustomLogFile
=== RUN   TestPluginGetStatusReturnsHealthyStatusOnSuccessfulOpsAgentStart
=== PAUSE TestPluginGetStatusReturnsHealthyStatusOnSuccessfulOpsAgentStart
=== RUN   TestPluginGetStatusReturnsRPCErrorOnSubAgentTerminationWithNonZeroCode
=== PAUSE TestPluginGetStatusReturnsRPCErrorOnSubAgentTerminationWithNonZeroCode
=== RUN   TestKillChildJobsWhenPluginServerProcessTerminates
=== PAUSE TestKillChildJobsWhenPluginServerProcessTerminates
=== RUN   TestCustomLogFormat
=== PAUSE TestCustomLogFormat
=== RUN   TestHTTPRequestLog
=== PAUSE TestHTTPRequestLog
=== RUN   TestLogEntrySpecialFields
=== PAUSE TestLogEntrySpecialFields
=== RUN   TestInvalidConfig
=== PAUSE TestInvalidConfig
=== RUN   TestInvalidStringConfigReceivedFromUAP
=== PAUSE TestInvalidStringConfigReceivedFromUAP
=== RUN   TestCustomStringConfigReceivedFromUAP
=== PAUSE TestCustomStringConfigReceivedFromUAP
=== RUN   TestProcessorOrder
=== PAUSE TestProcessorOrder
=== RUN   TestSyslogTCP
=== PAUSE TestSyslogTCP
=== RUN   TestSyslogUDP
=== PAUSE TestSyslogUDP
=== RUN   TestExcludeLogs
=== PAUSE TestExcludeLogs
=== RUN   TestExcludeLogsParseJsonOrder
=== PAUSE TestExcludeLogsParseJsonOrder
=== RUN   TestExcludeLogsModifyFieldsOrder
=== PAUSE TestExcludeLogsModifyFieldsOrder
=== RUN   TestModifyFields
=== PAUSE TestModifyFields
=== RUN   TestParseWithConflictsWithRecord
=== PAUSE TestParseWithConflictsWithRecord
=== RUN   TestResourceNameLabel
=== PAUSE TestResourceNameLabel
=== RUN   TestLogFilePathLabel
=== PAUSE TestLogFilePathLabel
=== RUN   TestTCPLog
=== PAUSE TestTCPLog
=== RUN   TestFluentForwardLog
=== PAUSE TestFluentForwardLog
=== RUN   TestWindowsEventLog
=== PAUSE TestWindowsEventLog
=== RUN   TestWindowsEventLogV1UnsupportedChannel
=== PAUSE TestWindowsEventLogV1UnsupportedChannel
=== RUN   TestWindowsEventLogV2
=== PAUSE TestWindowsEventLogV2
=== RUN   TestWindowsEventLogWithNonDefaultTimeZone
=== PAUSE TestWindowsEventLogWithNonDefaultTimeZone
=== RUN   TestSystemdLog
=== PAUSE TestSystemdLog
=== RUN   TestSystemLogByDefault
=== PAUSE TestSystemLogByDefault
=== RUN   TestDefaultMetricsNoProxy
=== PAUSE TestDefaultMetricsNoProxy
=== RUN   TestDefaultMetricsWithProxy
=== PAUSE TestDefaultMetricsWithProxy
=== RUN   TestGoogleSecretManagerProvider
=== PAUSE TestGoogleSecretManagerProvider
=== RUN   TestPrometheusMetrics
=== PAUSE TestPrometheusMetrics
=== RUN   TestPrometheusMetricsWithMetadata
=== PAUSE TestPrometheusMetricsWithMetadata
=== RUN   TestPrometheusMetricsWithJSONExporter
=== PAUSE TestPrometheusMetricsWithJSONExporter
=== RUN   TestPrometheusRelabelConfigs
=== PAUSE TestPrometheusRelabelConfigs
=== RUN   TestPrometheusUntypedMetrics
=== PAUSE TestPrometheusUntypedMetrics
=== RUN   TestPrometheusUntypedMetricsReset
=== PAUSE TestPrometheusUntypedMetricsReset
=== RUN   TestPrometheusHistogramMetrics
=== PAUSE TestPrometheusHistogramMetrics
=== RUN   TestPrometheusSummaryMetrics
=== PAUSE TestPrometheusSummaryMetrics
=== RUN   TestExcludeMetrics
=== PAUSE TestExcludeMetrics
=== RUN   TestExcludeWorkloadMetrics
=== PAUSE TestExcludeWorkloadMetrics
=== RUN   TestMetricsAgentCrashRestart
=== PAUSE TestMetricsAgentCrashRestart
=== RUN   TestLoggingAgentCrashRestart
=== PAUSE TestLoggingAgentCrashRestart
=== RUN   TestLoggingSelfLogs
=== PAUSE TestLoggingSelfLogs
=== RUN   TestLoggingDataprocAttributes
=== PAUSE TestLoggingDataprocAttributes
=== RUN   TestWindowsLoggingAgentConflict
=== PAUSE TestWindowsLoggingAgentConflict
=== RUN   TestWindowsMonitoringAgentConflict
=== PAUSE TestWindowsMonitoringAgentConflict
=== RUN   TestUpgradeOpsAgent
=== PAUSE TestUpgradeOpsAgent
=== RUN   TestResourceDetectorOnGCE
=== PAUSE TestResourceDetectorOnGCE
=== RUN   TestOTLPMetricsGCM
=== PAUSE TestOTLPMetricsGCM
=== RUN   TestOTLPMetricsGMP
=== PAUSE TestOTLPMetricsGMP
=== RUN   TestOTLPTraces
=== PAUSE TestOTLPTraces
=== RUN   TestOTLPLogsWithOtlpExporter
=== PAUSE TestOTLPLogsWithOtlpExporter
=== RUN   TestPortsAndAPIHealthChecks
=== PAUSE TestPortsAndAPIHealthChecks
=== RUN   TestNetworkHealthCheck
=== PAUSE TestNetworkHealthCheck
=== RUN   TestParsingFailureCheck
=== PAUSE TestParsingFailureCheck
=== RUN   TestNoFluentBitDebugSelfLogs
=== PAUSE TestNoFluentBitDebugSelfLogs
=== RUN   TestDisableSelfLogCollection
=== PAUSE TestDisableSelfLogCollection
=== RUN   TestBufferLimitSizeOpsAgent
=== PAUSE TestBufferLimitSizeOpsAgent
=== RUN   TestNoNvmlOtelReceiverWithoutGpu
=== PAUSE TestNoNvmlOtelReceiverWithoutGpu
=== RUN   TestPartialSuccess
=== PAUSE TestPartialSuccess
=== RUN   TestRestartVM
=== PAUSE TestRestartVM
=== RUN   TestLogCompression
=== PAUSE TestLogCompression
=== RUN   TestFileOffset
=== PAUSE TestFileOffset
=== RUN   TestAppHubLogLabels
=== PAUSE TestAppHubLogLabels
=== RUN   TestOpsAgentSigning
=== PAUSE TestOpsAgentSigning
=== RUN   TestUninstallRemovesService
=== PAUSE TestUninstallRemovesService
=== CONT  TestParseMultilineFileJava
=== CONT  TestPrometheusMetricsWithMetadata
=== CONT  TestOTLPMetricsGMP
=== CONT  TestWindowsEventLogWithNonDefaultTimeZone
=== CONT  TestHTTPRequestLog
=== RUN   TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestFluentForwardLog
=== CONT  TestNoNvmlOtelReceiverWithoutGpu
=== CONT  TestExcludeLogsModifyFieldsOrder
=== CONT  TestLoggingAgentCrashRestart
=== RUN   TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestLoggingAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestNoNvmlOtelReceiverWithoutGpu/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestLoggingAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestLoggingAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeLogs
=== RUN   TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestNoNvmlOtelReceiverWithoutGpu/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestNoNvmlOtelReceiverWithoutGpu/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsEventLogV2
=== RUN   TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestGoogleSecretManagerProvider
=== CONT  TestDefaultMetricsWithProxy
=== RUN   TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestGoogleSecretManagerProvider/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestGoogleSecretManagerProvider/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestGoogleSecretManagerProvider/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestSystemLogByDefault
=== RUN   TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSystemdLog
=== RUN   TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSyslogUDP
=== RUN   TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSyslogTCP
=== RUN   TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestProcessorOrder
=== CONT  TestCustomStringConfigReceivedFromUAP
--- SKIP: TestCustomStringConfigReceivedFromUAP (0.00s)
=== CONT  TestInvalidStringConfigReceivedFromUAP
=== CONT  TestInvalidConfig
=== CONT  TestLogEntrySpecialFields
=== CONT  TestTCPLog
=== CONT  TestExcludeLogsParseJsonOrder
=== CONT  TestUninstallRemovesService
=== CONT  TestOpsAgentSigning
=== CONT  TestAppHubLogLabels
=== CONT  TestWindowsEventLog
=== CONT  TestFileOffset
=== CONT  TestLogCompression
=== CONT  TestPrometheusMetrics
=== CONT  TestRestartVM
=== CONT  TestPartialSuccess
=== CONT  TestCustomLogFormat
=== CONT  TestKillChildJobsWhenPluginServerProcessTerminates
=== CONT  TestWindowsEventLogV1UnsupportedChannel
=== CONT  TestPluginGetStatusReturnsRPCErrorOnSubAgentTerminationWithNonZeroCode
=== CONT  TestPluginGetStatusReturnsHealthyStatusOnSuccessfulOpsAgentStart
=== CONT  TestCustomLogFile
=== CONT  TestParseMultilineFileMissingParser
=== CONT  TestParseMultilineFileGolangJavaPython
=== CONT  TestParseWithConflictsWithRecord
=== CONT  TestLogFilePathLabel
=== CONT  TestModifyFields
=== PAUSE TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestMetricsAgentCrashRestart
=== CONT  TestExcludeWorkloadMetrics
=== CONT  TestOTLPMetricsGCM
=== CONT  TestParseMultilineFileJavaPython
=== CONT  TestResourceDetectorOnGCE
=== CONT  TestExcludeMetrics
=== CONT  TestPrometheusSummaryMetrics
=== CONT  TestResourceNameLabel
=== CONT  TestPrometheusHistogramMetrics
=== CONT  TestUpgradeOpsAgent
=== CONT  TestLoggingDataprocAttributes
=== CONT  TestLoggingSelfLogs
=== CONT  TestWindowsMonitoringAgentConflict
=== CONT  TestBufferLimitSizeOpsAgent
=== CONT  TestPrometheusUntypedMetricsReset
=== CONT  TestDisableSelfLogCollection
=== RUN   TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestDisableSelfLogCollection/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestDisableSelfLogCollection/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestResourceDetectorOnGCE/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestLogCompression/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestResourceDetectorOnGCE/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestResourceDetectorOnGCE/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestExcludeMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestExcludeMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestWindowsMonitoringAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestWindowsMonitoringAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsMonitoringAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestMetricsAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestMetricsAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestMetricsAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestDisableSelfLogCollection/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestLogCompression/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestLogCompression/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPortsAndAPIHealthChecks
=== RUN   TestPortsAndAPIHealthChecks/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPortsAndAPIHealthChecks/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPortsAndAPIHealthChecks/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOTLPLogsWithOtlpExporter
=== RUN   TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging,otlp_exporter
=== PAUSE TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging,otlp_exporter
=== RUN   TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging
=== PAUSE TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging
=== CONT  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:5247: This test requires otlp_logging+otlp_exporter experimental flags to be enabled
=== CONT  TestPrometheusRelabelConfigs
=== RUN   TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestNetworkHealthCheck
=== PAUSE TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestNetworkHealthCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestNetworkHealthCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestNetworkHealthCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestParseMultilineFileMissingParser/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestParseMultilineFileMissingParser/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParseMultilineFileMissingParser/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestInvalidConfig/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestInvalidConfig/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestInvalidConfig/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusUntypedMetrics
=== RUN   TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParsingFailureCheck
=== RUN   TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:2741: Proxy test is currently only supported on windows.
=== RUN   TestExcludeWorkloadMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestExcludeWorkloadMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeWorkloadMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    main_test.go:2741: Proxy test is currently only supported on windows.
=== RUN   TestParseMultilineFileJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestParseMultilineFileJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParseMultilineFileJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    main_test.go:2741: Proxy test is currently only supported on windows.
=== RUN   TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    main_test.go:2741: Proxy test is currently only supported on windows.
=== PAUSE TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestParseMultilineFileJava/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestParseMultilineFileJava/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParseMultilineFileJava/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestProcessorOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestProcessorOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestProcessorOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestTCPLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestTCPLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestTCPLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestOpsAgentSigning/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestOpsAgentSigning/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOpsAgentSigning/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:6059: This test only applies to RPM-based or Windows OSes.
=== RUN   TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestUninstallRemovesService/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestUninstallRemovesService/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestUninstallRemovesService/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
--- SKIP: TestKillChildJobsWhenPluginServerProcessTerminates (0.00s)
--- SKIP: TestPluginGetStatusReturnsRPCErrorOnSubAgentTerminationWithNonZeroCode (0.00s)
--- SKIP: TestPluginGetStatusReturnsHealthyStatusOnSuccessfulOpsAgentStart (0.00s)
--- PASS: TestWindowsMonitoringAgentConflict (0.00s)
    --- SKIP: TestWindowsMonitoringAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
=== RUN   TestAppHubLogLabels/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestAppHubLogLabels/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestAppHubLogLabels/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
--- PASS: TestPortsAndAPIHealthChecks (0.00s)
    --- SKIP: TestPortsAndAPIHealthChecks/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
--- PASS: TestNetworkHealthCheck (0.00s)
    --- SKIP: TestNetworkHealthCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
--- PASS: TestWindowsEventLog (0.00s)
    --- PASS: TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- SKIP: TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (0.00s)
        --- SKIP: TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (0.00s)
        --- SKIP: TestWindowsEventLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (0.00s)
--- SKIP: TestInvalidStringConfigReceivedFromUAP (0.00s)
--- PASS: TestDefaultMetricsWithProxy (0.00s)
    --- PASS: TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.02s)
        --- SKIP: TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (0.00s)
        --- SKIP: TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (0.00s)
        --- SKIP: TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (0.00s)
        --- SKIP: TestDefaultMetricsWithProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (0.00s)
--- PASS: TestWindowsEventLogV1UnsupportedChannel (0.02s)
    --- PASS: TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- SKIP: TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (0.00s)
        --- SKIP: TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (0.00s)
        --- SKIP: TestWindowsEventLogV1UnsupportedChannel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (0.00s)
--- PASS: TestOpsAgentSigning (0.03s)
    --- SKIP: TestOpsAgentSigning/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
=== CONT  TestNoFluentBitDebugSelfLogs
=== RUN   TestNoFluentBitDebugSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestNoFluentBitDebugSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestNoFluentBitDebugSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsNoProxy
=== RUN   TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestLogEntrySpecialFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestLogEntrySpecialFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestLogEntrySpecialFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestParseMultilineFileGolangJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestParseMultilineFileGolangJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParseMultilineFileGolangJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestParseWithConflictsWithRecord/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestParseWithConflictsWithRecord/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParseWithConflictsWithRecord/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestRestartVM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestRestartVM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestRestartVM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestPartialSuccess/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPartialSuccess/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPartialSuccess/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestParsingFailureCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging,otlp_exporter
=== CONT  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging
=== CONT  TestPrometheusMetricsWithJSONExporter
=== RUN   TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsLoggingAgentConflict
=== CONT  TestOTLPTraces
=== PAUSE TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64
--- PASS: TestWindowsEventLogV2 (0.00s)
    --- PASS: TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- SKIP: TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (0.00s)
        --- SKIP: TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (0.00s)
        --- SKIP: TestWindowsEventLogV2/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (0.00s)
=== RUN   TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestResourceNameLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestResourceNameLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestResourceNameLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestParsingFailureCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestParsingFailureCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64
--- PASS: TestParsingFailureCheck (0.11s)
    --- SKIP: TestParsingFailureCheck/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
=== RUN   TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== RUN   TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== RUN   TestLoggingDataprocAttributes/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestLoggingDataprocAttributes/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestLoggingDataprocAttributes/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestLoggingSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestLoggingSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestLoggingSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== CONT  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== PAUSE TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== CONT  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
=== PAUSE TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== RUN   TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== PAUSE TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== RUN   TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
--- PASS: TestWindowsEventLogWithNonDefaultTimeZone (0.15s)
    --- PASS: TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- SKIP: TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (0.00s)
        --- SKIP: TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (0.00s)
        --- SKIP: TestWindowsEventLogWithNonDefaultTimeZone/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (0.00s)
=== PAUSE TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestWindowsLoggingAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestWindowsLoggingAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestWindowsLoggingAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64
--- PASS: TestWindowsLoggingAgentConflict (0.00s)
    --- SKIP: TestWindowsLoggingAgentConflict/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
=== RUN   TestOTLPTraces/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== PAUSE TestOTLPTraces/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== CONT  TestOTLPTraces/ubuntu-os-cloud:ubuntu-2604-lts-amd64
=== RUN   TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== PAUSE TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
=== CONT  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
=== CONT  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
=== NAME  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestSystemdLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestResourceDetectorOnGCE/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestResourceDetectorOnGCE_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestFluentForwardLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestBufferLimitSizeOpsAgent_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestLogEntrySpecialFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestLogEntrySpecialFields_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestOTLPMetricsGCM_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestSystemLogByDefault_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestNoNvmlOtelReceiverWithoutGpu/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestNoNvmlOtelReceiverWithoutGpu_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusHistogramMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestOTLPTraces/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestOTLPTraces_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestParseMultilineFileJava/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestParseMultilineFileJava_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestExcludeWorkloadMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeWorkloadMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusRelabelConfigs_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestBufferLimitSizeOpsAgent_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestCustomLogFile_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestCustomLogFormat_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogs_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusMetricsWithJSONExporter_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestInvalidConfig/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestInvalidConfig_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestBufferLimitSizeOpsAgent_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    main_test.go:3098: Test logs: /tmp/1731616225/TestPrometheusMetricsWithMetadata_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestParseWithConflictsWithRecord/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestParseWithConflictsWithRecord_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestLoggingDataprocAttributes/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:4427: Test logs: /tmp/1731616225/TestLoggingDataprocAttributes_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestSyslogUDP_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestDefaultMetricsNoProxy_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogsParseJsonOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestModifyFields_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestParseMultilineFileJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestParseMultilineFileJavaPython_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusUntypedMetricsReset_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestPartialSuccess/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestPartialSuccess_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestOTLPLogsWithOtlpExporter_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_logging,otlp_exporter 
=== NAME  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogsParseJsonOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusUntypedMetricsReset_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusHistogramMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestSyslogTCP_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestSyslogUDP_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusUntypedMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogsModifyFieldsOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestLoggingSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestLoggingSelfLogs_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogs_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusSummaryMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogs_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogsParseJsonOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestRestartVM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestRestartVM_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusMetricsWithJSONExporter_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestCustomLogFile_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestLogFilePathLabel_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestDefaultMetricsNoProxy_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestDefaultMetricsNoProxy_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusRelabelConfigs_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestFileOffset_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestFileOffset_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusUntypedMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestSyslogUDP_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestSystemdLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogsModifyFieldsOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestUninstallRemovesService/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestUninstallRemovesService_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestSystemdLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeLogsModifyFieldsOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestCustomLogFormat_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestOTLPMetricsGMP_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:3098: Test logs: /tmp/1731616225/TestPrometheusMetricsWithMetadata_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestCustomLogFormat_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestMetricsAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestMetricsAgentCrashRestart_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestTCPLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestTCPLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestSyslogTCP_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestResourceNameLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestResourceNameLabel_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestNoFluentBitDebugSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestNoFluentBitDebugSelfLogs_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestOTLPMetricsGCM_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestLogFilePathLabel_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestLoggingAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestLoggingAgentCrashRestart_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestFileOffset_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestFluentForwardLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestParseMultilineFileGolangJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestParseMultilineFileGolangJavaPython_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestUpgradeOpsAgent_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestCustomLogFile_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestLogCompression/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestLogCompression_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestSystemLogByDefault_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestSystemLogByDefault_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestGoogleSecretManagerProvider/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestGoogleSecretManagerProvider_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestDefaultMetricsNoProxy_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestAppHubLogLabels/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:188: Test logs: /tmp/1731616225/TestAppHubLogLabels_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestFluentForwardLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Test logs: /tmp/1731616225/TestModifyFields_ubuntu-os-cloud:ubuntu-2604-lts-amd64_default 
=== NAME  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestOTLPLogsWithOtlpExporter_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_logging 
=== NAME  TestParseMultilineFileMissingParser/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestParseMultilineFileMissingParser_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestDisableSelfLogCollection/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestDisableSelfLogCollection_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestPrometheusSummaryMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otlp_exporter 
=== NAME  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Test logs: /tmp/1731616225/TestSyslogTCP_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging,otlp_exporter 
=== NAME  TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestHTTPRequestLog_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestProcessorOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestProcessorOrder_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestExcludeMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Test logs: /tmp/1731616225/TestExcludeMetrics_ubuntu-os-cloud:ubuntu-2604-lts-amd64 
=== NAME  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Test logs: /tmp/1731616225/TestLogFilePathLabel_ubuntu-os-cloud:ubuntu-2604-lts-amd64_otel_logging 
=== NAME  TestResourceDetectorOnGCE/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLogEntrySpecialFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestParseWithConflictsWithRecord/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    main_test.go:3098: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestInvalidConfig/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestProcessorOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestOTLPTraces/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestParseMultilineFileMissingParser/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestUninstallRemovesService/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLoggingSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestTCPLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestGoogleSecretManagerProvider/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestParseMultilineFileJava/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:3098: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestRestartVM/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestNoNvmlOtelReceiverWithoutGpu/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestParseMultilineFileGolangJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLoggingDataprocAttributes/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:4427: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestMetricsAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLoggingAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestParseMultilineFileJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestNoFluentBitDebugSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPartialSuccess/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestDisableSelfLogCollection/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestExcludeWorkloadMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestResourceNameLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestLogCompression/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    agents.go:1029: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
=== NAME  TestAppHubLogLabels/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:188: Instance Log: https://console.cloud.google.com/logs/viewer?resource=gce_instance%2Finstance_id%2F[MASKED]&project=[MASKED]
    main_test.go:6008: Command failed: [gcloud apphub applications workloads create test-20260424-3b0c0-504a3069-c2a3-4e3b-9661-1542fa-wl --application=ops-agent-app-hub-integration-test-app --project=[MASKED] --location=global --discovered-workload=projects/[MASKED]/locations/asia-east1/discoveredWorkloads/apphub-00000000-0000-0000-d4b9-f3d505101d2b
         --format=json]
        exit status 1
        stdout+stderr: ERROR: (gcloud.apphub.applications.workloads.create) NOT_FOUND: Resource 'parent resource not found for projects/[MASKED]/locations/global/applications/ops-agent-app-hub-integration-test-app/workloads/test-20260424-3b0c0-504a3069-c2a3-4e3b-9661-1542fa-wl' was not found. This command is authenticated as [MASKED] which is the active account specified by the [core/account] property
        - '@type': type.googleapis.com/google.rpc.ResourceInfo
          resourceName: parent resource not found for projects/[MASKED]/locations/global/applications/ops-agent-app-hub-integration-test-app/workloads/test-20260424-3b0c0-504a3069-c2a3-4e3b-9661-1542fa-wl
        
=== NAME  TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:4524: Installing stable agent failed with error InstallOpsAgent() error running repo script: Command failed: sudo  bash -x add-google-cloud-ops-agent-repo.sh --also-install
        Command failed: [ssh test_user@35.187.153.87 -oIdentityFile=/tmp/ssh_keys3560830802/gce_testing_key -oConnectTimeout=120 -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR -oPreferredAuthentications=publickey sudo  bash -x add-google-cloud-ops-agent-repo.sh --also-install]
        exit status 1
        stdout+stderr: + CHANGED=0
        + ACTIONS=()
        + declare -a ACTIONS
        + DRY_RUN=
        + VERBOSE=false
        + getopts -- -: OPTCHAR
        + case "${OPTCHAR}" in
        + case "${OPTARG}" in
        + ACTIONS+=('also-install')
        + getopts -- -: OPTCHAR
        + [[  also-install  == * uninstall * ]]
        + [[  also-install  == * remove-repo * ]]
        + ACTIONS+=('add-repo')
        + readarray -t ACTIONS
        ++ printf '%s\n' also-install add-repo
        ++ sort
        + readonly ACTIONS DRY_RUN VERBOSE
        + [[  add-repo also-install  == * also-install*uninstall * ]]
        + [[ false == true ]]
        + REPO_HOST=packages.cloud.google.com
        + ARTIFACT_REGISTRY_PROJECT=cloud-ops-agents-artifacts-dev
        + AGENT_DOCS_URL=https://cloud.google.com/stackdriver/docs/solutions/ops-agent
        + AGENT_SUPPORTED_URL=https://cloud.google.com/stackdriver/docs/solutions/ops-agent/#supported_operating_systems
        + AGENT_PACKAGE=google-cloud-ops-agent
        + ADDITIONAL_PACKAGES=()
        + declare -a ADDITIONAL_PACKAGES
        + [[ -f /etc/os-release ]]
        + . /etc/os-release
        ++ PRETTY_NAME='Ubuntu 26.04 LTS'
        ++ NAME=Ubuntu
        ++ VERSION_ID=26.04
        ++ VERSION='26.04 (Resolute Raccoon)'
        ++ VERSION_CODENAME=resolute
        ++ ID=ubuntu
        ++ ID_LIKE=debian
        ++ HOME_URL=https://www.ubuntu.com/
        ++ SUPPORT_URL=https://help.ubuntu.com/
        ++ BUG_REPORT_URL=https://bugs.launchpad.net/ubuntu/
        ++ PRIVACY_POLICY_URL=https://www.ubuntu.com/legal/terms-and-policies/privacy-policy
        ++ UBUNTU_CODENAME=resolute
        ++ LOGO=ubuntu-logo
        + main --also-install
        + case "${ID:-}" in
        + handle_debian
        + EXTRA_OPTS=()
        + declare -a EXTRA_OPTS
        + [[ false == true ]]
        + [[  add-repo also-install  == * uninstall-standalone-logging-agent * ]]
        + [[  add-repo also-install  == * uninstall-standalone-monitoring-agent * ]]
        + [[  add-repo also-install  == * add-repo * ]]
        + resolve_version
        + [[ latest == latest ]]
        + AGENT_VERSION=
        + add_repo
        + [[ -n '' ]]
        + lsb_release -v
        ++ dpkg -l apt-transport-https
        ++ grep -o '^[a-z][a-z]'
        + [[ un == ii ]]
        + run_with_retry apt_get_update
        + local RETRY_LIMIT=3
        + local EXIT_CODE=0
        ++ seq 1 3
        + for count in $(seq 1 "${RETRY_LIMIT}")
        + apt_get_update
        + apt-get -o DPkg::Lock::Timeout=-1 install
        Reading package lists...
        Building dependency tree...
        Reading state information...
        Solving dependencies...
        + apt-get update
        0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
        Get:1 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute InRelease [136 kB]
        Hit:2 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-updates InRelease
        Get:3 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports InRelease [136 kB]
        Get:4 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/main amd64v3 Packages [1483 kB]
        Get:5 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/main Translation-en [524 kB]
        Get:6 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/main amd64 Components [395 kB]
        Get:7 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/main amd64 c-n-f Metadata [32.4 kB]
        Hit:8 http://security.ubuntu.com/ubuntu resolute-security InRelease
        Get:9 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/universe amd64v3 Packages [16.3 MB]
        Get:10 http://security.ubuntu.com/ubuntu resolute-security/universe amd64 Components [212 B]
        Get:11 http://security.ubuntu.com/ubuntu resolute-security/universe amd64 c-n-f Metadata [116 B]
        Get:12 http://security.ubuntu.com/ubuntu resolute-security/multiverse amd64 Components [212 B]
        Get:13 http://security.ubuntu.com/ubuntu resolute-security/multiverse amd64 c-n-f Metadata [120 B]
        Get:14 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/universe Translation-en [6329 kB]
        Get:15 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/universe amd64 Components [4556 kB]
        Get:16 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/universe amd64 c-n-f Metadata [313 kB]
        Get:17 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/restricted amd64v3 Packages [152 kB]
        Get:18 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/restricted amd64 Components [556 B]
        Get:19 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/multiverse amd64v3 Packages [291 kB]
        Get:20 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/multiverse Translation-en [127 kB]
        Get:21 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/multiverse amd64 Components [50.0 kB]
        Get:22 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/multiverse amd64 c-n-f Metadata [8276 B]
        Get:23 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-updates/universe amd64 Components [212 B]
        Get:24 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-updates/universe amd64 c-n-f Metadata [116 B]
        Get:25 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-updates/multiverse amd64 Components [216 B]
        Get:26 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-updates/multiverse amd64 c-n-f Metadata [116 B]
        Get:27 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/main amd64 Components [212 B]
        Get:28 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/main amd64 c-n-f Metadata [112 B]
        Get:29 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/universe amd64 Components [216 B]
        Get:30 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/universe amd64 c-n-f Metadata [116 B]
        Get:31 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/restricted amd64 Components [216 B]
        Get:32 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/restricted amd64 c-n-f Metadata [120 B]
        Get:33 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/multiverse amd64 Components [216 B]
        Get:34 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute-backports/multiverse amd64 c-n-f Metadata [120 B]
        Fetched 30.8 MB in 5s (6302 kB/s)
        Reading package lists...
        + return 0
        + apt-get -y install apt-transport-https
        Reading package lists...
        Building dependency tree...
        Reading state information...
        Solving dependencies...
        The following NEW packages will be installed:
          apt-transport-https
        0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.
        Need to get 3928 B of archives.
        After this operation, 36.9 kB of additional disk space will be used.
        Get:1 http://asia-east1.gce.archive.ubuntu.com/ubuntu resolute/universe amd64v3 apt-transport-https all 3.2.0 [3928 B]
        debconf: unable to initialize frontend: Dialog
        debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
        debconf: falling back to frontend: Readline
        debconf: unable to initialize frontend: Readline
        debconf: (This frontend requires a controlling tty.)
        debconf: falling back to frontend: Teletype
        debconf: unable to initialize frontend: Teletype
        debconf: (This frontend requires a controlling tty.)
        debconf: falling back to frontend: Noninteractive
        Fetched 3928 B in 0s (17.9 kB/s)
        Selecting previously unselected package apt-transport-https.
        (Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 86466 files and directories currently installed.)
        Preparing to unpack .../apt-transport-https_3.2.0_all.deb ...
        Unpacking apt-transport-https (3.2.0) ...
        Setting up apt-transport-https (3.2.0) ...
        debconf: unable to initialize frontend: Dialog
        debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
        debconf: falling back to frontend: Readline
        debconf: unable to initialize frontend: Readline
        debconf: (This frontend requires a controlling tty.)
        debconf: falling back to frontend: Teletype
        debconf: unable to initialize frontend: Teletype
        debconf: (This frontend requires a controlling tty.)
        debconf: falling back to frontend: Noninteractive
        
        Running kernel seems to be up-to-date.
        
        No services need to be restarted.
        
        No containers need to be restarted.
        
        No user sessions are running outdated binaries.
        
        No VM guests are running outdated hypervisor (qemu) binaries on this host.
        + CHANGED=1
        ++ dpkg -l ca-certificates
        ++ grep -o '^[a-z][a-z]'
        + [[ ii == ii ]]
        ++ dpkg -l gnupg
        ++ grep -o '^[a-z][a-z]'
        + [[ ii == ii ]]
        ++ lsb_release -sc
        + local CODENAME=resolute
        + local KEYRING_PATH=/etc/apt/keyrings/google-cloud-ops-agent.asc
        + local REPO_NAME=google-cloud-ops-agent-resolute-all
        + local REPO_URL
        + [[ -n '' ]]
        + REPO_URL=https://packages.cloud.google.com/apt
        + local USE_SIGNEDBY=0
        ++ dpkg-query '--showformat=${Version}' --show apt
        + dpkg --compare-versions 3.2.0 ge 2.9.17
        + USE_SIGNEDBY=1
        + [[ 1 == 1 ]]
        + REPO_DATA='deb [signed-by=/etc/apt/keyrings/google-cloud-ops-agent.asc] https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all main'
        + cmp -s - /etc/apt/sources.list.d/google-cloud-ops-agent.list
        + echo 'Adding agent repository for ubuntu.'
        + tee /etc/apt/sources.list.d/google-cloud-ops-agent.list
        Adding agent repository for ubuntu.
        + CHANGED=1
        + add_key https://packages.cloud.google.com/apt/doc/apt-key.gpg
        + [[ 1 == 1 ]]
        + curl --connect-timeout 5 --silent --fail https://packages.cloud.google.com/apt/doc/apt-key.gpg
        deb [signed-by=/etc/apt/keyrings/google-cloud-ops-agent.asc] https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all main
        + CHANGED=1
        + [[ ubuntu == ubuntu ]]
        + [[ -n '' ]]
        + run_with_retry apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + local RETRY_LIMIT=3
        + local EXIT_CODE=0
        ++ seq 1 3
        + for count in $(seq 1 "${RETRY_LIMIT}")
        + apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + apt-get -o DPkg::Lock::Timeout=-1 install
        Reading package lists...
        Building dependency tree...
        Reading state information...
        Solving dependencies...
        0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
        + apt-get update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        Ign:1 https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all InRelease
        Err:2 https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all Release
          404  Not Found [IP: 74.125.203.138 443]
        Reading package lists...
        E: The repository 'https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all Release' does not have a Release file.
        + EXIT_CODE=100
        + echo 'Attempt 1 of 3 failed. Command:' apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        Attempt 1 of 3 failed. Command: apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + for count in $(seq 1 "${RETRY_LIMIT}")
        + apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + apt-get -o DPkg::Lock::Timeout=-1 install
        Reading package lists...
        Building dependency tree...
        Reading state information...
        Solving dependencies...
        0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
        + apt-get update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        Ign:1 https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all InRelease
        Err:2 https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all Release
          404  Not Found [IP: 74.125.203.102 443]
        Reading package lists...
        E: The repository 'https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all Release' does not have a Release file.
        + EXIT_CODE=100
        + echo 'Attempt 2 of 3 failed. Command:' apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        Attempt 2 of 3 failed. Command: apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + for count in $(seq 1 "${RETRY_LIMIT}")
        + apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + apt-get -o DPkg::Lock::Timeout=-1 install
        Reading package lists...
        Building dependency tree...
        Reading state information...
        Solving dependencies...
        0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
        + apt-get update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        Ign:1 https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all InRelease
        Err:2 https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all Release
          404  Not Found [IP: 74.125.203.138 443]
        Reading package lists...E: The repository 'https://packages.cloud.google.com/apt google-cloud-ops-agent-resolute-all Release' does not have a Release file.
        + EXIT_CODE=100
        + echo 'Attempt 3 of 3 failed. Command:' apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        Attempt 3 of 3 failed. Command: apt_get_update -o Dir::Etc::sourcelist=sources.list.d/google-cloud-ops-agent.list -o Dir::Etc::sourceparts=-
        + return 100
        + refresh_failed apt ubuntu
        + local REPO_TYPE=apt
        + local OS_FAMILY=ubuntu
        + fail $'Could not refresh the google-cloud-ops-agent apt repositories.\nPlease check your network connectivity and make sure you are running a supported\nubuntu distribution. See https://cloud.google.com/stackdriver/docs/solutions/ops-agent/#supported_operating_systems\nfor a list of supported platforms.'
        ++ date +%Y-%m-%dT%H:%M:%S%z
        
        + echo $'[2026-04-24T03:00:24+0000] Could not refresh the google-cloud-ops-agent apt repositories.\nPlease check your network connectivity and make sure you are running a supported\nubuntu distribution. See https://cloud.google.com/stackdriver/docs/solutions/ops-agent/#supported_operating_systems\nfor a list of supported platforms.'
        [2026-04-24T03:00:24+0000] Could not refresh the google-cloud-ops-agent apt repositories.
        Please check your network connectivity and make sure you are running a supported
        ubuntu distribution. See https://cloud.google.com/stackdriver/docs/solutions/ops-agent/#supported_operating_systems
        for a list of supported platforms.
        + exit 1
        ; assuming first release.
=== RUN   TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/parse_new_HTTPRequest_key
=== PAUSE TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/parse_new_HTTPRequest_key
=== RUN   TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/don't_parse_old_HTTPRequest_key
=== PAUSE TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/don't_parse_old_HTTPRequest_key
=== CONT  TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/parse_new_HTTPRequest_key
=== CONT  TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/don't_parse_old_HTTPRequest_key
--- PASS: TestInvalidConfig (0.00s)
    --- PASS: TestInvalidConfig/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (198.68s)
--- PASS: TestUpgradeOpsAgent (0.01s)
    --- SKIP: TestUpgradeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (207.75s)
--- FAIL: TestAppHubLogLabels (0.03s)
    --- FAIL: TestAppHubLogLabels/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (218.33s)
--- PASS: TestNoFluentBitDebugSelfLogs (0.00s)
    --- PASS: TestNoFluentBitDebugSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (219.73s)
--- PASS: TestParseMultilineFileMissingParser (0.00s)
    --- PASS: TestParseMultilineFileMissingParser/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (221.19s)
--- PASS: TestNoNvmlOtelReceiverWithoutGpu (0.00s)
    --- PASS: TestNoNvmlOtelReceiverWithoutGpu/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (222.56s)
--- PASS: TestPartialSuccess (0.07s)
    --- PASS: TestPartialSuccess/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (223.70s)
--- PASS: TestParseMultilineFileJavaPython (0.01s)
    --- PASS: TestParseMultilineFileJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (230.48s)
--- PASS: TestResourceDetectorOnGCE (0.00s)
    --- PASS: TestResourceDetectorOnGCE/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (234.75s)
--- PASS: TestSyslogUDP (0.00s)
    --- PASS: TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.03s)
        --- PASS: TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (246.53s)
        --- PASS: TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (248.13s)
        --- PASS: TestSyslogUDP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (250.03s)
--- PASS: TestParseMultilineFileJava (0.02s)
    --- PASS: TestParseMultilineFileJava/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (253.65s)
--- PASS: TestLoggingAgentCrashRestart (0.00s)
    --- PASS: TestLoggingAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (254.53s)
--- PASS: TestParseMultilineFileGolangJavaPython (0.00s)
    --- PASS: TestParseMultilineFileGolangJavaPython/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (254.71s)
--- PASS: TestLoggingDataprocAttributes (0.01s)
    --- PASS: TestLoggingDataprocAttributes/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (254.77s)
--- PASS: TestSystemLogByDefault (0.00s)
    --- PASS: TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.02s)
        --- PASS: TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (256.54s)
        --- PASS: TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (257.39s)
        --- PASS: TestSystemLogByDefault/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (262.13s)
--- PASS: TestFluentForwardLog (0.00s)
    --- PASS: TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.20s)
        --- PASS: TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (258.37s)
        --- PASS: TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (263.36s)
        --- PASS: TestFluentForwardLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (264.03s)
--- PASS: TestLogEntrySpecialFields (0.03s)
    --- PASS: TestLogEntrySpecialFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (271.81s)
--- PASS: TestParseWithConflictsWithRecord (0.00s)
    --- PASS: TestParseWithConflictsWithRecord/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (276.65s)
--- PASS: TestLogFilePathLabel (0.00s)
    --- PASS: TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (255.28s)
        --- PASS: TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (256.59s)
        --- PASS: TestLogFilePathLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (281.15s)
--- PASS: TestTCPLog (0.03s)
    --- PASS: TestTCPLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (281.48s)
--- PASS: TestProcessorOrder (0.03s)
    --- PASS: TestProcessorOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (281.78s)
--- PASS: TestModifyFields (0.01s)
    --- PASS: TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (253.92s)
        --- PASS: TestModifyFields/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (282.24s)
--- PASS: TestHTTPRequestLog (0.00s)
    --- PASS: TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (222.28s)
        --- PASS: TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/parse_new_HTTPRequest_key (62.56s)
        --- PASS: TestHTTPRequestLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/don't_parse_old_HTTPRequest_key (62.63s)
--- PASS: TestResourceNameLabel (0.00s)
    --- PASS: TestResourceNameLabel/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (290.91s)
--- PASS: TestCustomLogFormat (0.07s)
    --- PASS: TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (248.84s)
        --- PASS: TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (264.83s)
        --- PASS: TestCustomLogFormat/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (292.48s)
--- PASS: TestLogCompression (0.01s)
    --- PASS: TestLogCompression/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (292.57s)
--- PASS: TestOTLPTraces (0.00s)
    --- PASS: TestOTLPTraces/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (295.55s)
--- PASS: TestSystemdLog (0.00s)
    --- PASS: TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (312.42s)
        --- PASS: TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (320.95s)
        --- PASS: TestSystemdLog/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (321.96s)
--- PASS: TestUninstallRemovesService (0.03s)
    --- PASS: TestUninstallRemovesService/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (327.78s)
--- PASS: TestOTLPLogsWithOtlpExporter (0.00s)
    --- PASS: TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- SKIP: TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (0.00s)
        --- PASS: TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging (343.07s)
        --- PASS: TestOTLPLogsWithOtlpExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_logging,otlp_exporter (344.62s)
--- PASS: TestDisableSelfLogCollection (0.00s)
    --- PASS: TestDisableSelfLogCollection/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (348.11s)
--- PASS: TestRestartVM (0.06s)
    --- PASS: TestRestartVM/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (365.26s)
--- PASS: TestGoogleSecretManagerProvider (0.00s)
    --- PASS: TestGoogleSecretManagerProvider/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (393.69s)
--- PASS: TestExcludeMetrics (0.00s)
    --- PASS: TestExcludeMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (398.46s)
--- PASS: TestPrometheusMetricsWithMetadata (0.01s)
    --- PASS: TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.02s)
        --- PASS: TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (396.00s)
        --- PASS: TestPrometheusMetricsWithMetadata/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (400.12s)
--- PASS: TestMetricsAgentCrashRestart (0.00s)
    --- PASS: TestMetricsAgentCrashRestart/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (403.42s)
--- PASS: TestFileOffset (0.00s)
    --- PASS: TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (347.02s)
        --- PASS: TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (357.52s)
        --- PASS: TestFileOffset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (437.96s)
--- PASS: TestPrometheusRelabelConfigs (0.00s)
    --- PASS: TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (471.56s)
        --- PASS: TestPrometheusRelabelConfigs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (477.70s)
--- PASS: TestExcludeWorkloadMetrics (0.00s)
    --- PASS: TestExcludeWorkloadMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (485.44s)
--- PASS: TestPrometheusMetricsWithJSONExporter (0.00s)
    --- PASS: TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.02s)
        --- PASS: TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (497.35s)
        --- PASS: TestPrometheusMetricsWithJSONExporter/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (504.37s)
--- PASS: TestCustomLogFile (0.00s)
    --- PASS: TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (493.14s)
        --- PASS: TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (499.78s)
        --- PASS: TestCustomLogFile/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (505.37s)
--- PASS: TestExcludeLogs (0.00s)
    --- PASS: TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (474.63s)
        --- PASS: TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (500.54s)
        --- PASS: TestExcludeLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (533.06s)
--- PASS: TestSyslogTCP (0.02s)
    --- PASS: TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (463.04s)
        --- PASS: TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (485.81s)
        --- PASS: TestSyslogTCP/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (555.06s)
--- PASS: TestExcludeLogsParseJsonOrder (0.03s)
    --- PASS: TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (466.61s)
        --- PASS: TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (499.39s)
        --- PASS: TestExcludeLogsParseJsonOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (567.32s)
--- PASS: TestPrometheusUntypedMetrics (0.07s)
    --- PASS: TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.03s)
        --- PASS: TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (580.62s)
        --- PASS: TestPrometheusUntypedMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (594.51s)
--- PASS: TestBufferLimitSizeOpsAgent (0.00s)
    --- PASS: TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (646.35s)
        --- PASS: TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (649.70s)
        --- PASS: TestBufferLimitSizeOpsAgent/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (652.76s)
--- PASS: TestPrometheusSummaryMetrics (0.00s)
    --- PASS: TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (655.89s)
        --- PASS: TestPrometheusSummaryMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (661.28s)
--- PASS: TestExcludeLogsModifyFieldsOrder (0.01s)
    --- PASS: TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.10s)
        --- PASS: TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (628.95s)
        --- PASS: TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (635.35s)
        --- PASS: TestExcludeLogsModifyFieldsOrder/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (662.40s)
--- PASS: TestPrometheusHistogramMetrics (0.01s)
    --- PASS: TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- PASS: TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (652.04s)
        --- PASS: TestPrometheusHistogramMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (692.17s)
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:2707: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter
    main_test.go:2707: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging
    main_test.go:2707: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    main_test.go:3080: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:3080: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64
    main_test.go:5181: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default
    main_test.go:4971: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    main_test.go:2707: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
=== NAME  TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter
    main_test.go:4971: WaitForMetricSeries(metric=agent.googleapis.com/agent/internal/ops/feature_tracking, extraFilters=[]) failed: exhausted retries
--- FAIL: TestPrometheusMetrics (0.04s)
    --- FAIL: TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- FAIL: TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (800.45s)
        --- FAIL: TestPrometheusMetrics/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (806.82s)
--- PASS: TestLoggingSelfLogs (0.02s)
    --- PASS: TestLoggingSelfLogs/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (817.35s)
--- FAIL: TestOTLPMetricsGMP (0.18s)
    --- FAIL: TestOTLPMetricsGMP/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (826.16s)
--- FAIL: TestDefaultMetricsNoProxy (0.00s)
    --- FAIL: TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- FAIL: TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (778.72s)
        --- FAIL: TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging,otlp_exporter (797.71s)
        --- FAIL: TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otel_logging (798.98s)
        --- FAIL: TestDefaultMetricsNoProxy/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (844.15s)
--- FAIL: TestOTLPMetricsGCM (0.00s)
    --- FAIL: TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.00s)
        --- FAIL: TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (826.42s)
        --- FAIL: TestOTLPMetricsGCM/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (850.06s)
--- PASS: TestPrometheusUntypedMetricsReset (0.10s)
    --- PASS: TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64 (0.01s)
        --- PASS: TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/otlp_exporter (1022.68s)
        --- PASS: TestPrometheusUntypedMetricsReset/ubuntu-os-cloud:ubuntu-2604-lts-amd64/default (1033.92s)
FAIL
FAIL	command-line-arguments	1034.125s
FAIL
make: *** [Makefile:174: integration_tests] Error 1

```

</details>

> During the testing, I've found integration tests has issue fetching metric data possibly due to incorrect metric
> filter. I've reported this problem at [GoogleCloudPlatform/opentelemetry-operations-collector#551](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/issues/551).

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [x] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
