### PR TITLE
Exclude oracle- distros from detector

### DIFF
--- a/cloudbuild/new-distro-detector/run.sh
+++ b/cloudbuild/new-distro-detector/run.sh
@@ -23,6 +23,7 @@ set -o pipefail
 PATTERNS_FILE="irrelevant_family_patterns.txt"
 echo '^cos-
 ^fedora-
+^oracle-
 ^rocky-linux-[0-9]+-optimized-gcp
 ^sql-
 ^ubuntu-pro-


### PR DESCRIPTION
## Description
Update the irrelevant_family_patterns to exclude Oracle Linux. 

## Related issue
[b/457816765](http://b/457816765)

## How has this been tested?
N/A

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [x] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [x] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [x] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
