### PR TITLE
Simplify uap plugin architecture

### DIFF
--- a/cmd/ops_agent_uap_plugin/plugin.go
+++ b/cmd/ops_agent_uap_plugin/plugin.go
@@ -50,10 +50,10 @@ var (
 // implementations.
 type RunCommandFunc func(cmd *exec.Cmd) (string, error)
 
-// RunSubAgentCommandFunc defines a function type that starts a subagent. If one subagent execution exited, other sugagents are also terminated via context cancellation. This abstraction is introduced
+// RunSubAgentCommandFunc defines a function type that starts a subagent. This abstraction is introduced
 // primarily to facilitate testing by allowing the injection of mock
 // implementations.
-type RunSubAgentCommandFunc func(ctx context.Context, cancel CancelContextAndSetPluginErrorFunc, cmd *exec.Cmd, runCommand RunCommandFunc, wg *sync.WaitGroup)
+type RunSubAgentCommandFunc func(ctx context.Context, cancel CancelContextAndSetPluginErrorFunc, cmd *exec.Cmd, runCommand RunCommandFunc)
 
 // CancelContextAndSetPluginErrorFunc defines a function type that terminates the Ops Agent from running and records the latest error that occurred.
 // This abstraction is introduced primarily to facilitate testing by allowing the injection of mock implementations.
@@ -185,8 +185,7 @@ func main() {
 	log.Println("Exiting")
 }
 
-func runSubAgentCommand(ctx context.Context, cancelAndSetError CancelContextAndSetPluginErrorFunc, cmd *exec.Cmd, runCommand RunCommandFunc, wg *sync.WaitGroup) {
-	defer wg.Done()
+func runSubAgentCommand(ctx context.Context, cancelAndSetError CancelContextAndSetPluginErrorFunc, cmd *exec.Cmd, runCommand RunCommandFunc) {
 	if cmd == nil {
 		return
 	}

--- a/cmd/ops_agent_uap_plugin/service_linux.go
+++ b/cmd/ops_agent_uap_plugin/service_linux.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"syscall"
 
 	pb "github.com/GoogleCloudPlatform/google-guest-agent/pkg/proto/plugin_comm"
@@ -135,17 +134,12 @@ func runSubagents(ctx context.Context, cancelAndSetError CancelContextAndSetPlug
 		cancelAndSetError(&OpsAgentPluginError{Message: fmt.Sprintf("Received signal: %s, stopping the Ops Agent", s.String()), ShouldRestart: true})
 	})
 
-	var wg sync.WaitGroup
-
 	// Starting Otel
 	runOtelCmd := exec.CommandContext(ctx,
 		path.Join(pluginInstallDirectory, OtelBinary),
 		"--config", path.Join(pluginStateDirectory, OtelRuntimeDirectory, "otel.yaml"),
 	)
-	wg.Add(1)
-	go runSubAgentCommand(ctx, cancelAndSetError, runOtelCmd, runCommand, &wg)
-
-	wg.Wait()
+	runSubAgentCommand(ctx, cancelAndSetError, runOtelCmd, runCommand)
 }
 
 // sigHandler handles SIGTERM, SIGINT etc signals. The function provided in the

--- a/cmd/ops_agent_uap_plugin/service_linux_test.go
+++ b/cmd/ops_agent_uap_plugin/service_linux_test.go
@@ -337,9 +337,17 @@ func Test_runSubAgentCommand_WhenCmdExitsBecauseCtxIsCancelled(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand)
-	time.Sleep(3 * time.Second)
-	cancel()
+	mockRunCommand := func(cmd *exec.Cmd) (string, error) {
+		time.Sleep(10 * time.Second)
+		return runCommand(cmd)
+	}
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		cancel()
+	}()
+
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, mockRunCommand)
 
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() didn't cancel the context but should")

--- a/cmd/ops_agent_uap_plugin/service_linux_test.go
+++ b/cmd/ops_agent_uap_plugin/service_linux_test.go
@@ -23,8 +23,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -270,13 +268,10 @@ func Test_runSubAgentCommand_CancelContextAndSetPluginErrorWhenCmdExitsWithError
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GO_HELPER_FAILURE=1"}
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	pluginServer := &OpsAgentPluginServer{}
 	pluginServer.cancel = cancel
 
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand)
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() did not cancel context but should")
 	}
@@ -295,10 +290,7 @@ func Test_runSubAgentCommand_CancelContextWhenCmdExitsSuccessfully(t *testing.T)
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand)
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() did not cancel context but should")
 	}
