### PR TITLE
Disable MetricStartTime for MSSQL pipelines

### DIFF
--- a/apps/mssql.go
+++ b/apps/mssql.go
@@ -58,6 +58,7 @@ func (m MetricsReceiverMssql) Pipelines(ctx context.Context) ([]otel.ReceiverPip
 				),
 				otel.MetricsRemoveServiceAttributes(),
 			}},
+			DisableMetricStartTime: true,
 		}, ctx)}, nil
 	}
 
@@ -107,6 +108,7 @@ func (m MetricsReceiverMssql) Pipelines(ctx context.Context) ([]otel.ReceiverPip
 				otel.SetScopeVersion("1.0"),
 			),
 		}},
+		DisableMetricStartTime: true,
 	}, ctx)}, nil
 }
 

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -244,6 +244,9 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 					},
 				},
 			},
+			otel.System_NoMetricStartTime: {
+				Exporter: googleCloudExporter(userAgent, false, false),
+			},
 			otel.OTel: {
 				Exporter: googleCloudExporter(userAgent, true, true),
 				ProcessorsByType: map[string][]otel.Component{
@@ -251,6 +254,9 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 						otel.MetricStartTime(),
 					},
 				},
+			},
+			otel.OTel_NoMetricStartTime: {
+				Exporter: googleCloudExporter(userAgent, true, true),
 			},
 			otel.GMP: {
 				Exporter: googleManagedPrometheusExporter(userAgent),
@@ -262,6 +268,16 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 					"metrics": {
 						otel.GCPProjectID(resource.ProjectName()),
 						otel.MetricStartTime(),
+						otel.BatchProcessor(200, 200, "200ms"),
+					},
+				},
+			},
+			otel.OTLP_Metrics_NoMetricStartTime: {
+				Exporter:       otlpExporterForMetrics(userAgent),
+				UsedExtensions: []string{googleClientAuthExtensionType},
+				ProcessorsByType: map[string][]otel.Component{
+					"metrics": {
+						otel.GCPProjectID(resource.ProjectName()),
 						otel.BatchProcessor(200, 200, "200ms"),
 					},
 				},

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -42,6 +42,9 @@ const (
 	OTLP_Metrics
 	OTLP_Logs
 	Logging
+	System_NoMetricStartTime
+	OTel_NoMetricStartTime
+	OTLP_Metrics_NoMetricStartTime
 )
 const (
 	Override ResourceDetectionMode = iota
@@ -53,14 +56,20 @@ func (t ExporterType) Name() string {
 	if t == System || t == GMP {
 		// The collector's OTel and GMP exporters have different types so can share the empty string.
 		return ""
+	} else if t == System_NoMetricStartTime {
+		return "system_nomst"
 	} else if t == OTel {
 		return "otel"
+	} else if t == OTel_NoMetricStartTime {
+		return "otel_nomst"
 	} else if t == Logging {
 		return "logging"
 	} else if t == OTLP_Metrics {
 		return "otlp_metrics"
 	} else if t == OTLP_Logs {
 		return "otlp_logs"
+	} else if t == OTLP_Metrics_NoMetricStartTime {
+		return "otlp_metrics_nomst"
 	} else {
 		panic("unknown ExporterType")
 	}
@@ -85,6 +94,8 @@ type ReceiverPipeline struct {
 	// ResourceDetectionModes indicates whether the resource should be forcibly set, set only if not already present, or never set.
 	// If a data type is not present, it will assume the zero value (Override).
 	ResourceDetectionModes map[string]ResourceDetectionMode
+	// DisableMetricStartTime disables the central MetricStartTime processor for this pipeline.
+	DisableMetricStartTime bool
 }
 
 // Pipeline represents one (of potentially many) pipelines consuming data from a ReceiverPipeline.
@@ -265,6 +276,15 @@ func (c ModularConfig) Generate(ctx context.Context) (string, error) {
 		}
 
 		exporterType := receiverPipeline.ExporterTypes[pipeline.Type]
+		if receiverPipeline.DisableMetricStartTime {
+			if exporterType == System {
+				exporterType = System_NoMetricStartTime
+			} else if exporterType == OTel {
+				exporterType = OTel_NoMetricStartTime
+			} else if exporterType == OTLP_Metrics {
+				exporterType = OTLP_Metrics_NoMetricStartTime
+			}
+		}
 		exporter := c.Exporters[exporterType]
 		if _, ok := exporterNames[exporterType]; !ok {
 			name := exporter.Exporter.name(exporterType.Name())

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1318,13 +1326,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1318,13 +1326,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1281,13 +1289,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1281,13 +1289,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1281,13 +1289,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1281,13 +1289,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1281,13 +1289,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1281,13 +1289,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1269,13 +1277,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1269,13 +1277,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -35,6 +35,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +51,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -890,6 +900,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1769,7 +1784,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1777,9 +1792,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -35,6 +35,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +51,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -890,6 +900,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1769,7 +1784,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1777,9 +1792,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -35,6 +35,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +51,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -894,6 +904,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1654,7 +1669,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1662,9 +1677,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -35,6 +35,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -45,6 +51,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -894,6 +904,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1654,7 +1669,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1662,9 +1677,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1433,13 +1441,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -975,6 +985,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1747,7 +1762,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1755,9 +1770,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1433,13 +1441,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -975,6 +985,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1747,7 +1762,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1755,9 +1770,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1384,13 +1392,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1698,7 +1713,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1706,9 +1721,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1384,13 +1392,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1698,7 +1713,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1706,9 +1721,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1299,13 +1307,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1299,13 +1307,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1351,13 +1359,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1665,7 +1680,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1673,9 +1688,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1351,13 +1359,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1665,7 +1680,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1673,9 +1688,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1410,13 +1418,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1720,7 +1735,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1728,9 +1743,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1410,13 +1418,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1720,7 +1735,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1728,9 +1743,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1609,7 +1624,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1617,9 +1632,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1609,7 +1624,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1617,9 +1632,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1300,13 +1308,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1614,7 +1629,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1622,9 +1637,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1300,13 +1308,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1614,7 +1629,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1622,9 +1637,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1388,13 +1396,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -872,6 +882,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1702,7 +1717,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1710,9 +1725,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1388,13 +1396,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -872,6 +882,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1702,7 +1717,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1710,9 +1725,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1602,13 +1610,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1916,7 +1931,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1924,9 +1939,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1602,13 +1610,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1916,7 +1931,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1924,9 +1939,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1955,13 +1963,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -881,6 +891,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -2277,7 +2292,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -2285,9 +2300,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1955,13 +1963,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -881,6 +891,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -2277,7 +2292,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -2285,9 +2300,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1570,13 +1578,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1888,7 +1903,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1896,9 +1911,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1570,13 +1578,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1888,7 +1903,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1896,9 +1911,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1047,13 +1055,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1353,7 +1368,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1361,9 +1376,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1047,13 +1055,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -859,6 +869,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1353,7 +1368,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1361,9 +1376,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -27,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -37,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -863,6 +873,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1633,7 +1648,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1641,9 +1656,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -27,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -37,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -863,6 +873,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1633,7 +1648,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1641,9 +1656,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1257,13 +1265,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1257,13 +1265,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1248,13 +1256,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1248,13 +1256,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1248,13 +1256,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1248,13 +1256,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1297,13 +1305,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1297,13 +1305,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1297,13 +1305,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1297,13 +1305,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1291,13 +1299,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1414,13 +1422,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1414,13 +1422,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1289,13 +1297,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1289,13 +1297,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1338,13 +1346,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1338,13 +1346,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1318,13 +1326,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1318,13 +1326,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/elasticsearch_elasticsearch:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1308,13 +1316,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/flink_flink:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1308,13 +1316,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/flink_flink:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1283,13 +1291,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1283,13 +1291,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1282,13 +1290,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1282,13 +1290,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1322,13 +1330,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1322,13 +1330,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1322,13 +1330,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1322,13 +1330,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1893,13 +1901,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1893,13 +1901,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1893,13 +1901,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1893,13 +1901,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1893,13 +1901,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1893,13 +1901,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1295,13 +1303,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1297,13 +1305,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1297,13 +1305,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1298,13 +1306,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1298,13 +1306,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1301,13 +1309,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1301,13 +1309,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1323,13 +1331,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1323,13 +1331,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1326,13 +1334,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1326,13 +1334,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1387,13 +1395,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1387,13 +1395,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1322,13 +1330,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1322,13 +1330,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1323,13 +1331,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1323,13 +1331,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1316,13 +1324,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1377,13 +1385,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1377,13 +1385,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1323,13 +1331,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1323,13 +1331,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1359,13 +1367,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1359,13 +1367,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1321,13 +1329,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
   googlemanagedprometheus:
     metric:
       add_metric_suffixes: false
@@ -1321,13 +1329,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1285,13 +1293,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1285,13 +1293,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1285,13 +1293,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1285,13 +1293,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1286,13 +1294,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1286,13 +1294,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1289,13 +1297,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1289,13 +1297,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1287,13 +1295,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1289,13 +1297,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1289,13 +1297,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1280,13 +1288,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1277,13 +1285,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1277,13 +1285,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1960,13 +1968,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1960,13 +1968,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1960,13 +1968,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1960,13 +1968,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1964,13 +1972,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1964,13 +1972,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1282,13 +1290,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1282,13 +1290,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1282,13 +1290,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1282,13 +1290,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1276,13 +1284,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -27,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -37,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -863,6 +873,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1675,7 +1690,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1683,9 +1698,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -27,6 +27,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -37,6 +43,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -863,6 +873,11 @@ processors:
     - action: insert
       key: gcp.project_id
       value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
   resourcedetection/_global_0:
     detectors:
     - gcp
@@ -1675,7 +1690,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1683,9 +1698,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1225,12 +1233,11 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1225,12 +1233,11 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -7,6 +7,14 @@ exporters:
       service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
@@ -805,13 +813,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1242,13 +1250,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1245,13 +1253,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1214,12 +1222,11 @@ service:
       - windowsperfcounters/iis
     metrics/another__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1214,12 +1222,11 @@ service:
       - windowsperfcounters/iis
     metrics/another__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/default__pipeline_hostmetrics:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1286,13 +1294,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1286,13 +1294,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1294,13 +1302,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1294,13 +1302,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1237,13 +1245,12 @@ service:
       - iis/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1237,13 +1245,12 @@ service:
       - iis/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
@@ -29,6 +29,14 @@ exporters:
       service_resource_labels: true
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1278,13 +1286,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -21,12 +21,20 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
-  googlecloud/otel:
+  googlecloud/otel_nomst:
     metric:
       instrumentation_library_labels: true
       prefix: ""
       resource_filters: []
       service_resource_labels: true
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
@@ -109,8 +117,6 @@ processors:
         - googlecloudmonitoring/point_count
   interval/loggingmetrics_8:
     interval: 1m
-  metric_start_time/googlecloud/otel_metrics_0:
-    strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
   metricstransform/fluentbit_1:
@@ -1281,13 +1287,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1322,13 +1327,12 @@ service:
       - prometheus/agent_prometheus
     metrics/mssql__v2_mssql__v2:
       exporters:
-      - googlecloud/otel
+      - googlecloud/otel_nomst
       processors:
       - metricstransform/mssql__v2_0
       - transform/mssql__v2_1
       - transform/mssql__v2_2
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql__v2
     metrics/opsagent:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -21,12 +21,20 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
-  googlecloud/otel:
+  googlecloud/otel_nomst:
     metric:
       instrumentation_library_labels: true
       prefix: ""
       resource_filters: []
       service_resource_labels: true
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
       skip_create_descriptor: true
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
@@ -109,8 +117,6 @@ processors:
         - googlecloudmonitoring/point_count
   interval/loggingmetrics_8:
     interval: 1m
-  metric_start_time/googlecloud/otel_metrics_0:
-    strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
   metricstransform/fluentbit_1:
@@ -1281,13 +1287,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:
@@ -1322,13 +1327,12 @@ service:
       - prometheus/agent_prometheus
     metrics/mssql__v2_mssql__v2:
       exporters:
-      - googlecloud/otel
+      - googlecloud/otel_nomst
       processors:
       - metricstransform/mssql__v2_0
       - transform/mssql__v2_1
       - transform/mssql__v2_2
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql__v2
     metrics/opsagent:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -21,7 +21,7 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
-  googlecloud/otel:
+  googlecloud/otel_nomst:
     metric:
       instrumentation_library_labels: true
       prefix: ""
@@ -109,8 +109,6 @@ processors:
         - googlecloudmonitoring/point_count
   interval/loggingmetrics_8:
     interval: 1m
-  metric_start_time/googlecloud/otel_metrics_0:
-    strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
   metricstransform/fluentbit_1:
@@ -1246,14 +1244,13 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud/otel
+      - googlecloud/otel_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - transform/mssql_2
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql
     metrics/fluentbit:
@@ -1288,13 +1285,12 @@ service:
       - prometheus/agent_prometheus
     metrics/mssql_mssql:
       exporters:
-      - googlecloud/otel
+      - googlecloud/otel_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - transform/mssql_2
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql
     metrics/opsagent:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -21,7 +21,7 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
-  googlecloud/otel:
+  googlecloud/otel_nomst:
     metric:
       instrumentation_library_labels: true
       prefix: ""
@@ -109,8 +109,6 @@ processors:
         - googlecloudmonitoring/point_count
   interval/loggingmetrics_8:
     interval: 1m
-  metric_start_time/googlecloud/otel_metrics_0:
-    strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
   metricstransform/fluentbit_1:
@@ -1246,14 +1244,13 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud/otel
+      - googlecloud/otel_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - transform/mssql_2
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql
     metrics/fluentbit:
@@ -1288,13 +1285,12 @@ service:
       - prometheus/agent_prometheus
     metrics/mssql_mssql:
       exporters:
-      - googlecloud/otel
+      - googlecloud/otel_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - transform/mssql_2
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql
     metrics/opsagent:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1815,13 +1823,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -2137,7 +2152,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -2145,9 +2160,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1815,13 +1823,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -2137,7 +2152,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -2145,9 +2160,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1402,13 +1410,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1720,7 +1735,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1728,9 +1743,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -21,6 +21,14 @@ exporters:
       sizer: items
       storage: file_storage
     timeout: 3600s
+  googlecloud/system_nomst:
+    metric:
+      instrumentation_library_labels: false
+      prefix: ""
+      resource_filters: []
+      service_resource_labels: false
+      skip_create_descriptor: true
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -1402,13 +1410,12 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - googlecloud
+      - googlecloud/system_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
@@ -23,6 +23,12 @@ exporters:
     balancer_name: pick_first
     endpoint: telemetry.googleapis.com:443
     user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
+  otlp_grpc/otlp_metrics_nomst:
+    auth:
+      authenticator: googleclientauth
+    balancer_name: pick_first
+    endpoint: telemetry.googleapis.com:443
+    user_agent: Google-Cloud-Ops-Agent-Metrics/latest (BuildDistro=build_distro;Platform=windows;ShortName=win_platform;ShortVersion=win_platform_version)
 extensions:
   file_storage:
     create_directory: true
@@ -33,6 +39,10 @@ processors:
     blank_label_metrics:
     - system.cpu.utilization
   batch/otlp_grpc/otlp_metrics_metrics_2:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 200ms
+  batch/otlp_grpc/otlp_metrics_nomst_metrics_1:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
@@ -855,6 +865,11 @@ processors:
       key: gcp.use_legacy_mapping
       value: "true"
   resource/otlp_grpc/otlp_metrics_metrics_0:
+    attributes:
+    - action: insert
+      key: gcp.project_id
+      value: test-project
+  resource/otlp_grpc/otlp_metrics_nomst_metrics_0:
     attributes:
     - action: insert
       key: gcp.project_id
@@ -1720,7 +1735,7 @@ service:
       - windowsperfcounters/iis
     metrics/default__pipeline_mssql:
       exporters:
-      - otlp_grpc/otlp_metrics
+      - otlp_grpc/otlp_metrics_nomst
       processors:
       - metricstransform/mssql_0
       - transform/mssql_1
@@ -1728,9 +1743,8 @@ service:
       - transform/mssql_3
       - filter/default__pipeline_mssql_0
       - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
+      - resource/otlp_grpc/otlp_metrics_nomst_metrics_0
+      - batch/otlp_grpc/otlp_metrics_nomst_metrics_1
       receivers:
       - windowsperfcounters/mssql
     metrics/fluentbit:


### PR DESCRIPTION
## Description

This change disables the MetricStartTime processor for MSSQL (v1 and v2) pipelines by routing them to a new set of exporters that omit this processor. This is a temporary change to verify if MetricStartTime is causing the MSSQL integration test failures in CI.

<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
