### PR TITLE
Integrate googlecloudopsagent confmap.Provider into Ops Agent

### DIFF
--- a/cmd/ops_agent_uap_plugin/service_linux.go
+++ b/cmd/ops_agent_uap_plugin/service_linux.go
@@ -137,7 +137,10 @@ func runSubagents(ctx context.Context, cancelAndSetError CancelContextAndSetPlug
 	// Starting Otel
 	runOtelCmd := exec.CommandContext(ctx,
 		path.Join(pluginInstallDirectory, OtelBinary),
-		"--config", path.Join(pluginStateDirectory, OtelRuntimeDirectory, "otel.yaml"),
+		"--config", fmt.Sprintf("googlecloudopsagent:%s?platform=linux&state_dir=%s&out_dir=%s",
+			OpsAgentConfigLocationLinux,
+			path.Join(pluginStateDirectory, OtelStateDiectory),
+			path.Join(pluginStateDirectory, OtelRuntimeDirectory)),
 	)
 	wg.Add(1)
 	go runSubAgentCommand(ctx, cancelAndSetError, runOtelCmd, runCommand, &wg)

--- a/cmd/ops_agent_windows/main_windows.go
+++ b/cmd/ops_agent_windows/main_windows.go
@@ -136,7 +136,10 @@ func initServices() error {
 			fmt.Sprintf("%s - Metrics Agent", serviceDisplayName),
 			filepath.Join(base, "google-cloud-metrics-agent_windows_amd64.exe"),
 			[]string{
-				"--config=" + filepath.Join(configOutDir, `otel\otel.yaml`),
+				fmt.Sprintf("--config=googlecloudopsagent:%s?platform=windows&state_dir=%s&out_dir=%s",
+					filepath.Join(base, "../config/config.yaml"),
+					filepath.Join(os.Getenv("PROGRAMDATA"), dataDirectory, "run"),
+					configOutDir),
 			},
 		},
 		{

--- a/confgenerator/files.go
+++ b/confgenerator/files.go
@@ -59,13 +59,8 @@ func (uc *UnifiedConfig) GenerateFilesFromConfig(ctx context.Context, service, l
 			}
 		}
 	case "otel":
-		otelConfig, err := uc.GenerateOtelConfig(ctx, outDir, stateDir)
-		if err != nil {
-			return fmt.Errorf("can't parse configuration: %w", err)
-		}
-		if err = WriteConfigFile([]byte(otelConfig), filepath.Join(outDir, "otel.yaml")); err != nil {
-			return err
-		}
+		// No-op. otelopscol now uses the googlecloudopsagent provider to translate config on the fly.
+		return nil
 	default:
 		return fmt.Errorf("unknown service %q", service)
 	}

--- a/systemd/google-cloud-ops-agent-opentelemetry-collector.service
+++ b/systemd/google-cloud-ops-agent-opentelemetry-collector.service
@@ -24,7 +24,7 @@ StateDirectory=google-cloud-ops-agent/opentelemetry-collector
 LogsDirectory=google-cloud-ops-agent
 Type=simple
 ExecStartPre=@PREFIX@/libexec/google_cloud_ops_agent_engine -service=otel -in @SYSCONFDIR@/google-cloud-ops-agent/config.yaml -logs ${LOGS_DIRECTORY} -state ${STATE_DIRECTORY}
-ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --config=${RUNTIME_DIRECTORY}/otel.yaml
+ExecStart=@PREFIX@/subagents/opentelemetry-collector/otelopscol --config=googlecloudopsagent:@SYSCONFDIR@/google-cloud-ops-agent/config.yaml?platform=linux&state_dir=${STATE_DIRECTORY}&out_dir=${RUNTIME_DIRECTORY}
 Restart=always
 # For debugging:
 RuntimeDirectoryPreserve=yes


### PR DESCRIPTION
## Description
This integrates the new confmap.Provider from the otelopscol submodule. It modifies: - Systemd service to use the provider URI. - UAP plugin to use the provider URI. - Windows service manager to use the provider URI. - confgenerator to stop generating otel.yaml (made it a no-op). Updates submodule reference to ecabbc77c92fc35af35141280423dd5f9e3b4300.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
