### PR TITLE
Fix healthcheck port override

### DIFF
--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/filter"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/secret"
@@ -76,11 +77,11 @@ const (
 )
 
 func (uc *UnifiedConfig) GetFluentBitMetricsPort() uint16 {
-	return fluentbit.GetPort()
+	return portutil.GetPortFromEnv(ExperimentalFluentBitMetricsPortEnv, fluentbit.MetricsPort)
 }
 
 func (uc *UnifiedConfig) GetOtelMetricsPort() uint16 {
-	return otel.GetPort()
+	return portutil.GetPortFromEnv(ExperimentalOtelMetricsPortEnv, otel.MetricsPort)
 }
 
 func (uc *UnifiedConfig) DeepCopy(ctx context.Context) (*UnifiedConfig, error) {

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -18,13 +18,11 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -73,26 +71,16 @@ func (uc *UnifiedConfig) HasCombined() bool {
 }
 
 const (
-	ExperimentalFluentBitMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_FLUENT_BIT_METRICS_PORT"
-	ExperimentalOtelMetricsPortEnv      = "EXPERIMENTAL_OPS_AGENT_OTEL_METRICS_PORT"
+	ExperimentalFluentBitMetricsPortEnv = fluentbit.ExperimentalMetricsPortEnv
+	ExperimentalOtelMetricsPortEnv      = otel.ExperimentalMetricsPortEnv
 )
 
 func (uc *UnifiedConfig) GetFluentBitMetricsPort() uint16 {
-	if portStr := os.Getenv(ExperimentalFluentBitMetricsPortEnv); portStr != "" {
-		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
-			return uint16(port)
-		}
-	}
-	return fluentbit.MetricsPort
+	return fluentbit.GetPort()
 }
 
 func (uc *UnifiedConfig) GetOtelMetricsPort() uint16 {
-	if portStr := os.Getenv(ExperimentalOtelMetricsPortEnv); portStr != "" {
-		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
-			return uint16(port)
-		}
-	}
-	return otel.MetricsPort
+	return otel.GetPort()
 }
 
 func (uc *UnifiedConfig) DeepCopy(ctx context.Context) (*UnifiedConfig, error) {

--- a/confgenerator/config.go
+++ b/confgenerator/config.go
@@ -71,17 +71,12 @@ func (uc *UnifiedConfig) HasCombined() bool {
 	return uc.Combined != nil
 }
 
-const (
-	ExperimentalFluentBitMetricsPortEnv = fluentbit.ExperimentalMetricsPortEnv
-	ExperimentalOtelMetricsPortEnv      = otel.ExperimentalMetricsPortEnv
-)
-
 func (uc *UnifiedConfig) GetFluentBitMetricsPort() uint16 {
-	return portutil.GetPortFromEnv(ExperimentalFluentBitMetricsPortEnv, fluentbit.MetricsPort)
+	return portutil.GetPortFromEnv(fluentbit.ExperimentalMetricsPortEnv, fluentbit.MetricsPort)
 }
 
 func (uc *UnifiedConfig) GetOtelMetricsPort() uint16 {
-	return portutil.GetPortFromEnv(ExperimentalOtelMetricsPortEnv, otel.MetricsPort)
+	return portutil.GetPortFromEnv(otel.ExperimentalMetricsPortEnv, otel.MetricsPort)
 }
 
 func (uc *UnifiedConfig) DeepCopy(ctx context.Context) (*UnifiedConfig, error) {

--- a/confgenerator/fluentbit/metrics.go
+++ b/confgenerator/fluentbit/metrics.go
@@ -16,16 +16,10 @@ package fluentbit
 
 import (
 	"strconv"
-
-	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
 )
 
 const MetricsPort = 20202
 const ExperimentalMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_FLUENT_BIT_METRICS_PORT"
-
-func GetPort() uint16 {
-	return portutil.GetPortFromEnv(ExperimentalMetricsPortEnv, MetricsPort)
-}
 
 func MetricsInputComponent() Component {
 	return Component{

--- a/confgenerator/fluentbit/metrics.go
+++ b/confgenerator/fluentbit/metrics.go
@@ -14,9 +14,22 @@
 
 package fluentbit
 
-import "strconv"
+import (
+	"os"
+	"strconv"
+)
 
 const MetricsPort = 20202
+const ExperimentalMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_FLUENT_BIT_METRICS_PORT"
+
+func GetPort() uint16 {
+	if portStr := os.Getenv(ExperimentalMetricsPortEnv); portStr != "" {
+		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
+			return uint16(port)
+		}
+	}
+	return MetricsPort
+}
 
 func MetricsInputComponent() Component {
 	return Component{

--- a/confgenerator/fluentbit/metrics.go
+++ b/confgenerator/fluentbit/metrics.go
@@ -15,20 +15,16 @@
 package fluentbit
 
 import (
-	"os"
 	"strconv"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
 )
 
 const MetricsPort = 20202
 const ExperimentalMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_FLUENT_BIT_METRICS_PORT"
 
 func GetPort() uint16 {
-	if portStr := os.Getenv(ExperimentalMetricsPortEnv); portStr != "" {
-		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
-			return uint16(port)
-		}
-	}
-	return MetricsPort
+	return portutil.GetPortFromEnv(ExperimentalMetricsPortEnv, MetricsPort)
 }
 
 func MetricsInputComponent() Component {

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -18,10 +18,9 @@ package otel
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
-	"strconv"
 
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/mitchellh/mapstructure"
@@ -33,12 +32,7 @@ const MetricsPort = 20201
 const ExperimentalMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_OTEL_METRICS_PORT"
 
 func GetPort() uint16 {
-	if portStr := os.Getenv(ExperimentalMetricsPortEnv); portStr != "" {
-		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
-			return uint16(port)
-		}
-	}
-	return MetricsPort
+	return portutil.GetPortFromEnv(ExperimentalMetricsPortEnv, MetricsPort)
 }
 
 type ExporterType int

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/mitchellh/mapstructure"
@@ -30,10 +29,6 @@ import (
 
 const MetricsPort = 20201
 const ExperimentalMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_OTEL_METRICS_PORT"
-
-func GetPort() uint16 {
-	return portutil.GetPortFromEnv(ExperimentalMetricsPortEnv, MetricsPort)
-}
 
 type ExporterType int
 type ResourceDetectionMode int

--- a/confgenerator/otel/modular.go
+++ b/confgenerator/otel/modular.go
@@ -18,7 +18,9 @@ package otel
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
+	"strconv"
 
 	"github.com/GoogleCloudPlatform/ops-agent/internal/platform"
 	yaml "github.com/goccy/go-yaml"
@@ -28,6 +30,16 @@ import (
 )
 
 const MetricsPort = 20201
+const ExperimentalMetricsPortEnv = "EXPERIMENTAL_OPS_AGENT_OTEL_METRICS_PORT"
+
+func GetPort() uint16 {
+	if portStr := os.Getenv(ExperimentalMetricsPortEnv); portStr != "" {
+		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
+			return uint16(port)
+		}
+	}
+	return MetricsPort
+}
 
 type ExporterType int
 type ResourceDetectionMode int

--- a/confgenerator/port_env_test.go
+++ b/confgenerator/port_env_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestPortOverriddenByEnv(t *testing.T) {
 	// Set env vars
-	os.Setenv(ExperimentalFluentBitMetricsPortEnv, "40002")
-	os.Setenv(ExperimentalOtelMetricsPortEnv, "40001")
-	defer os.Unsetenv(ExperimentalFluentBitMetricsPortEnv)
-	defer os.Unsetenv(ExperimentalOtelMetricsPortEnv)
+	os.Setenv(fluentbit.ExperimentalMetricsPortEnv, "40002")
+	os.Setenv(otel.ExperimentalMetricsPortEnv, "40001")
+	defer os.Unsetenv(fluentbit.ExperimentalMetricsPortEnv)
+	defer os.Unsetenv(otel.ExperimentalMetricsPortEnv)
 
 	uc := &UnifiedConfig{}
 
@@ -28,8 +28,8 @@ func TestPortOverriddenByEnv(t *testing.T) {
 
 func TestPortDefaultWhenEnvEmpty(t *testing.T) {
 	// Ensure env vars are not set
-	os.Unsetenv(ExperimentalFluentBitMetricsPortEnv)
-	os.Unsetenv(ExperimentalOtelMetricsPortEnv)
+	os.Unsetenv(fluentbit.ExperimentalMetricsPortEnv)
+	os.Unsetenv(otel.ExperimentalMetricsPortEnv)
 
 	uc := &UnifiedConfig{}
 
@@ -44,10 +44,10 @@ func TestPortDefaultWhenEnvEmpty(t *testing.T) {
 
 func TestPortInvalidEnvFallbacksToDefault(t *testing.T) {
 	// Set invalid env vars
-	os.Setenv(ExperimentalFluentBitMetricsPortEnv, "invalid")
-	os.Setenv(ExperimentalOtelMetricsPortEnv, "65536") // Out of range for uint16
-	defer os.Unsetenv(ExperimentalFluentBitMetricsPortEnv)
-	defer os.Unsetenv(ExperimentalOtelMetricsPortEnv)
+	os.Setenv(fluentbit.ExperimentalMetricsPortEnv, "invalid")
+	os.Setenv(otel.ExperimentalMetricsPortEnv, "65536") // Out of range for uint16
+	defer os.Unsetenv(fluentbit.ExperimentalMetricsPortEnv)
+	defer os.Unsetenv(otel.ExperimentalMetricsPortEnv)
 
 	uc := &UnifiedConfig{}
 

--- a/confgenerator/portutil/portutil.go
+++ b/confgenerator/portutil/portutil.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portutil
+
+import (
+	"os"
+	"strconv"
+)
+
+// GetPortFromEnv retrieves a port number from the specified environment variable.
+// If the environment variable is not set or contains an invalid port number,
+// it returns the defaultPort.
+func GetPortFromEnv(envVar string, defaultPort uint16) uint16 {
+	if portStr := os.Getenv(envVar); portStr != "" {
+		if port, err := strconv.ParseUint(portStr, 10, 16); err == nil {
+			return uint16(port)
+		}
+	}
+	return defaultPort
+}

--- a/confgenerator/portutil/portutil_test.go
+++ b/confgenerator/portutil/portutil_test.go
@@ -25,30 +25,50 @@ func TestGetPortFromEnv(t *testing.T) {
 	envVar := "TEST_PORT_ENV"
 	defaultPort := uint16(12345)
 
-	// Test 1: Env empty
-	os.Unsetenv(envVar)
-	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != defaultPort {
-		t.Errorf("Expected port %d when env is empty, got %d", defaultPort, port)
+	tests := []struct {
+		name         string
+		setupEnv     func()
+		expectedPort uint16
+	}{
+		{
+			name: "Env empty",
+			setupEnv: func() {
+				os.Unsetenv(envVar)
+			},
+			expectedPort: defaultPort,
+		},
+		{
+			name: "Valid port",
+			setupEnv: func() {
+				os.Setenv(envVar, "54321")
+			},
+			expectedPort: 54321,
+		},
+		{
+			name: "Invalid port (not a number)",
+			setupEnv: func() {
+				os.Setenv(envVar, "invalid")
+			},
+			expectedPort: defaultPort,
+		},
+		{
+			name: "Out of range port",
+			setupEnv: func() {
+				os.Setenv(envVar, "65536")
+			},
+			expectedPort: defaultPort,
+		},
 	}
 
-	// Test 2: Valid port
-	os.Setenv(envVar, "54321")
-	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != 54321 {
-		t.Errorf("Expected port 54321, got %d", port)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setupEnv()
+			defer os.Unsetenv(envVar)
 
-	// Test 3: Invalid port (not a number)
-	os.Setenv(envVar, "invalid")
-	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != defaultPort {
-		t.Errorf("Expected port %d for invalid env value, got %d", defaultPort, port)
+			got := portutil.GetPortFromEnv(envVar, defaultPort)
+			if got != tc.expectedPort {
+				t.Errorf("GetPortFromEnv() = %d, want %d", got, tc.expectedPort)
+			}
+		})
 	}
-
-	// Test 4: Out of range port
-	os.Setenv(envVar, "65536")
-	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != defaultPort {
-		t.Errorf("Expected port %d for out-of-range env value, got %d", defaultPort, port)
-	}
-
-	// Clean up
-	os.Unsetenv(envVar)
 }

--- a/confgenerator/portutil/portutil_test.go
+++ b/confgenerator/portutil/portutil_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portutil_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
+)
+
+func TestGetPortFromEnv(t *testing.T) {
+	envVar := "TEST_PORT_ENV"
+	defaultPort := uint16(12345)
+
+	// Test 1: Env empty
+	os.Unsetenv(envVar)
+	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != defaultPort {
+		t.Errorf("Expected port %d when env is empty, got %d", defaultPort, port)
+	}
+
+	// Test 2: Valid port
+	os.Setenv(envVar, "54321")
+	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != 54321 {
+		t.Errorf("Expected port 54321, got %d", port)
+	}
+
+	// Test 3: Invalid port (not a number)
+	os.Setenv(envVar, "invalid")
+	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != defaultPort {
+		t.Errorf("Expected port %d for invalid env value, got %d", defaultPort, port)
+	}
+
+	// Test 4: Out of range port
+	os.Setenv(envVar, "65536")
+	if port := portutil.GetPortFromEnv(envVar, defaultPort); port != defaultPort {
+		t.Errorf("Expected port %d for out-of-range env value, got %d", defaultPort, port)
+	}
+
+	// Clean up
+	os.Unsetenv(envVar)
+}

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/gce"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/logging"
-	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -40,6 +40,8 @@ import (
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/gce"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/logging"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 
 	"github.com/blang/semver"
 	"github.com/cenkalti/backoff/v4"
@@ -200,10 +202,10 @@ func RunOpsAgentDiagnostics(ctx context.Context, logger *logging.DirectoryLogger
 	// hang, so give them a shorter timeout to avoid hanging the whole test.
 	metricsCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	fbPortCmd := fmt.Sprintf(`sudo bash -c 'PORT=$(systemctl show google-cloud-ops-agent-fluent-bit -p Environment | grep -oP "%s=\K\d+"); if [ -z "$PORT" ]; then PORT=20202; fi; curl -s localhost:$PORT/metrics'`, confgenerator.ExperimentalFluentBitMetricsPortEnv)
+	fbPortCmd := fmt.Sprintf(`sudo bash -c 'PORT=$(systemctl show google-cloud-ops-agent-fluent-bit -p Environment | grep -oP "%s=\K\d+"); if [ -z "$PORT" ]; then PORT=20202; fi; curl -s localhost:$PORT/metrics'`, fluentbit.ExperimentalMetricsPortEnv)
 	gce.RunRemotely(metricsCtx, logger.ToFile("fluent_bit_metrics.txt"), vm, fbPortCmd)
 
-	otelPortCmd := fmt.Sprintf(`sudo bash -c 'PORT=$(systemctl show google-cloud-ops-agent-opentelemetry-collector -p Environment | grep -oP "%s=\K\d+"); if [ -z "$PORT" ]; then PORT=20201; fi; curl -s localhost:$PORT/metrics'`, confgenerator.ExperimentalOtelMetricsPortEnv)
+	otelPortCmd := fmt.Sprintf(`sudo bash -c 'PORT=$(systemctl show google-cloud-ops-agent-opentelemetry-collector -p Environment | grep -oP "%s=\K\d+"); if [ -z "$PORT" ]; then PORT=20201; fi; curl -s localhost:$PORT/metrics'`, otel.ExperimentalMetricsPortEnv)
 	gce.RunRemotely(metricsCtx, logger.ToFile("otel_metrics.txt"), vm, otelPortCmd)
 
 	isUAPPlugin := gce.IsOpsAgentUAPPlugin()

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -66,6 +66,8 @@ import (
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/gce"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/agents"
 	feature_tracking_metadata "github.com/GoogleCloudPlatform/ops-agent/integration_test/feature_tracking"
@@ -6150,14 +6152,14 @@ func TestMetricsPortOverrideEnv(t *testing.T) {
 		if gce.IsWindows(imageSpec) {
 			// Set environment variables via PowerShell
 			setEnvCmd := fmt.Sprintf(`[Environment]::SetEnvironmentVariable("%s", "40002", "Machine"); [Environment]::SetEnvironmentVariable("%s", "40001", "Machine")`,
-				confgenerator.ExperimentalFluentBitMetricsPortEnv, confgenerator.ExperimentalOtelMetricsPortEnv)
+				fluentbit.ExperimentalMetricsPortEnv, otel.ExperimentalMetricsPortEnv)
 			if _, err := gce.RunRemotely(ctx, logger, vm, setEnvCmd); err != nil {
 				t.Fatal(err)
 			}
 			// Cleanup env vars at the end of the test
 			t.Cleanup(func() {
 				unsetEnvCmd := fmt.Sprintf(`[Environment]::SetEnvironmentVariable("%s", $null, "Machine"); [Environment]::SetEnvironmentVariable("%s", $null, "Machine")`,
-					confgenerator.ExperimentalFluentBitMetricsPortEnv, confgenerator.ExperimentalOtelMetricsPortEnv)
+					fluentbit.ExperimentalMetricsPortEnv, otel.ExperimentalMetricsPortEnv)
 				gce.RunRemotely(ctx, logger, vm, unsetEnvCmd)
 			})
 			// Restart agent
@@ -6178,7 +6180,7 @@ func TestMetricsPortOverrideEnv(t *testing.T) {
 			}
 			fbOverrideContent := fmt.Sprintf(`[Service]
 Environment="%s=40002"
-`, confgenerator.ExperimentalFluentBitMetricsPortEnv)
+`, fluentbit.ExperimentalMetricsPortEnv)
 			if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("echo '%s' | sudo tee %s", fbOverrideContent, fbOverrideFile)); err != nil {
 				t.Fatal(err)
 			}
@@ -6192,7 +6194,7 @@ Environment="%s=40002"
 			otelOverrideContent := fmt.Sprintf(`[Service]
 Environment="%s=40001"
 Environment="%s=40002"
-`, confgenerator.ExperimentalOtelMetricsPortEnv, confgenerator.ExperimentalFluentBitMetricsPortEnv)
+`, otel.ExperimentalMetricsPortEnv, fluentbit.ExperimentalMetricsPortEnv)
 			if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("echo '%s' | sudo tee %s", otelOverrideContent, otelOverrideFile)); err != nil {
 				t.Fatal(err)
 			}

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -65,7 +65,6 @@ import (
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal/gce"
-	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/resourcedetector"

--- a/internal/healthchecks/ports_check.go
+++ b/internal/healthchecks/ports_check.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/fluentbit"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
+	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/portutil"
 	"github.com/GoogleCloudPlatform/ops-agent/internal/logs"
 )
 
@@ -66,7 +67,7 @@ func runFluentBitCheck(logger logs.StructuredLogger) error {
 	}
 
 	// Fluent-bit listens on tcp4. Check for fluent-bit self metrics port.
-	err = runPortCheck(logger, int(fluentbit.GetPort()), tcpHost, "tcp4", FbMetricsPortErr)
+	err = runPortCheck(logger, int(portutil.GetPortFromEnv(fluentbit.ExperimentalMetricsPortEnv, fluentbit.MetricsPort)), tcpHost, "tcp4", FbMetricsPortErr)
 	if err != nil {
 		return err
 	}
@@ -83,12 +84,12 @@ func runOtelCollectorCheck(logger logs.StructuredLogger) error {
 	}
 
 	// Opentelemetry-collector listens in both tcp4 and tcp6. Check for opentelemetry-collector self metrics port.
-	err = runPortCheck(logger, int(otel.GetPort()), tcpHost, "tcp4", OtelMetricsPortErr)
+	err = runPortCheck(logger, int(portutil.GetPortFromEnv(otel.ExperimentalMetricsPortEnv, otel.MetricsPort)), tcpHost, "tcp4", OtelMetricsPortErr)
 	if err != nil {
 		return err
 	}
 
-	err = runPortCheck(logger, int(otel.GetPort()), tcp6Host, "tcp6", OtelMetricsPortErr)
+	err = runPortCheck(logger, int(portutil.GetPortFromEnv(otel.ExperimentalMetricsPortEnv, otel.MetricsPort)), tcp6Host, "tcp6", OtelMetricsPortErr)
 	if err != nil {
 		return err
 	}

--- a/internal/healthchecks/ports_check.go
+++ b/internal/healthchecks/ports_check.go
@@ -66,7 +66,7 @@ func runFluentBitCheck(logger logs.StructuredLogger) error {
 	}
 
 	// Fluent-bit listens on tcp4. Check for fluent-bit self metrics port.
-	err = runPortCheck(logger, fluentbit.MetricsPort, tcpHost, "tcp4", FbMetricsPortErr)
+	err = runPortCheck(logger, int(fluentbit.GetPort()), tcpHost, "tcp4", FbMetricsPortErr)
 	if err != nil {
 		return err
 	}
@@ -83,12 +83,12 @@ func runOtelCollectorCheck(logger logs.StructuredLogger) error {
 	}
 
 	// Opentelemetry-collector listens in both tcp4 and tcp6. Check for opentelemetry-collector self metrics port.
-	err = runPortCheck(logger, otel.MetricsPort, tcpHost, "tcp4", OtelMetricsPortErr)
+	err = runPortCheck(logger, int(otel.GetPort()), tcpHost, "tcp4", OtelMetricsPortErr)
 	if err != nil {
 		return err
 	}
 
-	err = runPortCheck(logger, otel.MetricsPort, tcp6Host, "tcp6", OtelMetricsPortErr)
+	err = runPortCheck(logger, int(otel.GetPort()), tcp6Host, "tcp6", OtelMetricsPortErr)
 	if err != nil {
 		return err
 	}
@@ -101,6 +101,11 @@ func runPortCheck(logger logs.StructuredLogger, port int, host, network string, 
 		return err
 	}
 	if !available {
+		if hcErr, ok := healthCheckError.(HealthCheckError); ok {
+			hcErr.Message = fmt.Sprintf("Port %d needed for Ops Agent self metrics is unavailable.", port)
+			hcErr.Action = fmt.Sprintf("Verify that port %d is open.", port)
+			return hcErr
+		}
 		return healthCheckError
 	}
 	logger.Infof("listening to %s:", net.JoinHostPort(host, strconv.Itoa(port)))


### PR DESCRIPTION
## Description
The startup health checks for ports (fluent-bit and otel) were previously hardcoded to check the default ports (20202 and 20201). This caused false-positive warnings/failures on VMs where the default ports were occupied but the user had configured overrides.

This change:
1. Centralizes the port override logic in fluentbit and otel packages.
2. Updates the health checks to use these new methods.
3. Dynamically formats the error messages to report the actual ports checked.

## Related issue
b/515107326

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
