### PR TITLE
Fixing duplicated timeseries when using otlp_http exporters

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -400,6 +400,11 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 			otel.SetName("otel_log_entry_retry_count", "agent/log_entry_retry_count"),
 			otel.SetName("otel_request_count", "agent/request_count"),
 		),
+		otel.MetricsTransform(
+			otel.CombineMetrics(`^agent/log_entry_count$`, "agent/log_entry_count", otel.AggregateLabels("sum", "response_code")),
+			otel.CombineMetrics(`^agent/log_entry_retry_count$`, "agent/log_entry_retry_count", otel.AggregateLabels("sum", "response_code")),
+			otel.CombineMetrics(`^agent/request_count$`, "agent/request_count", otel.AggregateLabels("sum", "response_code")),
+		),
 		// DeltaToCumulative keeps in memory information of previous delta points
 		// to generate a valid cumulative monotonic metric.
 		otel.DeltaToCumulative(),

--- a/confgenerator/otel/processors.go
+++ b/confgenerator/otel/processors.go
@@ -217,6 +217,7 @@ func TransformationMetrics(queries ...TransformQuery) Component {
 	metricQueryStrings := []string{}
 	datapointQueryStrings := []string{}
 	scopeQueryStrings := []string{}
+	resourceQueryStrings := []string{}
 
 	for _, q := range queries {
 		switch q.Context {
@@ -226,6 +227,8 @@ func TransformationMetrics(queries ...TransformQuery) Component {
 			scopeQueryStrings = append(scopeQueryStrings, string(q.Statement))
 		case Datapoint:
 			datapointQueryStrings = append(datapointQueryStrings, string(q.Statement))
+		case Resource:
+			resourceQueryStrings = append(resourceQueryStrings, string(q.Statement))
 		}
 	}
 
@@ -251,6 +254,13 @@ func TransformationMetrics(queries ...TransformQuery) Component {
 			"statements": scopeQueryStrings,
 		}
 		metricStatements = append(metricStatements, scopeMetricStatement)
+	}
+	if len(resourceQueryStrings) != 0 {
+		resourceMetricStatement := map[string]any{
+			"context":    "resource",
+			"statements": resourceQueryStrings,
+		}
+		metricStatements = append(metricStatements, resourceMetricStatement)
 	}
 
 	return Component{
@@ -305,6 +315,7 @@ const (
 	Metric    TransformQueryContext = "metric"
 	Datapoint TransformQueryContext = "datapoint"
 	Scope     TransformQueryContext = "scope"
+	Resource  TransformQueryContext = "resource"
 )
 
 // TransformQuery is a type wrapper for query expressions supported by the transform
@@ -334,8 +345,8 @@ func GroupByAttribute(attribute string) TransformQuery {
 // DeleteMetricResourceAttribute returns an expression that removes the metric resource attribute specified.
 func DeleteMetricResourceAttribute(metricAttribute string) TransformQuery {
 	return TransformQuery{
-		Context:   Metric,
-		Statement: fmt.Sprintf(`delete_key(resource.attributes, "%s")`, metricAttribute),
+		Context:   Resource,
+		Statement: fmt.Sprintf(`delete_key(attributes, "%s")`, metricAttribute),
 	}
 }
 

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -84,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -534,7 +534,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -764,9 +796,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -84,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -510,7 +510,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -566,13 +598,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -730,9 +762,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -66,7 +66,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -499,7 +499,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -555,13 +587,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -667,9 +699,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -66,7 +66,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -499,7 +499,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -555,13 +587,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -667,9 +699,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -794,9 +826,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -746,9 +778,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -751,9 +783,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -111,7 +111,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -561,7 +561,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,13 +657,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -852,9 +884,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -532,7 +532,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -596,13 +628,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -812,9 +844,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1311,9 +1343,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1311,9 +1343,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -810,9 +842,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -601,13 +633,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -770,9 +802,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1269,9 +1301,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1269,9 +1301,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -110,7 +110,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -560,7 +560,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -638,13 +670,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -818,9 +850,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -530,7 +530,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -608,13 +640,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -777,9 +809,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -676,13 +708,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1278,9 +1310,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -676,13 +708,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1278,9 +1310,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -111,7 +111,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -561,7 +561,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,13 +657,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -532,7 +532,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -596,13 +628,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -775,9 +807,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -111,7 +111,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -561,7 +561,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,13 +657,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -532,7 +532,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -596,13 +628,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -775,9 +807,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -111,7 +111,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -561,7 +561,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,13 +657,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -532,7 +532,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -596,13 +628,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -775,9 +807,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -57,7 +57,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -121,7 +121,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -103,7 +103,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -553,7 +553,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -613,13 +645,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -803,9 +835,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -524,7 +524,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -584,13 +616,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -763,9 +795,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -113,7 +113,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -574,7 +574,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,13 +682,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1262,9 +1294,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -113,7 +113,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -574,7 +574,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,13 +682,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1262,9 +1294,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -59,7 +59,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -622,7 +622,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -844,13 +876,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1291,9 +1323,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -59,7 +59,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -114,7 +114,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -593,7 +593,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -815,13 +847,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1231,9 +1263,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -64,7 +64,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -129,7 +129,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -643,7 +643,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -881,13 +913,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1778,9 +1810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -64,7 +64,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -129,7 +129,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -643,7 +643,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -881,13 +913,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1778,9 +1810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -59,7 +59,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -622,7 +622,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -844,13 +876,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1176,9 +1208,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -59,7 +59,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -114,7 +114,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -593,7 +593,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -815,13 +847,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1116,9 +1148,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -64,7 +64,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -129,7 +129,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -643,7 +643,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -881,13 +913,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1663,9 +1695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -64,7 +64,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -129,7 +129,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -643,7 +643,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -881,13 +913,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1663,9 +1695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -210,7 +210,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -660,7 +660,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -716,13 +748,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -967,9 +999,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -218,7 +218,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -721,7 +721,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -917,13 +949,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1269,9 +1301,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -205,7 +205,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -631,7 +631,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -687,13 +719,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -927,9 +959,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -213,7 +213,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -692,7 +692,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -888,13 +920,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1209,9 +1241,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -220,7 +220,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -681,7 +681,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -753,13 +785,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1426,9 +1458,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -228,7 +228,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -742,7 +742,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -954,13 +986,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1756,9 +1788,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -220,7 +220,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -681,7 +681,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -753,13 +785,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1426,9 +1458,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -228,7 +228,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -742,7 +742,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -954,13 +986,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1756,9 +1788,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -918,9 +950,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1220,9 +1252,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -878,9 +910,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1160,9 +1192,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1377,9 +1409,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1707,9 +1739,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1377,9 +1409,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1707,9 +1739,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -833,9 +865,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -793,9 +825,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1292,9 +1324,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1292,9 +1324,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -885,9 +917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1187,9 +1219,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -845,9 +877,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1127,9 +1159,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1344,9 +1376,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1674,9 +1706,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1344,9 +1376,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1674,9 +1706,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -832,9 +864,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1130,9 +1162,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -792,9 +824,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1070,9 +1102,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1403,9 +1435,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1729,9 +1761,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1403,9 +1435,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1729,9 +1761,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -829,9 +861,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1131,9 +1163,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -789,9 +821,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1071,9 +1103,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1288,9 +1320,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1618,9 +1650,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1288,9 +1320,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1618,9 +1650,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/fluent__forward_0:
     error_mode: ignore
     log_statements:
@@ -834,9 +866,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1136,9 +1168,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/fluent__forward_0:
     error_mode: ignore
     log_statements:
@@ -794,9 +826,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1076,9 +1108,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/fluent__forward_0:
     error_mode: ignore
     log_statements:
@@ -1293,9 +1325,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1623,9 +1655,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/fluent__forward_0:
     error_mode: ignore
     log_statements:
@@ -1293,9 +1325,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1623,9 +1655,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -557,7 +557,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -613,13 +645,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/kafka_1:
     error_mode: ignore
     log_statements:
@@ -922,9 +954,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -618,7 +618,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -814,13 +846,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1224,9 +1256,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -528,7 +528,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -584,13 +616,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/kafka_1:
     error_mode: ignore
     log_statements:
@@ -882,9 +914,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -589,7 +589,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -785,13 +817,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1164,9 +1196,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -578,7 +578,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,13 +682,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1381,9 +1413,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -639,7 +639,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -851,13 +883,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1711,9 +1743,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -578,7 +578,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,13 +682,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1381,9 +1413,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/kafka_0:
     operators:
@@ -639,7 +639,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -851,13 +883,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1711,9 +1743,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1136,9 +1168,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1438,9 +1470,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1096,9 +1128,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1378,9 +1410,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1595,9 +1627,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1925,9 +1957,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1595,9 +1627,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1925,9 +1957,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -570,7 +570,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -626,13 +658,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1489,9 +1521,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -631,7 +631,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -827,13 +859,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1799,9 +1831,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -541,7 +541,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -597,13 +629,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1449,9 +1481,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -602,7 +602,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -798,13 +830,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1739,9 +1771,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -591,7 +591,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -663,13 +695,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1948,9 +1980,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -652,7 +652,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -864,13 +896,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -2286,9 +2318,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -591,7 +591,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -663,13 +695,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1948,9 +1980,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   logstransform/mysql__general_0:
     operators:
@@ -652,7 +652,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -864,13 +896,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -2286,9 +2318,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1104,9 +1136,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1410,9 +1442,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1064,9 +1096,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1350,9 +1382,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1563,9 +1595,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1897,9 +1929,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1563,9 +1595,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1897,9 +1929,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -945,9 +977,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1247,9 +1279,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -905,9 +937,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1187,9 +1219,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1040,9 +1072,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1362,9 +1394,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1040,9 +1072,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1362,9 +1394,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -854,9 +886,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -605,7 +605,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -801,13 +833,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1156,9 +1188,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -814,9 +846,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
@@ -47,7 +47,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -576,7 +576,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -772,13 +804,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1096,9 +1128,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -76,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -526,7 +526,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -582,13 +614,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -703,9 +735,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -22,7 +22,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -71,7 +71,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -497,7 +497,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,13 +585,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -663,9 +695,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -51,7 +51,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -609,7 +609,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -805,13 +837,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1155,9 +1187,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -51,7 +51,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -776,13 +808,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1095,9 +1127,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -56,7 +56,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -630,7 +630,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -842,13 +874,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1642,9 +1674,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -56,7 +56,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -630,7 +630,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -842,13 +874,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1642,9 +1674,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -520,7 +520,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -576,13 +608,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -741,9 +773,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -520,7 +520,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -576,13 +608,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -741,9 +773,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1250,9 +1282,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1250,9 +1282,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -546,7 +546,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -602,13 +634,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -780,9 +812,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +91,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -517,7 +517,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -573,13 +605,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -738,9 +770,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -110,7 +110,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -571,7 +571,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -643,13 +675,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1241,9 +1273,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -110,7 +110,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -571,7 +571,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -643,13 +675,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1241,9 +1273,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -780,9 +812,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +91,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -517,7 +517,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -573,13 +605,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -738,9 +770,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -110,7 +110,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -571,7 +571,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -643,13 +675,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1241,9 +1273,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -110,7 +110,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -571,7 +571,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -643,13 +675,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1241,9 +1273,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -546,7 +546,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -602,13 +634,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -113,7 +113,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -563,7 +563,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -821,9 +853,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -532,7 +532,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,13 +642,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -779,9 +811,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -125,7 +125,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -586,7 +586,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -680,13 +712,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1282,9 +1314,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -125,7 +125,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -586,7 +586,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -680,13 +712,13 @@ processors:
     override: false
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1282,9 +1314,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -120,7 +120,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -570,7 +570,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -626,13 +658,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -806,9 +838,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -528,7 +528,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -584,13 +616,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -751,9 +783,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -535,7 +535,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -591,13 +623,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1125,9 +1157,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -535,7 +535,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -591,13 +623,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1125,9 +1157,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -614,13 +646,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -792,9 +824,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -522,7 +522,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -578,13 +610,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -744,9 +776,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,13 +617,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1118,9 +1150,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,13 +617,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1118,9 +1150,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -84,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -534,7 +534,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -764,9 +796,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -84,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -510,7 +510,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -566,13 +598,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -730,9 +762,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -84,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -517,7 +517,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -573,13 +605,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1104,9 +1136,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -84,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -517,7 +517,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -573,13 +605,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1104,9 +1136,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -601,13 +633,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -601,13 +633,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/activemq_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/aerospike_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -634,13 +666,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -828,9 +860,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/aerospike_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -605,13 +637,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -788,9 +820,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/aerospike_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,13 +703,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1287,9 +1319,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/aerospike_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,13 +703,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1287,9 +1319,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -564,7 +564,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -621,13 +653,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -830,9 +862,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -103,7 +103,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -535,7 +535,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -592,13 +624,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -790,9 +822,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -585,7 +585,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -1289,9 +1321,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -585,7 +585,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -1289,9 +1321,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -564,7 +564,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -621,13 +653,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -830,9 +862,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -103,7 +103,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -535,7 +535,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -592,13 +624,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -790,9 +822,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -585,7 +585,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -1289,9 +1321,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/apache_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/apache_2:
     transforms:
@@ -585,7 +585,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/apache_3:
     metric_statements:
     - context: datapoint
@@ -1289,9 +1321,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/cassandra_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/cassandra_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/couchbase_1:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchbase_2:
     transforms:
@@ -648,7 +648,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -705,13 +737,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchbase_3:
     metric_statements:
     - context: metric
@@ -947,9 +979,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/couchbase_1:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchbase_2:
     transforms:
@@ -619,7 +619,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -676,13 +708,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchbase_3:
     metric_statements:
     - context: metric
@@ -907,9 +939,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/couchbase_1:
     metrics:
       exclude:
@@ -122,7 +122,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchbase_2:
     transforms:
@@ -669,7 +669,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -742,13 +774,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchbase_3:
     metric_statements:
     - context: metric
@@ -1406,9 +1438,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/couchbase_1:
     metrics:
       exclude:
@@ -122,7 +122,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchbase_2:
     transforms:
@@ -669,7 +669,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -742,13 +774,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchbase_3:
     metric_statements:
     - context: metric
@@ -1406,9 +1438,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchdb_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchdb_2:
     metric_statements:
     - context: scope
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchdb_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchdb_2:
     metric_statements:
     - context: scope
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchdb_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchdb_2:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/couchdb_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/couchdb_2:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +94,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -600,13 +632,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -515,7 +515,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,13 +603,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -736,9 +768,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
@@ -54,7 +54,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   deltatorate/dcgm_2:
     metrics:
     - dcgm.gpu.profiling.nvlink_traffic_rate
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/dcgm_0:
     transforms:
@@ -624,7 +624,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -680,13 +712,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/dcgm_5:
     metric_statements:
     - context: datapoint
@@ -916,9 +948,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
@@ -54,7 +54,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   deltatorate/dcgm_2:
     metrics:
     - dcgm.gpu.profiling.nvlink_traffic_rate
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/dcgm_0:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -651,13 +683,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/dcgm_5:
     metric_statements:
     - context: datapoint
@@ -876,9 +908,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/dcgm_0:
     transforms:
@@ -602,7 +602,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/dcgm_2:
     metric_statements:
     - context: datapoint
@@ -858,9 +890,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/dcgm_0:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,13 +661,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/dcgm_2:
     metric_statements:
     - context: datapoint
@@ -818,9 +850,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -562,7 +562,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -861,9 +893,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -533,7 +533,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -821,9 +853,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -562,7 +562,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -861,9 +893,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -533,7 +533,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -821,9 +853,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -562,7 +562,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -861,9 +893,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -533,7 +533,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -821,9 +853,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -562,7 +562,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -861,9 +893,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -533,7 +533,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -821,9 +853,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1320,9 +1352,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -562,7 +562,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -883,9 +915,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -533,7 +533,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -843,9 +875,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1342,9 +1374,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1342,9 +1374,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -562,7 +562,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -863,9 +895,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -533,7 +533,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -823,9 +855,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1322,9 +1354,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/elasticsearch_2:
     transforms:
@@ -583,7 +583,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/elasticsearch_3:
     metric_statements:
     - context: scope
@@ -1322,9 +1354,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -546,7 +546,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -602,13 +634,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/flink_1:
     transforms:
@@ -582,7 +582,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -639,13 +671,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/flink_2:
     metric_statements:
     - context: datapoint
@@ -852,9 +884,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/flink_1:
     transforms:
@@ -553,7 +553,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,13 +642,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/flink_2:
     metric_statements:
     - context: datapoint
@@ -812,9 +844,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/flink_1:
     transforms:
@@ -603,7 +603,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -676,13 +708,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/flink_2:
     metric_statements:
     - context: datapoint
@@ -1311,9 +1343,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/flink_1:
     transforms:
@@ -603,7 +603,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -676,13 +708,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/flink_2:
     metric_statements:
     - context: datapoint
@@ -1311,9 +1343,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hadoop_2:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -831,9 +863,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -536,7 +536,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -593,13 +625,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -791,9 +823,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -586,7 +586,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -1290,9 +1322,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -586,7 +586,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -1290,9 +1322,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -831,9 +863,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -536,7 +536,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -593,13 +625,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -791,9 +823,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -586,7 +586,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -1290,9 +1322,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -586,7 +586,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/hbase__metrics_2:
     metric_statements:
     - context: scope
@@ -1290,9 +1322,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jetty__metrics_2:
     metric_statements:
     - context: scope
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jetty__metrics_2:
     metric_statements:
     - context: scope
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jetty__metrics_2:
     metric_statements:
     - context: scope
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jetty__metrics_2:
     metric_statements:
     - context: scope
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvm_2:
     metric_statements:
     - context: scope
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvm_2:
     metric_statements:
     - context: scope
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvm_2:
     metric_statements:
     - context: scope
@@ -824,9 +856,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvm_2:
     metric_statements:
     - context: scope
@@ -784,9 +816,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1283,9 +1315,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvm_2:
     metric_statements:
     - context: scope
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvm_2:
     metric_statements:
     - context: scope
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -117,7 +117,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/kafka_3:
     metric_statements:
     - context: scope
@@ -840,9 +872,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -601,13 +633,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/kafka_3:
     metric_statements:
     - context: scope
@@ -800,9 +832,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -127,7 +127,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -594,7 +594,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1299,9 +1331,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -127,7 +127,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -594,7 +594,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1299,9 +1331,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -117,7 +117,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/kafka_3:
     metric_statements:
     - context: scope
@@ -840,9 +872,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -544,7 +544,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -601,13 +633,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/kafka_3:
     metric_statements:
     - context: scope
@@ -800,9 +832,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -127,7 +127,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -594,7 +594,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1299,9 +1331,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -127,7 +127,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -594,7 +594,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1299,9 +1331,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -621,13 +653,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -816,9 +848,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -103,7 +103,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -592,13 +624,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -776,9 +808,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1275,9 +1307,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1275,9 +1307,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -775,9 +807,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -813,9 +845,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -773,9 +805,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -635,13 +667,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -855,9 +887,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -606,13 +638,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -672,13 +704,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1314,9 +1346,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -672,13 +704,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1314,9 +1346,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -635,13 +667,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -855,9 +887,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -606,13 +638,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -672,13 +704,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1314,9 +1346,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -672,13 +704,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1314,9 +1346,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -809,9 +841,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -769,9 +801,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -809,9 +841,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -769,9 +801,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1426,9 +1458,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -611,13 +643,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1386,9 +1418,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -677,13 +709,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1885,9 +1917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -677,13 +709,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1885,9 +1917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1426,9 +1458,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -611,13 +643,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1386,9 +1418,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -677,13 +709,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1885,9 +1917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -677,13 +709,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1885,9 +1917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1426,9 +1458,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -611,13 +643,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1386,9 +1418,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -677,13 +709,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1885,9 +1917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -677,13 +709,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1885,9 +1917,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -828,9 +860,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -788,9 +820,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1287,9 +1319,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1287,9 +1319,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -830,9 +862,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -790,9 +822,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1289,9 +1321,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1289,9 +1321,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -831,9 +863,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -791,9 +823,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1290,9 +1322,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1290,9 +1322,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -834,9 +866,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -590,13 +622,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -794,9 +826,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1293,9 +1325,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -656,13 +688,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1293,9 +1325,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -857,9 +889,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -817,9 +849,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1316,9 +1348,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1316,9 +1348,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -860,9 +892,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -820,9 +852,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1319,9 +1351,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1319,9 +1351,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -921,9 +953,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -881,9 +913,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1380,9 +1412,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1380,9 +1412,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -856,9 +888,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -816,9 +848,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1315,9 +1347,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1315,9 +1347,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -857,9 +889,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -817,9 +849,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1316,9 +1348,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1316,9 +1348,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -850,9 +882,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -810,9 +842,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1309,9 +1341,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1309,9 +1341,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -911,9 +943,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -871,9 +903,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1370,9 +1402,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1370,9 +1402,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -857,9 +889,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -817,9 +849,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1316,9 +1348,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1316,9 +1348,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -893,9 +925,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -853,9 +885,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1352,9 +1384,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1352,9 +1384,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +98,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -548,7 +548,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -604,13 +636,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -855,9 +887,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -44,7 +44,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -519,7 +519,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -575,13 +607,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1314,9 +1346,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -49,7 +49,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -569,7 +569,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -641,13 +673,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1314,9 +1346,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -818,9 +850,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1277,9 +1309,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1277,9 +1309,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -818,9 +850,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1277,9 +1309,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1277,9 +1309,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -819,9 +851,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -779,9 +811,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1278,9 +1310,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1278,9 +1310,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -109,7 +109,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -559,7 +559,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -820,9 +852,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -530,7 +530,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -593,13 +625,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -780,9 +812,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1279,9 +1311,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1279,9 +1311,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -109,7 +109,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -559,7 +559,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -820,9 +852,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -530,7 +530,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -593,13 +625,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -780,9 +812,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1279,9 +1311,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         metric_names:
         - redis.commands
         - redis.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1279,9 +1311,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         match_type: strict
         metric_names:
         - saphana.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -621,13 +653,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -103,7 +103,7 @@ processors:
         match_type: strict
         metric_names:
         - saphana.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -592,13 +624,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         match_type: strict
         metric_names:
         - saphana.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -118,7 +118,7 @@ processors:
         match_type: strict
         metric_names:
         - saphana.uptime
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -658,13 +690,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -813,9 +845,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -773,9 +805,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -813,9 +845,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -773,9 +805,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -813,9 +845,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -773,9 +805,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1272,9 +1304,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -810,9 +842,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -770,9 +802,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1269,9 +1301,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1269,9 +1301,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -124,7 +124,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -574,7 +574,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1493,9 +1525,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -545,7 +545,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1453,9 +1485,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -134,7 +134,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -696,13 +728,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1952,9 +1984,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -134,7 +134,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -696,13 +728,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1952,9 +1984,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -124,7 +124,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -574,7 +574,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1493,9 +1525,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -545,7 +545,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1453,9 +1485,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -134,7 +134,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -696,13 +728,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1952,9 +1984,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -134,7 +134,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -696,13 +728,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1952,9 +1984,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -124,7 +124,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -574,7 +574,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -659,13 +691,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1497,9 +1529,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -119,7 +119,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -545,7 +545,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,13 +662,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -1457,9 +1489,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -134,7 +134,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -696,13 +728,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1956,9 +1988,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -134,7 +134,7 @@ processors:
         - vault.token.revoke.time
         - vault.token.renew.time
         - vault.core.leader.duration
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -595,7 +595,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -696,13 +728,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1956,9 +1988,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -775,9 +807,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -815,9 +847,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -775,9 +807,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1274,9 +1306,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -809,9 +841,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -769,9 +801,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -552,7 +552,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -809,9 +841,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -523,7 +523,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -769,9 +801,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1268,9 +1300,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
@@ -51,7 +51,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -106,7 +106,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -609,7 +609,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -805,13 +837,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1197,9 +1229,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
@@ -51,7 +51,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +101,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -580,7 +580,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -776,13 +808,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1137,9 +1169,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -56,7 +56,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -630,7 +630,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -842,13 +874,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1684,9 +1716,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -56,7 +56,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -116,7 +116,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -630,7 +630,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -842,13 +874,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1684,9 +1716,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -550,7 +550,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1217,9 +1249,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -550,7 +550,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1217,9 +1249,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1245,9 +1277,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1245,9 +1277,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -27,7 +27,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -547,7 +547,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -619,13 +651,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -798,9 +830,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1235,9 +1267,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -546,7 +546,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -602,13 +634,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +96,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -546,7 +546,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -602,13 +634,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -778,9 +810,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
@@ -40,7 +40,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +90,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -516,7 +516,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,13 +604,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/loggingmetrics_0:
     error_mode: ignore
     metric_statements:
@@ -737,9 +769,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +107,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -568,7 +568,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1238,9 +1270,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -550,7 +550,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1217,9 +1249,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/fluentbit_0:
     metrics:
       include:
@@ -89,7 +89,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -550,7 +550,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -622,13 +654,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1217,9 +1249,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/active__directory__ds_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1278,9 +1310,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/active__directory__ds_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -667,13 +699,13 @@ processors:
       - delete_key(attributes, "service.version")
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1278,9 +1310,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -113,7 +113,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis__v2_3: {}
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -589,7 +589,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1299,9 +1331,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -113,7 +113,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis__v2_3: {}
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -589,7 +589,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -662,13 +694,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1299,9 +1331,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis_3: {}
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -556,7 +556,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,13 +660,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_0:
     metric_statements:
     - context: datapoint
@@ -1243,9 +1275,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +108,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis_3: {}
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -556,7 +556,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,13 +660,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_0:
     metric_statements:
     - context: datapoint
@@ -1243,9 +1275,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +102,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -558,7 +558,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -615,13 +647,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvmmetrics_2:
     metric_statements:
     - context: scope
@@ -822,9 +854,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
@@ -48,7 +48,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -97,7 +97,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -529,7 +529,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,13 +618,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/jvmmetrics_2:
     metric_statements:
     - context: scope
@@ -782,9 +814,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -579,7 +579,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -652,13 +684,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1281,9 +1313,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -655,13 +687,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1273,9 +1305,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -655,13 +687,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1273,9 +1305,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1240,9 +1272,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -53,7 +53,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -573,7 +573,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,13 +672,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1240,9 +1272,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1808,9 +1840,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -2146,9 +2178,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1808,9 +1840,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -2146,9 +2178,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1395,9 +1427,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1729,9 +1761,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -45,7 +45,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +104,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metricstransform/fluentbit_1:
     transforms:
@@ -565,7 +565,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -637,13 +669,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/iis_3:
     metric_statements:
     - context: scope
@@ -1395,9 +1427,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       receivers:
       - prometheus/agent_prometheus

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
@@ -52,7 +52,7 @@ processors:
       - fluentbit_log_entry_retry_count
       - fluentbit_request_count
     initial_value: drop
-  deltatocumulative/loggingmetrics_6: {}
+  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +112,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_7:
+  interval/loggingmetrics_8:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -626,7 +626,39 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-  metricstransform/loggingmetrics_8:
+  metricstransform/loggingmetrics_6:
+    transforms:
+    - action: combine
+      include: ^agent/log_entry_count$
+      match_type: regexp
+      new_name: agent/log_entry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/log_entry_retry_count$
+      match_type: regexp
+      new_name: agent/log_entry_retry_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+    - action: combine
+      include: ^agent/request_count$
+      match_type: regexp
+      new_name: agent/request_count
+      operations:
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - response_code
+      submatch_case: lower
+  metricstransform/loggingmetrics_9:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -838,13 +870,13 @@ processors:
     - gcp
   transform/agent_prometheus_0:
     metric_statements:
-    - context: metric
+    - context: resource
       statements:
-      - delete_key(resource.attributes, "service.name")
-      - delete_key(resource.attributes, "service.version")
-      - delete_key(resource.attributes, "service.instance.id")
-      - delete_key(resource.attributes, "server.port")
-      - delete_key(resource.attributes, "url.scheme")
+      - delete_key(attributes, "service.name")
+      - delete_key(attributes, "service.version")
+      - delete_key(attributes, "service.instance.id")
+      - delete_key(attributes, "server.port")
+      - delete_key(attributes, "url.scheme")
   transform/agent_prometheus_1:
     metric_statements:
     - context: scope
@@ -1729,9 +1761,10 @@ service:
       - metricstransform/loggingmetrics_3
       - cumulativetodelta/loggingmetrics_4
       - transform/loggingmetrics_5
-      - deltatocumulative/loggingmetrics_6
-      - interval/loggingmetrics_7
-      - metricstransform/loggingmetrics_8
+      - metricstransform/loggingmetrics_6
+      - deltatocumulative/loggingmetrics_7
+      - interval/loggingmetrics_8
+      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1


### PR DESCRIPTION
## Description
When the Ops Agent is configured to run both Fluent Bit and OpenTelemetry logging pipelines concurrently (e.g., when using the OTLP exporter experiment), the agent's self-metrics pipeline encountered a "Duplicate TimeSeries" error in Google Cloud Monitoring (GCM), causing self-metrics (agent/log_entry_count and agent/request_count) to be dropped.

This was caused by two problems, the "server.port" and "URL.scheme" not being correctly deleted, and a collision when exporting the data from the pipeline.
* In OTTL, modifying resource-level metadata from the metric context is not effective (it silently modifies a copy and is ignored at runtime). As a result, server.port survived in the exported metrics (20202 for Fluent Bit, 20201 for OTel).
* Even if we correctly deleted the server.port, we still need to combine the metrics to equal avoid duplicate metric points.

## Related issue
b/510797065

## How has this been tested?
### 1. Control VM
Setup: Standard released package (2.66.0~debian12), OTLP exporter enabled via EXPERIMENTAL_FEATURES=otlp_exporter.
Observation: Within minutes, the otelopscol log began printing recurring InvalidArgument / Duplicate TimeSeries errors:

One or more TimeSeries could not be written: timeSeries[2] (metric.type="agent.googleapis.com/agent/request_count", ...): Duplicate TimeSeries encountered. Only one point can be written per TimeSeries per request.
timeSeries[3] (metric.type="agent.googleapis.com/agent/log_entry_count", ...): Duplicate TimeSeries encountered. Only one point can be written per TimeSeries per request.
Status: Bug successfully reproduced. The released agent is dropping self-metrics.

### 2. Feature VM
Setup: Injected Go binary with the fix ,OTLP exporter enabled via EXPERIMENTAL_FEATURES=otlp_exporter.
Observation: The agent started without any errors and successfully initiated OTLP metrics collection and export:
Everything is ready. Begin running and processing data.
Over a 5+ minute observation period, the collector logs remained 100% clean. There were no duplicate errors and no data points were dropped.
Status: Fix successfully verified. Refactoring the OTel generator to use the correct resource context and introducing CombineMetrics to sum the streams resolved the duplicate TimeSeries conflict.

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