@@ -314,24 +306,24 @@ func Test_runSubAgentCommand_CancelContextWhenCmdTerminatedBySignals(t *testing.
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GO_HELPER_KILL_BY_SIGNALS=1"}
-	var wg sync.WaitGroup
-	wg.Add(1)
 
-	mockRunCommandFunc := func(cmd *exec.Cmd) (string, error) {
-		if err := cmd.Start(); err != nil {
-			t.Errorf("the command %s did not start successfully", cmd.Args)
+	// Terminate the command asynchronously using signals once it starts
+	go func() {
+		for {
+			if cmd.Process != nil {
+				cmd.Process.Signal(os.Interrupt)
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
 		}
-		cmd.Process.Signal(syscall.SIGABRT)
-		err := cmd.Wait()
-		return "", err
-	}
+	}()
 
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, mockRunCommandFunc, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand)
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() didn't cancel the context but should")
 	}
 	if pluginServer.pluginError == nil {
-		t.Errorf("runSubAgentCommand() did not set pluginError but should")
+		t.Fatalf("runSubAgentCommand() did not set pluginError but should")
 	}
 	if !pluginServer.pluginError.ShouldRestart {
 		t.Error("runSubAgentCommand() set pluginError.ShouldRestart to false, want true")
@@ -345,10 +337,7 @@ func Test_runSubAgentCommand_WhenCmdExitsBecauseCtxIsCancelled(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommand)
 	time.Sleep(3 * time.Second)
 	cancel()
 
@@ -368,8 +357,8 @@ func Test_runSubagents_TerminatesWhenSpawnedGoRoutinesReturn(t *testing.T) {
 	mockCmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
 	mockCmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GO_HELPER_FAILURE=1"}
 
-	mockRunSubAgentCmd := func(ctx context.Context, cancel CancelContextAndSetPluginErrorFunc, _ *exec.Cmd, runCommand RunCommandFunc, wg *sync.WaitGroup) {
-		runSubAgentCommand(ctx, cancel, mockCmd, runCommand, wg)
+	mockRunSubAgentCmd := func(ctx context.Context, cancel CancelContextAndSetPluginErrorFunc, _ *exec.Cmd, runCommand RunCommandFunc) {
+		runSubAgentCommand(ctx, cancel, mockCmd, runCommand)
 	}
 	runSubagents(ctx, pluginServer.cancelAndSetPluginError, "", "", mockRunSubAgentCmd, runCommand)
 }

--- a/cmd/ops_agent_uap_plugin/service_windows.go
+++ b/cmd/ops_agent_uap_plugin/service_windows.go
@@ -26,7 +26,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"sync"
 	"unsafe"
 
 	_ "github.com/GoogleCloudPlatform/ops-agent/apps"
@@ -272,17 +271,12 @@ func createWindowsJobHandle() (windows.Handle, error) {
 // and GetStatus() returns a non-healthy status, signaling UAP to re-trigger Start().
 func runSubagents(ctx context.Context, cancelAndSetError CancelContextAndSetPluginErrorFunc, pluginInstallDirectory string, pluginStateDirectory string, runSubAgentCommand RunSubAgentCommandFunc, runCommand RunCommandFunc) {
 
-	var wg sync.WaitGroup
-
 	// Starting Otel
 	runOtelCmd := exec.CommandContext(ctx,
 		path.Join(pluginInstallDirectory, OtelBinary),
 		"--config", path.Join(pluginStateDirectory, GeneratedConfigsOutDir, "otel/otel.yaml"),
 	)
-	wg.Add(1)
-	go runSubAgentCommand(ctx, cancelAndSetError, runOtelCmd, runCommand, &wg)
-
-	wg.Wait()
+	runSubAgentCommand(ctx, cancelAndSetError, runOtelCmd, runCommand)
 }
 
 func runCommand(cmd *exec.Cmd) (string, error) {

--- a/cmd/ops_agent_uap_plugin/service_windows_test.go
+++ b/cmd/ops_agent_uap_plugin/service_windows_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"sync"
 	"testing"
 	"time"
 
@@ -297,10 +296,7 @@ func Test_runSubAgentCommand_CancelContextWhenCmdExitsSuccessfully(t *testing.T)
 	pluginServer.cancel = cancel
 	cmd := exec.CommandContext(ctx, "fake-command")
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommandSuccessfully, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommandSuccessfully)
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() did not cancel context but should")
 	}
@@ -319,9 +315,7 @@ func Test_runSubAgentCommand_CancelContextWhenCmdExitsWithErrors(t *testing.T) {
 	pluginServer.cancel = cancel
 	cmd := exec.CommandContext(ctx, "fake-command")
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommandAndFailed, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, runCommandAndFailed)
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() did not cancel context but should")
 	}
@@ -344,13 +338,7 @@ func Test_runSubAgentCommand_WhenCmdExitsBecauseCtxIsCancelled(t *testing.T) {
 		return runCommand(cmd)
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		time.Sleep(2 * time.Second)
-		cancel()
-	}()
-	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, mockRunCommand, &wg)
+	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, mockRunCommand)
 
 	if ctx.Err() != context.Canceled {
 		t.Error("runSubAgentCommand() didn't cancel the context but should")

--- a/cmd/ops_agent_uap_plugin/service_windows_test.go
+++ b/cmd/ops_agent_uap_plugin/service_windows_test.go
@@ -338,6 +338,11 @@ func Test_runSubAgentCommand_WhenCmdExitsBecauseCtxIsCancelled(t *testing.T) {
 		return runCommand(cmd)
 	}
 
+	go func() {
+		time.Sleep(2 * time.Second)
+		cancel()
+	}()
+
 	runSubAgentCommand(ctx, pluginServer.cancelAndSetPluginError, cmd, mockRunCommand)
 
 	if ctx.Err() != context.Canceled {


### PR DESCRIPTION
## Description
With Fluent Bit completely removed, there is no longer a need to maintain complex lifecycle synchronization across multiple subagents. We have simplified the `cmd/ops_agent_uap_plugin` subagent loops to execute OTel collector directly:
- Removed `sync.WaitGroup` and goroutine spawning from `runSubagents` on both Linux and Windows.
- Removed `sync.WaitGroup` parameters and `defer wg.Done()` from `runSubAgentCommand`.
- Simplified `RunSubAgentCommandFunc` type definition to omit the `WaitGroup` parameter.
- Deleted `sync` package imports from `service_linux.go` and `service_windows.go`.
- Simplified all UAP plugin linux/windows unit tests to remove `WaitGroup` declarations and calls.

## Related issue
b/517494318

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
