### PR TITLE
Decommission Fluent Bit self-metrics scraping from OpenTelemetry pipelines

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -241,7 +241,6 @@ func (r AgentSelfMetrics) OtelPipelineProcessors(ctx context.Context) []otel.Com
 	}
 }
 
-
 func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) []otel.Component {
 	durationMetric := "grpc.client.attempt.duration"
 	durationCountMetric := "grpc.client.attempt.duration_count"
@@ -251,13 +250,7 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 		`metric.name == "` + durationCountMetric + `" and (not IsMatch(datapoint.attributes["grpc.target"], "logging.googleapis"))`,
 	})
 
-	otelRequestCount := otel.RenameMetric(durationCountMetric, "otel_request_count",
-		otel.RenameLabel("grpc.status", "response_code"),
-		otel.RenameLabelValues("response_code", grpcToHTTPStatus),
-		// delete grpc_client_method dimension & service.version label, retaining only response_code
-		otel.AggregateLabels("sum", "response_code"),
-	)
-
+	var agentRequestCount map[string]interface{}
 	expOtlpExporter := experiments.FromContext(ctx)["otlp_exporter"]
 	if expOtlpExporter {
 		durationMetric = "rpc.client.call.duration"
@@ -267,11 +260,17 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 			// Filter out histogram datapoints where the rpc.method is not related to logging.
 			`metric.name == "` + durationCountMetric + `" and (not IsMatch(datapoint.attributes["rpc.method"], "opentelemetry.proto.collector.logs.v1.LogsService/Export"))`,
 		})
-		otelRequestCount = otel.RenameMetric(durationCountMetric, "otel_request_count",
+		agentRequestCount = otel.RenameMetric(durationCountMetric, "agent/request_count",
 			otel.RenameLabelValues("rpc.response.status_code", otelErrorTypeToStatus),
-
 			otel.RenameLabel("rpc.response.status_code", "response_code"),
 			otel.RenameLabelValues("response_code", grpcToHTTPStatus),
+			otel.AggregateLabels("sum", "response_code"),
+		)
+	} else {
+		agentRequestCount = otel.RenameMetric(durationCountMetric, "agent/request_count",
+			otel.RenameLabel("grpc.status", "response_code"),
+			otel.RenameLabelValues("response_code", grpcToHTTPStatus),
+			// delete grpc_client_method dimension & service.version label, retaining only response_code
 			otel.AggregateLabels("sum", "response_code"),
 		)
 	}
@@ -288,66 +287,38 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 			"otelcol_exporter_send_failed_log_records",
 			durationCountMetric,
 		),
-		// Format otel logging metrics before aggregation.
+		// Format otel logging metrics directly to target agent.googleapis.com/agent/ metrics.
 		otel.MetricsTransform(
-			otel.DuplicateMetric("otelcol_exporter_send_failed_log_records", "otel_log_entry_retry_count",
+			otel.DuplicateMetric("otelcol_exporter_send_failed_log_records", "agent/log_entry_retry_count",
 				// change data type from double -> int64
 				otel.ToggleScalarDataType,
 				otel.AddLabel("response_code", "400"),
 				otel.AggregateLabels("sum", "response_code"),
 			),
-			otelRequestCount,
-			otel.RenameMetric("otelcol_exporter_sent_log_records", "otel_log_entry_count",
+			agentRequestCount,
+			otel.RenameMetric("otelcol_exporter_sent_log_records", "agent/log_entry_count",
 				// change data type from double -> int64
 				otel.ToggleScalarDataType,
 				otel.AddLabel("response_code", "200"),
 				otel.AggregateLabels("sum", "response_code"),
 			),
-			otel.RenameMetric("otelcol_exporter_send_failed_log_records", "otel_log_entry_count",
+			otel.RenameMetric("otelcol_exporter_send_failed_log_records", "agent/log_entry_count",
 				// change data type from double -> int64
 				otel.ToggleScalarDataType,
 				otel.AddLabel("response_code", "400"),
 				otel.AggregateLabels("sum", "response_code"),
 			),
-			otel.CombineMetrics("^otel_log_entry_count$$", "otel_log_entry_count",
+			// Merge response_code dimensions under a single agent/log_entry_count metric object.
+			otel.CombineMetrics(`^agent/log_entry_count$`, "agent/log_entry_count",
 				otel.AggregateLabels("sum", "response_code")),
 		),
-		// Aggregating as delta metrics isolates data for only the most recent metric cumulative update.
-		// Set `initial_value: drop" to always store the "first point" as "anchor" to set the "start_time" and
-		// calculate next point values as difference with the "first point" value.
-		otel.CumulativeToDeltaWithInitialValue("drop",
-			"otel_log_entry_count", "otel_log_entry_retry_count", "otel_request_count",
-		),
 		otel.TransformationMetrics(
-			// Set "start_time_unix_nano = 0" and "time = Now()" so "deltatocumulative" can sum all points
-			// without "out of order" or "older start" errors.
-			// TODO: b/445233472 - Update "deltatocumulative" processor with a new "strategy" for point aggreagation.
-			otel.TransformQuery{
-				Context:   otel.Datapoint,
-				Statement: `set(time, Now())`,
-			},
-			otel.TransformQuery{
-				Context:   otel.Datapoint,
-				Statement: `set(start_time_unix_nano, 0)`,
-			},
 			// Set unit = "1" to metrics who may not have it.
 			otel.TransformQuery{
 				Context:   otel.Metric,
 				Statement: `set(unit, "1")`,
 			},
-			// Rename metrics for aggregation by "deltatocumulative".
-			otel.SetName("otel_log_entry_count", "agent/log_entry_count"),
-			otel.SetName("otel_log_entry_retry_count", "agent/log_entry_retry_count"),
-			otel.SetName("otel_request_count", "agent/request_count"),
 		),
-		otel.MetricsTransform(
-			otel.CombineMetrics(`^agent/log_entry_count$`, "agent/log_entry_count", otel.AggregateLabels("sum", "response_code")),
-			otel.CombineMetrics(`^agent/log_entry_retry_count$`, "agent/log_entry_retry_count", otel.AggregateLabels("sum", "response_code")),
-			otel.CombineMetrics(`^agent/request_count$`, "agent/request_count", otel.AggregateLabels("sum", "response_code")),
-		),
-		// DeltaToCumulative keeps in memory information of previous delta points
-		// to generate a valid cumulative monotonic metric.
-		otel.DeltaToCumulative(),
 		// The processor "interval" outputs the last point in each 1 minute interval.
 		otel.Interval("1m"),
 		otel.MetricsTransform(otel.AddPrefix("agent.googleapis.com")),

--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -30,8 +30,6 @@ import (
 // Therefore, it does not need to implement any interfaces.
 type AgentSelfMetrics struct {
 	MetricsVersionLabel string
-	LoggingVersionLabel string
-	FluentBitPort       int
 	OtelPort            int
 	OtelRuntimeDir      string
 }
@@ -95,12 +93,6 @@ func (r AgentSelfMetrics) AddSelfMetricsPipelines(receiverPipelines map[string]o
 		Processors:           r.OtelPipelineProcessors(ctx),
 	}
 
-	pipelines["fluentbit"] = otel.Pipeline{
-		Type:                 "metrics",
-		ReceiverPipelineName: "agent_prometheus",
-		Processors:           r.FluentBitPipelineProcessors(),
-	}
-
 	pipelines["loggingmetrics"] = otel.Pipeline{
 		Type:                 "metrics",
 		ReceiverPipelineName: "agent_prometheus",
@@ -121,15 +113,7 @@ func (r AgentSelfMetrics) PrometheusMetricsPipeline(ctx context.Context) otel.Re
 			Config: map[string]interface{}{
 				"config": map[string]interface{}{
 					"scrape_configs": []map[string]interface{}{
-						{
-							"job_name":        "logging-collector",
-							"scrape_interval": "1m",
-							"metrics_path":    "/metrics",
-							"static_configs": []map[string]interface{}{{
-								// TODO(b/196990135): Customization for the port number
-								"targets": []string{fmt.Sprintf("0.0.0.0:%d", r.FluentBitPort)},
-							}},
-						},
+
 						{
 							"job_name":        "otel-collector",
 							"scrape_interval": "1m",
@@ -257,25 +241,6 @@ func (r AgentSelfMetrics) OtelPipelineProcessors(ctx context.Context) []otel.Com
 	}
 }
 
-func (r AgentSelfMetrics) FluentBitPipelineProcessors() []otel.Component {
-	return []otel.Component{
-		otel.MetricsFilter(
-			"include",
-			"strict",
-			"fluentbit_uptime",
-		),
-		otel.MetricsTransform(
-			otel.RenameMetric("fluentbit_uptime", "agent/uptime",
-				// change data type from double -> int64
-				otel.ToggleScalarDataType,
-				otel.AddLabel("version", r.LoggingVersionLabel),
-				// remove service.version label
-				otel.AggregateLabels("sum", "version"),
-			),
-			otel.AddPrefix("agent.googleapis.com"),
-		),
-	}
-}
 
 func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) []otel.Component {
 	durationMetric := "grpc.client.attempt.duration"
@@ -319,40 +284,19 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 		otel.MetricsFilter(
 			"include",
 			"strict",
-			"fluentbit_stackdriver_requests_total",
-			"fluentbit_stackdriver_proc_records_total",
-			"fluentbit_stackdriver_retried_records_total",
 			"otelcol_exporter_sent_log_records",
 			"otelcol_exporter_send_failed_log_records",
 			durationCountMetric,
 		),
-		// Format fluentbit and otel logging metrics before aggregation.
+		// Format otel logging metrics before aggregation.
 		otel.MetricsTransform(
-			otel.RenameMetric("fluentbit_stackdriver_retried_records_total", "fluentbit_log_entry_retry_count",
-				// change data type from double -> int64
-				otel.ToggleScalarDataType,
-				otel.RenameLabel("status", "response_code"),
-				otel.AggregateLabels("sum", "response_code"),
-			),
 			otel.DuplicateMetric("otelcol_exporter_send_failed_log_records", "otel_log_entry_retry_count",
 				// change data type from double -> int64
 				otel.ToggleScalarDataType,
 				otel.AddLabel("response_code", "400"),
 				otel.AggregateLabels("sum", "response_code"),
 			),
-			otel.RenameMetric("fluentbit_stackdriver_requests_total", "fluentbit_request_count",
-				// change data type from double -> int64
-				otel.ToggleScalarDataType,
-				otel.RenameLabel("status", "response_code"),
-				otel.AggregateLabels("sum", "response_code"),
-			),
 			otelRequestCount,
-			otel.RenameMetric("fluentbit_stackdriver_proc_records_total", "fluentbit_log_entry_count",
-				// change data type from double -> int64
-				otel.ToggleScalarDataType,
-				otel.RenameLabel("status", "response_code"),
-				otel.AggregateLabels("sum", "response_code"),
-			),
 			otel.RenameMetric("otelcol_exporter_sent_log_records", "otel_log_entry_count",
 				// change data type from double -> int64
 				otel.ToggleScalarDataType,
@@ -373,7 +317,6 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 		// calculate next point values as difference with the "first point" value.
 		otel.CumulativeToDeltaWithInitialValue("drop",
 			"otel_log_entry_count", "otel_log_entry_retry_count", "otel_request_count",
-			"fluentbit_log_entry_count", "fluentbit_log_entry_retry_count", "fluentbit_request_count",
 		),
 		otel.TransformationMetrics(
 			// Set "start_time_unix_nano = 0" and "time = Now()" so "deltatocumulative" can sum all points
@@ -393,9 +336,6 @@ func (r AgentSelfMetrics) LoggingMetricsPipelineProcessors(ctx context.Context) 
 				Statement: `set(unit, "1")`,
 			},
 			// Rename metrics for aggregation by "deltatocumulative".
-			otel.SetName("fluentbit_log_entry_count", "agent/log_entry_count"),
-			otel.SetName("fluentbit_log_entry_retry_count", "agent/log_entry_retry_count"),
-			otel.SetName("fluentbit_request_count", "agent/request_count"),
 			otel.SetName("otel_log_entry_count", "agent/log_entry_count"),
 			otel.SetName("otel_log_entry_retry_count", "agent/log_entry_retry_count"),
 			otel.SetName("otel_request_count", "agent/request_count"),

--- a/confgenerator/confgenerator.go
+++ b/confgenerator/confgenerator.go
@@ -210,7 +210,6 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 	p := platform.FromContext(ctx)
 	userAgent, _ := p.UserAgent("Google-Cloud-Ops-Agent-Metrics")
 	metricVersionLabel, _ := p.VersionLabel("google-cloud-ops-agent-metrics")
-	loggingVersionLabel, _ := p.VersionLabel("google-cloud-ops-agent-logging")
 
 	receiverPipelines, pipelines, err := uc.generateOtelPipelines(ctx)
 	if err != nil {
@@ -219,8 +218,6 @@ func (uc *UnifiedConfig) GenerateOtelConfig(ctx context.Context, outDir, stateDi
 
 	agentSelfMetrics := AgentSelfMetrics{
 		MetricsVersionLabel: metricVersionLabel,
-		LoggingVersionLabel: loggingVersionLabel,
-		FluentBitPort:       int(uc.GetFluentBitMetricsPort()),
 		OtelPort:            int(uc.GetOtelMetricsPort()),
 		OtelRuntimeDir:      outDir,
 	}

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -406,18 +376,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -426,18 +384,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -486,18 +432,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -646,9 +580,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -736,12 +667,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -779,17 +704,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -378,7 +369,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -390,7 +381,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -438,7 +429,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,18 +452,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -482,27 +461,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,18 +530,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -713,12 +665,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -382,18 +352,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -402,18 +360,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -462,18 +408,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -622,9 +556,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -710,12 +641,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -744,17 +669,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -354,7 +345,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -366,7 +357,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -414,7 +405,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -437,18 +428,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -458,27 +437,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -547,18 +506,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -678,12 +630,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -389,18 +359,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -409,18 +367,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -469,18 +415,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -629,9 +563,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -720,12 +651,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -754,17 +679,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -361,7 +352,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -373,7 +364,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,18 +435,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -465,27 +444,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -554,18 +513,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -688,12 +640,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -389,18 +359,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -409,18 +367,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -469,18 +415,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -629,9 +563,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -720,12 +651,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -754,17 +679,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -361,7 +352,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -373,7 +364,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,18 +435,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -465,27 +444,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -554,18 +513,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -688,12 +640,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -799,17 +724,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/host_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -753,12 +705,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -703,12 +655,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -758,17 +683,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/host_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -721,9 +655,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -791,12 +722,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -838,17 +763,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -646,18 +605,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_journald_0:
     error_mode: ignore
     log_statements:
@@ -772,12 +724,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -692,9 +626,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -797,17 +722,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -617,18 +576,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_journald_0:
     error_mode: ignore
     log_statements:
@@ -731,12 +683,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -699,12 +651,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -765,17 +690,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -433,18 +403,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -453,18 +411,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -513,18 +459,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -681,9 +615,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -814,12 +745,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -867,17 +792,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -405,7 +396,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -417,7 +408,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -465,7 +456,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -477,7 +468,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -488,18 +479,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -509,27 +488,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -606,18 +565,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -801,12 +753,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -376,7 +367,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -388,7 +379,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -459,18 +450,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -480,27 +459,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -577,18 +536,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -760,12 +712,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -110,24 +98,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -404,18 +374,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -424,18 +382,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -484,18 +430,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -652,9 +586,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -783,12 +714,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -826,17 +751,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1183,12 +1114,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1327,17 +1252,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1261,12 +1213,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1183,12 +1114,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1327,17 +1252,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1261,12 +1213,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -108,24 +96,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -426,18 +396,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -446,18 +404,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -506,18 +452,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -688,9 +622,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -782,12 +713,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -827,17 +752,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -398,7 +389,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -410,7 +401,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -458,7 +449,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -470,7 +461,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -481,18 +472,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -502,27 +481,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -613,18 +572,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -761,12 +713,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -369,7 +360,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -381,7 +372,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -429,7 +420,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -441,7 +432,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -452,18 +443,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -473,27 +452,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -584,18 +543,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -720,12 +672,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -54,12 +51,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -78,9 +69,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -397,18 +367,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -417,18 +375,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -477,18 +423,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -659,9 +593,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -751,12 +682,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -786,17 +711,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -657,18 +616,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1221,12 +1173,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -113,24 +101,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -732,9 +666,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1151,12 +1082,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1287,17 +1212,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -657,18 +616,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1221,12 +1173,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -113,24 +101,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -732,9 +666,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1151,12 +1082,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1287,17 +1212,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -61,12 +58,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -85,9 +76,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -116,24 +104,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -434,18 +404,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -454,18 +412,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -514,18 +460,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -696,9 +630,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -790,12 +721,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -835,17 +760,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -98,7 +89,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -406,7 +397,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -418,7 +409,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -466,7 +457,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -489,18 +480,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -510,27 +489,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -621,18 +580,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -769,12 +721,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -92,7 +83,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -376,7 +367,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -388,7 +379,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -459,18 +450,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -480,27 +459,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -591,18 +550,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -727,12 +679,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -110,24 +98,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -404,18 +374,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -424,18 +382,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -484,18 +430,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -666,9 +600,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -758,12 +689,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -793,17 +718,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -67,12 +64,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,9 +82,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -122,24 +110,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -451,18 +421,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -471,18 +429,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -531,18 +477,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -741,9 +675,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1160,12 +1091,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1296,17 +1221,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -423,7 +414,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -483,7 +474,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -495,7 +486,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -506,18 +497,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -527,27 +506,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -666,18 +625,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1230,12 +1182,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -67,12 +64,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,9 +82,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -122,24 +110,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -451,18 +421,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -471,18 +429,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -531,18 +477,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -741,9 +675,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1160,12 +1091,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1296,17 +1221,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/utilization$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -423,7 +414,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -483,7 +474,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -495,7 +486,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -506,18 +497,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -527,27 +506,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -666,18 +625,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1230,12 +1182,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -405,7 +396,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -417,7 +408,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -465,7 +456,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -477,7 +468,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -488,18 +479,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -509,27 +488,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -606,18 +565,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -764,12 +716,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -433,18 +403,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -453,18 +411,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -513,18 +459,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -681,9 +615,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -785,12 +716,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -830,17 +755,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -376,7 +367,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -388,7 +379,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -459,18 +450,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -480,27 +459,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -577,18 +536,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -723,12 +675,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -110,24 +98,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -404,18 +374,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -424,18 +382,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -484,18 +430,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -652,9 +586,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -754,12 +685,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -789,17 +714,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1154,12 +1085,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1154,12 +1085,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -405,7 +396,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -417,7 +408,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -465,7 +456,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -477,7 +468,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -488,18 +479,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -509,27 +488,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -606,18 +565,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -764,12 +716,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -433,18 +403,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -453,18 +411,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -513,18 +459,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -681,9 +615,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -785,12 +716,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -830,17 +755,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -376,7 +367,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -388,7 +379,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -459,18 +450,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -480,27 +459,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -577,18 +536,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -723,12 +675,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -110,24 +98,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -404,18 +374,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -424,18 +382,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -484,18 +430,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -652,9 +586,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -754,12 +685,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -789,17 +714,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1154,12 +1085,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1154,12 +1085,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -405,7 +396,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -417,7 +408,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -465,7 +456,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -477,7 +468,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -488,18 +479,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -509,27 +488,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -606,18 +565,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -764,12 +716,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -433,18 +403,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -453,18 +411,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -513,18 +459,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -681,9 +615,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -785,12 +716,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -830,17 +755,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -376,7 +367,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -388,7 +379,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -459,18 +450,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -480,27 +459,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -577,18 +536,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -723,12 +675,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -110,24 +98,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -404,18 +374,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -424,18 +382,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -484,18 +430,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -652,9 +586,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -754,12 +685,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -789,17 +714,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1154,12 +1085,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -41,15 +41,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -104,7 +95,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -421,7 +412,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,7 +484,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -504,18 +495,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -525,27 +504,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -650,18 +609,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -48,9 +48,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -68,12 +65,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -92,9 +83,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -120,24 +108,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -449,18 +419,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -469,18 +427,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -529,18 +475,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -725,9 +659,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1154,12 +1085,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -397,7 +388,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -409,7 +400,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -457,7 +448,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -469,7 +460,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,18 +471,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -501,27 +480,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -594,18 +553,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -752,12 +704,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -425,18 +395,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -445,18 +403,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -505,18 +451,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -669,9 +603,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -773,12 +704,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -818,17 +743,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -396,18 +366,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -416,18 +374,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -476,18 +422,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -640,9 +574,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -742,12 +673,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -777,17 +702,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -368,7 +359,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -380,7 +371,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -428,7 +419,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -440,7 +431,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -451,18 +442,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -472,27 +451,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -565,18 +524,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -711,12 +663,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -112,24 +100,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -441,18 +411,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -461,18 +419,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -521,18 +467,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -713,9 +647,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1142,12 +1073,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1278,17 +1203,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -413,7 +404,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -425,7 +416,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -473,7 +464,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -485,7 +476,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -496,18 +487,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -517,27 +496,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -638,18 +597,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1212,12 +1164,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -112,24 +100,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -441,18 +411,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -461,18 +419,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -521,18 +467,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -713,9 +647,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1142,12 +1073,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1278,17 +1203,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -413,7 +404,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -425,7 +416,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -473,7 +464,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -485,7 +476,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -496,18 +487,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -517,27 +496,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -638,18 +597,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1212,12 +1164,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +98,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -413,7 +404,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -425,7 +416,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -524,7 +515,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -536,7 +527,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -547,18 +538,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -568,27 +547,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -897,18 +856,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1231,12 +1183,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -70,12 +67,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -94,9 +85,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -123,24 +111,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -441,18 +411,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -461,18 +419,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -572,18 +518,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -972,9 +906,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1196,12 +1127,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1295,21 +1220,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +93,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -384,7 +375,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -396,7 +387,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -495,7 +486,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -518,18 +509,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -539,27 +518,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -853,18 +812,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1171,12 +1123,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -65,12 +62,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,9 +80,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -118,24 +106,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -412,18 +382,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -432,18 +390,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -543,18 +489,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -928,9 +862,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1150,12 +1081,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1235,21 +1160,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +103,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -429,7 +420,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -441,7 +432,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -540,7 +531,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -552,7 +543,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -563,18 +554,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -584,27 +563,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -941,18 +900,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1718,12 +1670,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -75,12 +72,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,9 +90,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -128,24 +116,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -457,18 +427,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -477,18 +435,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -588,18 +534,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -1016,9 +950,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1580,12 +1511,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1782,21 +1707,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +103,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -429,7 +420,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -441,7 +432,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -540,7 +531,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -552,7 +543,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -563,18 +554,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -584,27 +563,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -941,18 +900,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1718,12 +1670,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -75,12 +72,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,9 +90,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -128,24 +116,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -457,18 +427,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -477,18 +435,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -588,18 +534,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -1016,9 +950,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1580,12 +1511,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1782,21 +1707,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -70,12 +67,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -94,9 +85,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -123,24 +111,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -441,18 +411,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -461,18 +419,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -572,18 +518,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -943,9 +877,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1110,12 +1041,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1180,21 +1105,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -107,7 +98,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -413,7 +404,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -425,7 +416,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -524,7 +515,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -536,7 +527,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -547,18 +538,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -568,27 +547,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -868,18 +827,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1116,12 +1068,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +93,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -384,7 +375,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -396,7 +387,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -495,7 +486,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -518,18 +509,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -539,27 +518,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -824,18 +783,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1056,12 +1008,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -65,12 +62,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,9 +80,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -118,24 +106,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -412,18 +382,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -432,18 +390,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -543,18 +489,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -899,9 +833,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1064,12 +995,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1120,21 +1045,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +103,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -429,7 +420,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -441,7 +432,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -540,7 +531,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -552,7 +543,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -563,18 +554,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -584,27 +563,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -912,18 +871,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1603,12 +1555,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -75,12 +72,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,9 +90,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -128,24 +116,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -457,18 +427,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -477,18 +435,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -588,18 +534,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -987,9 +921,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1494,12 +1425,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1667,21 +1592,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -48,15 +48,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -112,7 +103,7 @@ processors:
     - namespace
     - cluster
     - location
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -429,7 +420,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -441,7 +432,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -540,7 +531,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -552,7 +543,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -563,18 +554,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -584,27 +563,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -912,18 +871,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1603,12 +1555,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -55,9 +55,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -75,12 +72,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -99,9 +90,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -128,24 +116,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -457,18 +427,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -477,18 +435,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -588,18 +534,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -987,9 +921,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1494,12 +1425,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1667,21 +1592,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -64,7 +55,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -370,7 +361,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -382,7 +373,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -430,7 +421,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,7 +433,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -453,18 +444,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -474,27 +453,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -563,18 +522,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -652,12 +604,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -33,12 +30,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -57,9 +48,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -80,24 +68,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -398,18 +368,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -418,18 +376,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -478,18 +424,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -638,9 +572,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -683,12 +614,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -718,17 +643,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -59,7 +50,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -341,7 +332,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -353,7 +344,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -401,7 +392,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -413,7 +404,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,18 +415,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -445,27 +424,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -534,18 +493,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -611,12 +563,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -28,12 +25,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -52,9 +43,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -75,24 +63,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -369,18 +339,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -389,18 +347,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -449,18 +395,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -609,9 +543,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -652,12 +583,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -677,17 +602,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -69,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -386,7 +377,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -398,7 +389,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -446,7 +437,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -458,7 +449,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -469,18 +460,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -490,27 +469,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -607,18 +566,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -748,12 +700,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -38,12 +35,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -62,9 +53,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -85,24 +73,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -414,18 +384,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -434,18 +392,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -494,18 +440,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -682,9 +616,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -734,12 +665,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -814,17 +739,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -69,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -386,7 +377,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -398,7 +389,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -446,7 +437,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -458,7 +449,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -469,18 +460,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -490,27 +469,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -607,18 +566,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -748,12 +700,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -38,12 +35,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -62,9 +53,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -85,24 +73,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -414,18 +384,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -434,18 +392,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -494,18 +440,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -682,9 +616,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -734,12 +665,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -814,17 +739,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -64,7 +55,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -370,7 +361,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -382,7 +373,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -430,7 +421,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,7 +433,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -453,18 +444,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -474,27 +453,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -563,18 +522,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -652,12 +604,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -33,12 +30,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -57,9 +48,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -80,24 +68,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -398,18 +368,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -418,18 +376,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -478,18 +424,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -638,9 +572,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -683,12 +614,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -718,17 +643,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -59,7 +50,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -341,7 +332,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -353,7 +344,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -401,7 +392,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -413,7 +404,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,18 +415,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -445,27 +424,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -534,18 +493,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -611,12 +563,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -28,12 +25,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -52,9 +43,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -75,24 +63,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -369,18 +339,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -389,18 +347,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -449,18 +395,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -609,9 +543,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -652,12 +583,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -677,17 +602,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -69,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -386,7 +377,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -398,7 +389,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -446,7 +437,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -458,7 +449,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -469,18 +460,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -490,27 +469,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -607,18 +566,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -748,12 +700,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -38,12 +35,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -62,9 +53,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -85,24 +73,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -414,18 +384,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -434,18 +392,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -494,18 +440,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -682,9 +616,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -734,12 +665,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -814,17 +739,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -11,15 +11,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -69,7 +60,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -386,7 +377,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -398,7 +389,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -446,7 +437,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -458,7 +449,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -469,18 +460,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -490,27 +469,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -607,18 +566,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -748,12 +700,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -18,9 +18,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -38,12 +35,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -62,9 +53,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -85,24 +73,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -414,18 +384,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -434,18 +392,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -494,18 +440,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -682,9 +616,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -734,12 +665,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -814,17 +739,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -198,7 +189,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -504,7 +495,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -516,7 +507,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -564,7 +555,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -576,7 +567,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -587,18 +578,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -608,27 +587,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -697,18 +656,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -916,12 +868,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -214,24 +202,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -532,18 +502,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -552,18 +510,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -612,18 +558,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -772,9 +706,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -906,12 +837,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -982,17 +907,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -206,7 +197,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -512,7 +503,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -524,7 +515,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -623,7 +614,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -635,7 +626,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -646,18 +637,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -667,27 +646,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -941,18 +900,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1209,12 +1161,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -222,24 +210,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -540,18 +510,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -560,18 +518,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -671,18 +617,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -1016,9 +950,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1180,12 +1111,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1273,21 +1198,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -209,24 +197,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -503,18 +473,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -523,18 +481,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -583,18 +529,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -743,9 +677,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -875,12 +806,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -941,17 +866,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -193,7 +184,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -475,7 +466,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,7 +478,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -547,7 +538,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -558,18 +549,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -579,27 +558,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -668,18 +627,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -875,12 +827,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -217,24 +205,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -511,18 +481,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -531,18 +489,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -642,18 +588,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -972,9 +906,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1134,12 +1065,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1213,21 +1138,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -201,7 +192,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -483,7 +474,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -495,7 +486,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -594,7 +585,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -606,7 +597,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -617,18 +608,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -638,27 +617,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -897,18 +856,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1149,12 +1101,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -219,24 +207,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -548,18 +518,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -568,18 +526,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,18 +574,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -816,9 +750,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1275,12 +1206,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1442,17 +1367,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -203,7 +194,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -520,7 +511,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -532,7 +523,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -580,7 +571,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -592,7 +583,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -603,18 +594,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -624,27 +603,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -741,18 +700,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1376,12 +1328,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -211,7 +202,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -528,7 +519,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -540,7 +531,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -639,7 +630,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -651,7 +642,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -662,18 +653,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -683,27 +662,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -985,18 +944,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1696,12 +1648,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -227,24 +215,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -556,18 +526,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -576,18 +534,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -687,18 +633,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -1060,9 +994,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1564,12 +1495,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1760,21 +1685,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -219,24 +207,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -548,18 +518,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -568,18 +526,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,18 +574,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -816,9 +750,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1275,12 +1206,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1442,17 +1367,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -203,7 +194,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -520,7 +511,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -532,7 +523,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -580,7 +571,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -592,7 +583,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -603,18 +594,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -624,27 +603,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -741,18 +700,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1376,12 +1328,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -211,7 +202,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -528,7 +519,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -540,7 +531,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -639,7 +630,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -651,7 +642,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -662,18 +653,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -683,27 +662,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -985,18 +944,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1696,12 +1648,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -227,24 +215,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -556,18 +526,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -576,18 +534,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -687,18 +633,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -1060,9 +994,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1564,12 +1495,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1760,21 +1685,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -879,12 +810,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -933,17 +858,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -867,12 +819,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -900,9 +834,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1153,12 +1084,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1224,21 +1149,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -825,18 +784,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1160,12 +1112,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -848,12 +779,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -892,17 +817,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -826,12 +778,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -856,9 +790,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1107,12 +1038,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1164,21 +1089,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -781,18 +740,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1100,12 +1052,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1327,12 +1279,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1248,12 +1179,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1393,17 +1318,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1537,12 +1468,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1711,21 +1636,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1647,12 +1599,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1327,12 +1279,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1248,12 +1179,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1393,17 +1318,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1537,12 +1468,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1711,21 +1636,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1647,12 +1599,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -794,12 +725,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -848,17 +773,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -782,12 +734,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -763,12 +694,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -807,17 +732,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -741,12 +693,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1242,12 +1194,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1308,17 +1233,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1242,12 +1194,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1308,17 +1233,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -846,12 +777,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -900,17 +825,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -834,12 +786,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -854,18 +813,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1127,12 +1079,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -929,9 +863,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1120,12 +1051,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1191,21 +1116,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -793,12 +745,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -815,12 +746,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -859,17 +784,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -885,9 +819,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1074,12 +1005,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1131,21 +1056,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -810,18 +769,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1067,12 +1019,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -729,9 +663,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1215,12 +1146,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1360,17 +1285,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -654,18 +613,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1294,12 +1246,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -973,9 +907,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1504,12 +1435,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1678,21 +1603,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -898,18 +857,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1614,12 +1566,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -729,9 +663,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1215,12 +1146,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1360,17 +1285,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -654,18 +613,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1294,12 +1246,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -973,9 +907,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1504,12 +1435,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1678,21 +1603,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -898,18 +857,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1614,12 +1566,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -801,12 +732,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -847,17 +772,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_syslog_0:
     error_mode: ignore
     log_statements:
@@ -781,12 +733,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -825,18 +784,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_syslog_0:
     error_mode: ignore
     log_statements:
@@ -1070,12 +1022,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -900,9 +834,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1075,12 +1006,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1134,21 +1059,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -770,12 +701,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -806,17 +731,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_syslog_0:
     error_mode: ignore
     log_statements:
@@ -740,12 +692,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -856,9 +790,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1029,12 +960,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1074,21 +999,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -781,18 +740,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_syslog_0:
     error_mode: ignore
     log_statements:
@@ -1010,12 +962,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1280,12 +1211,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1419,17 +1344,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_windows__event__log_0:
     error_mode: ignore
     log_statements:
@@ -1353,12 +1305,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_windows__event__log_0:
     error_mode: ignore
     log_statements:
@@ -1669,12 +1621,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1569,12 +1500,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1733,21 +1658,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1280,12 +1211,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1419,17 +1344,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_windows__event__log_0:
     error_mode: ignore
     log_statements:
@@ -1353,12 +1305,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_windows__event__log_0:
     error_mode: ignore
     log_statements:
@@ -1669,12 +1621,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1569,12 +1500,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1733,21 +1658,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -778,12 +730,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -791,12 +722,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -844,17 +769,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -929,9 +863,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1065,12 +996,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1135,21 +1060,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -854,18 +813,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1071,12 +1023,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -737,12 +689,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -803,17 +728,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -810,18 +769,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1011,12 +963,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -885,9 +819,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1019,12 +950,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1075,21 +1000,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -729,9 +663,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1160,12 +1091,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1304,17 +1229,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -654,18 +613,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1238,12 +1190,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -973,9 +907,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1449,12 +1380,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1622,21 +1547,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -898,18 +857,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1558,12 +1510,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -729,9 +663,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1160,12 +1091,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1304,17 +1229,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -654,18 +613,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1238,12 +1190,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -973,9 +907,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1449,12 +1380,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1622,21 +1547,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -898,18 +857,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1558,12 +1510,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -702,9 +636,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -794,12 +725,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -849,17 +774,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -627,18 +586,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -783,12 +735,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -871,18 +830,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1076,12 +1028,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -946,9 +880,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1068,12 +999,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1140,21 +1065,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -598,18 +557,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -742,12 +694,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -673,9 +607,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -763,12 +694,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -808,17 +733,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -827,18 +786,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1016,12 +968,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -902,9 +836,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1022,12 +953,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1080,21 +1005,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -746,9 +680,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1309,17 +1234,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,18 +630,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1243,12 +1195,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -915,18 +874,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1563,12 +1515,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -990,9 +924,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1452,12 +1383,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1627,21 +1552,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -746,9 +680,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1309,17 +1234,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,18 +630,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1243,12 +1195,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -915,18 +874,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1563,12 +1515,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -990,9 +924,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1452,12 +1383,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1627,21 +1552,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -895,12 +826,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -960,17 +885,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -894,12 +846,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -825,18 +784,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1187,12 +1139,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -900,9 +834,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1169,12 +1100,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,21 +1176,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -853,12 +805,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -864,12 +795,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -919,17 +844,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -781,18 +740,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1127,12 +1079,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -856,9 +790,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1123,12 +1054,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1191,21 +1116,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -946,12 +877,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1056,17 +981,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -990,12 +942,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1235,12 +1166,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1366,21 +1291,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1302,12 +1254,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -946,12 +877,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1056,17 +981,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -990,12 +942,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1235,12 +1166,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1366,21 +1291,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1302,12 +1254,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -815,12 +746,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -869,17 +794,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -803,12 +755,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -396,7 +387,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -408,7 +399,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -507,7 +498,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -519,7 +510,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -530,18 +521,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -551,27 +530,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -825,18 +784,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1096,12 +1048,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -58,12 +55,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -82,9 +73,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -424,18 +394,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -444,18 +402,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -555,18 +501,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -900,9 +834,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1089,12 +1020,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1160,21 +1085,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -784,12 +715,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -828,17 +753,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -762,12 +714,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -101,24 +89,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -395,18 +365,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -415,18 +373,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -526,18 +472,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -856,9 +790,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1043,12 +974,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1100,21 +1025,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -85,7 +76,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -367,7 +358,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -379,7 +370,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -478,7 +469,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -501,18 +492,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -522,27 +501,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -781,18 +740,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1036,12 +988,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -714,9 +648,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -989,12 +920,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1070,17 +995,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -639,18 +598,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1004,12 +956,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -963,12 +915,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -958,12 +889,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1029,17 +954,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -758,9 +692,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1040,12 +971,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1166,17 +1091,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -683,18 +642,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1100,12 +1052,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -758,9 +692,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1040,12 +971,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1166,17 +1091,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -683,18 +642,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1100,12 +1052,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -198,7 +189,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -504,7 +495,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -516,7 +507,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -564,7 +555,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -576,7 +567,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -587,18 +578,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -608,27 +587,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -697,18 +656,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -916,12 +868,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -214,24 +202,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -532,18 +502,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -552,18 +510,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -612,18 +558,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -772,9 +706,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -906,12 +837,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -982,17 +907,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -209,24 +197,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -503,18 +473,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -523,18 +481,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -583,18 +529,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -743,9 +677,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -875,12 +806,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -941,17 +866,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -193,7 +184,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -475,7 +466,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,7 +478,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -547,7 +538,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -558,18 +549,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -579,27 +558,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -668,18 +627,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -875,12 +827,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -219,24 +207,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -548,18 +518,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -568,18 +526,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,18 +574,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -816,9 +750,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1275,12 +1206,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1442,17 +1367,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -203,7 +194,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -520,7 +511,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -532,7 +523,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -580,7 +571,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -592,7 +583,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -603,18 +594,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -624,27 +603,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -741,18 +700,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1376,12 +1328,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -219,24 +207,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -548,18 +518,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -568,18 +526,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,18 +574,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -816,9 +750,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1275,12 +1206,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1442,17 +1367,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -203,7 +194,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -520,7 +511,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -532,7 +523,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -580,7 +571,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -592,7 +583,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -603,18 +594,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -624,27 +603,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -741,18 +700,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1376,12 +1328,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -393,7 +384,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -405,7 +396,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -453,7 +444,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -465,7 +456,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,18 +467,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -497,27 +476,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -586,18 +545,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_0:
     error_mode: ignore
     log_statements:
@@ -839,12 +791,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -421,18 +391,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -441,18 +399,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -501,18 +447,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -661,9 +595,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -850,12 +781,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -905,17 +830,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -392,18 +362,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -412,18 +370,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -472,18 +418,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -632,9 +566,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -819,12 +750,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -864,17 +789,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -364,7 +355,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -376,7 +367,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -447,18 +438,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -468,27 +447,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -557,18 +516,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_0:
     error_mode: ignore
     log_statements:
@@ -798,12 +750,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -108,24 +96,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -437,18 +407,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -457,18 +415,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -517,18 +463,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -705,9 +639,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1219,12 +1150,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1365,17 +1290,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -92,7 +83,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -409,7 +400,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -469,7 +460,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -492,18 +483,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -513,27 +492,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,18 +589,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_0:
     error_mode: ignore
     log_statements:
@@ -1299,12 +1251,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -108,24 +96,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -437,18 +407,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -457,18 +415,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -517,18 +463,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -705,9 +639,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1219,12 +1150,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1365,17 +1290,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -92,7 +83,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -409,7 +400,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -469,7 +460,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -492,18 +483,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -513,27 +492,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -630,18 +589,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_0:
     error_mode: ignore
     log_statements:
@@ -1299,12 +1251,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -862,12 +814,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -874,12 +805,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -928,17 +853,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -843,12 +774,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -887,17 +812,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -821,12 +773,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1322,12 +1274,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1243,12 +1174,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1388,17 +1313,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_p1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1322,12 +1274,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1243,12 +1174,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1388,17 +1313,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -994,12 +925,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1059,17 +984,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -993,12 +945,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -952,12 +904,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -963,12 +894,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1018,17 +943,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1363,12 +1294,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1519,17 +1444,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1453,12 +1405,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1363,12 +1294,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1519,17 +1444,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1453,12 +1405,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -714,9 +648,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1099,12 +1030,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1182,17 +1107,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -639,18 +598,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1116,12 +1068,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1068,12 +999,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1141,17 +1066,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1075,12 +1027,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -683,18 +642,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1212,12 +1164,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -758,9 +692,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1150,12 +1081,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1278,17 +1203,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -683,18 +642,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_log__source__id1_0:
     error_mode: ignore
     log_statements:
@@ -1212,12 +1164,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -758,9 +692,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1150,12 +1081,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1278,17 +1203,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -801,12 +732,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -847,17 +772,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_syslog_0:
     error_mode: ignore
     log_statements:
@@ -781,12 +733,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -770,12 +701,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -806,17 +731,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_syslog_0:
     error_mode: ignore
     log_statements:
@@ -740,12 +692,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1280,12 +1211,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1419,17 +1344,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_windows__event__log_0:
     error_mode: ignore
     log_statements:
@@ -1353,12 +1305,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1280,12 +1211,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1419,17 +1344,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_default__pipeline_windows__event__log_0:
     error_mode: ignore
     log_statements:
@@ -1353,12 +1305,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -772,9 +706,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -932,12 +863,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1009,17 +934,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -697,18 +656,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -943,12 +895,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -668,18 +627,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -902,12 +854,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -743,9 +677,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -901,12 +832,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -968,17 +893,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -816,9 +750,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1301,12 +1232,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1469,17 +1394,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -741,18 +700,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1403,12 +1355,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -816,9 +750,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1301,12 +1232,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1469,17 +1394,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -741,18 +700,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1403,12 +1355,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -778,12 +730,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -791,12 +722,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -844,17 +769,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -737,12 +689,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -803,17 +728,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -729,9 +663,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1160,12 +1091,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1304,17 +1229,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -654,18 +613,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1238,12 +1190,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -729,9 +663,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1160,12 +1091,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1304,17 +1229,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -654,18 +613,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1238,12 +1190,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -726,18 +685,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline5_log__source__id5_0:
     error_mode: ignore
     log_statements:
@@ -1045,12 +997,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -801,9 +735,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1025,12 +956,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1111,17 +1036,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -697,18 +656,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline5_log__source__id5_0:
     error_mode: ignore
     log_statements:
@@ -1004,12 +956,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -772,9 +706,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -994,12 +925,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1070,17 +995,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -845,9 +779,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1394,12 +1325,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1571,17 +1496,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -770,18 +729,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline5_log__source__id5_0:
     error_mode: ignore
     log_statements:
@@ -1505,12 +1457,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -845,9 +779,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1394,12 +1325,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1571,17 +1496,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -770,18 +729,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline5_log__source__id5_0:
     error_mode: ignore
     log_statements:
@@ -1505,12 +1457,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -702,9 +636,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -794,12 +725,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -849,17 +774,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -627,18 +586,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -783,12 +735,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -598,18 +557,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -742,12 +694,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -673,9 +607,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -763,12 +694,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -808,17 +733,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -746,9 +680,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1309,17 +1234,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,18 +630,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1243,12 +1195,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -746,9 +680,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1309,17 +1234,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,18 +630,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1243,12 +1195,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -748,9 +682,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -842,12 +773,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -907,17 +832,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -673,18 +632,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -841,12 +793,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -719,9 +653,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -811,12 +742,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -866,17 +791,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -644,18 +603,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -800,12 +752,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -717,18 +676,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1301,12 +1253,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -792,9 +726,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1211,12 +1142,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1367,17 +1292,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -717,18 +676,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1301,12 +1253,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -792,9 +726,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1211,12 +1142,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1367,17 +1292,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -748,9 +682,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -842,12 +773,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -907,17 +832,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -673,18 +632,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -841,12 +793,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -719,9 +653,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -811,12 +742,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -866,17 +791,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -644,18 +603,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -800,12 +752,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -717,18 +676,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1301,12 +1253,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -792,9 +726,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1211,12 +1142,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1367,17 +1292,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -717,18 +676,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1301,12 +1253,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -792,9 +726,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1211,12 +1142,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1367,17 +1292,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -702,9 +636,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -794,12 +725,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -849,17 +774,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -627,18 +586,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -783,12 +735,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -598,18 +557,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -742,12 +694,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -673,9 +607,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -763,12 +694,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -808,17 +733,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -746,9 +680,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1309,17 +1234,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,18 +630,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1243,12 +1195,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -746,9 +680,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1163,12 +1094,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1309,17 +1234,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -671,18 +630,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1243,12 +1195,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -895,12 +826,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -960,17 +885,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -894,12 +846,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -853,12 +805,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -864,12 +795,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -919,17 +844,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -946,12 +877,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1056,17 +981,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -990,12 +942,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -946,12 +877,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1056,17 +981,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/logs_pipeline1_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -990,12 +942,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -815,12 +746,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -869,17 +794,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -803,12 +755,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -784,12 +715,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -828,17 +753,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -762,12 +714,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -400,7 +391,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -412,7 +403,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -511,7 +502,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -534,18 +525,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -555,27 +534,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -829,18 +788,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1095,12 +1047,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -62,12 +59,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -86,9 +77,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -110,24 +98,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -428,18 +398,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -448,18 +406,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -559,18 +505,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -904,9 +838,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1034,12 +965,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1159,21 +1084,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -57,12 +54,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -81,9 +72,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -105,24 +93,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -399,18 +369,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -419,18 +377,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -530,18 +476,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -860,9 +794,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -988,12 +919,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1099,21 +1024,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +80,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -371,7 +362,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -383,7 +374,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -482,7 +473,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -494,7 +485,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -505,18 +496,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -526,27 +505,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -785,18 +744,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1035,12 +987,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -67,12 +64,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,9 +82,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -444,18 +414,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -464,18 +422,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -575,18 +521,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -948,9 +882,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1418,12 +1349,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1646,21 +1571,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -416,7 +407,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -428,7 +419,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -527,7 +518,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -539,7 +530,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -550,18 +541,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -571,27 +550,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -873,18 +832,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1582,12 +1534,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -67,12 +64,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,9 +82,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -444,18 +414,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -464,18 +422,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -575,18 +521,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -948,9 +882,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1418,12 +1349,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1646,21 +1571,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -416,7 +407,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -428,7 +419,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -527,7 +518,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -539,7 +530,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -550,18 +541,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -571,27 +550,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -873,18 +832,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1582,12 +1534,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -364,7 +355,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -376,7 +367,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -447,18 +438,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -468,27 +447,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -557,18 +516,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -689,12 +641,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
         - "^agent\\.googleapis\\.com/gpu/memory/bytes_used$$"
         - "^agent\\.googleapis\\.com/gpu/processes/max_bytes_used$$"
         - "^agent\\.googleapis\\.com/processes/disk/write_bytes_count$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -392,18 +362,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -412,18 +370,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -472,18 +418,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -632,9 +566,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -720,12 +651,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -755,17 +680,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -364,7 +355,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -376,7 +367,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -436,7 +427,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -447,18 +438,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -468,27 +447,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -557,18 +516,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -689,12 +641,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
         - "^agent\\.googleapis\\.com/gpu/memory/bytes_used$$"
         - "^agent\\.googleapis\\.com/gpu/processes/max_bytes_used$$"
         - "^agent\\.googleapis\\.com/processes/disk/write_bytes_count$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -392,18 +362,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -412,18 +370,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -472,18 +418,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -632,9 +566,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -720,12 +651,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -755,17 +680,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -419,7 +410,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,7 +482,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -502,18 +493,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -523,27 +502,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,18 +599,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1200,12 +1152,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -71,12 +68,6 @@ processors:
         - "^agent\\.googleapis\\.com/gpu/memory/bytes_used$$"
         - "^agent\\.googleapis\\.com/gpu/processes/max_bytes_used$$"
         - "^agent\\.googleapis\\.com/processes/disk/write_bytes_count$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -95,9 +86,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -118,24 +106,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -447,18 +417,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -467,18 +425,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -527,18 +473,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -715,9 +649,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1130,12 +1061,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1266,17 +1191,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -102,7 +93,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -419,7 +410,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,7 +482,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -502,18 +493,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -523,27 +502,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -640,18 +599,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1200,12 +1152,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -71,12 +68,6 @@ processors:
         - "^agent\\.googleapis\\.com/gpu/memory/bytes_used$$"
         - "^agent\\.googleapis\\.com/gpu/processes/max_bytes_used$$"
         - "^agent\\.googleapis\\.com/processes/disk/write_bytes_count$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -95,9 +86,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -118,24 +106,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -447,18 +417,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -467,18 +425,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -527,18 +473,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -715,9 +649,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1130,12 +1061,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1266,17 +1191,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/cpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -418,18 +388,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -438,18 +396,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -498,18 +444,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -658,9 +592,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -748,12 +679,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -793,17 +718,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -390,7 +381,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -402,7 +393,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -473,18 +464,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -494,27 +473,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -583,18 +542,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -727,12 +679,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/cpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/cpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/cpu/utilization$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
         - "^agent\\.googleapis\\.com/cpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -750,12 +681,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -795,17 +720,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -729,12 +681,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -79,7 +70,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -361,7 +352,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -373,7 +364,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,18 +435,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -465,27 +444,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -554,18 +513,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -686,12 +638,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -48,12 +45,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
         - "^agent\\.googleapis\\.com/cpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,9 +63,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -95,24 +83,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -389,18 +359,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -409,18 +367,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -469,18 +415,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -629,9 +563,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -717,12 +648,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -752,17 +677,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -62,12 +59,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
         - "^agent\\.googleapis\\.com/cpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -86,9 +77,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -109,24 +97,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -438,18 +408,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -458,18 +416,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -518,18 +464,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -706,9 +640,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1121,12 +1052,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1257,17 +1182,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -410,7 +401,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -422,7 +413,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -470,7 +461,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -482,7 +473,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,18 +484,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -514,27 +493,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -631,18 +590,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1191,12 +1143,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -62,12 +59,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
         - "^agent\\.googleapis\\.com/cpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -86,9 +77,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -109,24 +97,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -438,18 +408,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -458,18 +416,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -518,18 +464,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -706,9 +640,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1121,12 +1052,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1257,17 +1182,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -410,7 +401,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -422,7 +413,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -470,7 +461,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -482,7 +473,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,18 +484,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -514,27 +493,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -631,18 +590,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1191,12 +1143,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/proce.*ses/.*$$"
         - "^agent\\.googleapis\\.com/c.*u/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -750,12 +681,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -795,17 +720,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -729,12 +681,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -79,7 +70,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -361,7 +352,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -373,7 +364,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,18 +435,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -465,27 +444,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -554,18 +513,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -686,12 +638,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -48,12 +45,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/proce.*ses/.*$$"
         - "^agent\\.googleapis\\.com/c.*u/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,9 +63,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -95,24 +83,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -389,18 +359,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -409,18 +367,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -469,18 +415,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -629,9 +563,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -717,12 +648,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -752,17 +677,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -62,12 +59,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/proce.*ses/.*$$"
         - "^agent\\.googleapis\\.com/c.*u/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -86,9 +77,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -109,24 +97,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -438,18 +408,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -458,18 +416,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -518,18 +464,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -706,9 +640,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1121,12 +1052,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1257,17 +1182,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -410,7 +401,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -422,7 +413,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -470,7 +461,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -482,7 +473,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,18 +484,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -514,27 +493,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -631,18 +590,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1191,12 +1143,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -62,12 +59,6 @@ processors:
         metric_names:
         - "^agent\\.googleapis\\.com/proce.*ses/.*$$"
         - "^agent\\.googleapis\\.com/c.*u/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -86,9 +77,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -109,24 +97,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -438,18 +408,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -458,18 +416,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -518,18 +464,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -706,9 +640,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1121,12 +1052,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1257,17 +1182,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -93,7 +84,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -410,7 +401,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -422,7 +413,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -470,7 +461,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -482,7 +473,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -493,18 +484,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -514,27 +493,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -631,18 +590,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1191,12 +1143,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -390,7 +381,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -402,7 +393,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -473,18 +464,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -494,27 +473,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -583,18 +542,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -727,12 +679,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/x\\$$y\\(%28\\)z\\\\,a':w-\\+!/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -418,18 +388,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -438,18 +396,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -498,18 +444,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -658,9 +592,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -748,12 +679,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -793,17 +718,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/x\\$$y\\(%28\\)z\\\\,a':w-\\+!/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/x\\$$y\\(%28\\)z\\\\,a':w-\\+!/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/x\\$$y\\(%28\\)z\\\\,a':w-\\+!/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -101,7 +92,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -409,7 +400,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -469,7 +460,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -492,18 +483,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -513,27 +492,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -624,18 +583,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -772,12 +724,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -119,24 +107,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -437,18 +407,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -457,18 +415,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -517,18 +463,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -699,9 +633,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -793,12 +724,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -838,17 +763,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -112,24 +100,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -406,18 +376,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -426,18 +384,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -486,18 +432,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -668,9 +602,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -795,17 +720,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -378,7 +369,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -390,7 +381,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -438,7 +429,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,18 +452,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -482,27 +461,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -593,18 +552,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -729,12 +681,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -70,12 +67,6 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -94,9 +85,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -126,24 +114,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -455,18 +425,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -475,18 +433,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -535,18 +481,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -745,9 +679,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1164,12 +1095,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1300,17 +1225,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +99,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -427,7 +418,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -439,7 +430,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -487,7 +478,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -499,7 +490,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -510,18 +501,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -531,27 +510,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -670,18 +629,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1234,12 +1186,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -70,12 +67,6 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -94,9 +85,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -126,24 +114,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -455,18 +425,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -475,18 +433,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -535,18 +481,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -745,9 +679,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1164,12 +1095,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1300,17 +1225,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +99,7 @@ processors:
         metric_names:
         - "^workload\\.googleapis\\.com/otlp\\.test\\.gauge$$"
         - "^workload\\.googleapis\\.com/otlp\\.test\\.prefix.*$$"
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -427,7 +418,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -439,7 +430,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -487,7 +478,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -499,7 +490,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -510,18 +501,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -531,27 +510,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -670,18 +629,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1234,12 +1186,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -77,12 +74,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -101,9 +92,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -124,24 +112,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -682,9 +616,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -772,12 +703,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -821,17 +746,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -108,7 +99,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -607,18 +566,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -755,12 +707,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -400,18 +370,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -420,18 +378,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -480,18 +426,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -640,9 +574,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -728,12 +659,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -765,17 +690,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -372,7 +363,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -384,7 +375,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,7 +435,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -455,18 +446,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -476,27 +455,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -565,18 +524,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -699,12 +651,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -379,7 +370,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -391,7 +382,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -439,7 +430,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -451,7 +442,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,18 +453,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -483,27 +462,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,18 +531,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1073,12 +1025,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -407,18 +377,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -427,18 +385,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -487,18 +433,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -647,9 +581,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1056,12 +987,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1139,17 +1064,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -379,7 +370,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -391,7 +382,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -439,7 +430,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -451,7 +442,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,18 +453,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -483,27 +462,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -572,18 +531,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1073,12 +1025,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -407,18 +377,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -427,18 +385,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -487,18 +433,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -647,9 +581,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1056,12 +987,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1139,17 +1064,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -65,12 +62,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -89,9 +80,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -112,24 +100,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -430,18 +400,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -450,18 +408,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -510,18 +456,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -670,9 +604,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -807,17 +732,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -402,7 +393,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -414,7 +405,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -485,18 +476,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -506,27 +485,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -595,18 +554,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -741,12 +693,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -366,7 +357,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -378,7 +369,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -438,7 +429,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -449,18 +440,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -470,27 +449,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -559,18 +518,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -692,12 +644,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -394,18 +364,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -414,18 +372,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -474,18 +420,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -634,9 +568,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -722,12 +653,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -758,17 +683,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -373,7 +364,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -385,7 +376,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -445,7 +436,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -456,18 +447,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -477,27 +456,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -566,18 +525,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1066,12 +1018,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -401,18 +371,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -421,18 +379,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -481,18 +427,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -641,9 +575,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1050,12 +981,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1132,17 +1057,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -373,7 +364,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -385,7 +376,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -445,7 +436,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -456,18 +447,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -477,27 +456,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -566,18 +525,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1066,12 +1018,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/processes/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -401,18 +371,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -421,18 +379,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -481,18 +427,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -641,9 +575,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1050,12 +981,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1132,17 +1057,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -406,18 +376,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -426,18 +384,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -486,18 +432,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -646,9 +580,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -736,12 +667,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -779,17 +704,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -378,7 +369,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -390,7 +381,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -438,7 +429,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,18 +452,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -482,27 +461,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -571,18 +530,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -713,12 +665,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -382,18 +352,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -402,18 +360,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -462,18 +408,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -622,9 +556,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -710,12 +641,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -744,17 +669,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -354,7 +345,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -366,7 +357,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -414,7 +405,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -437,18 +428,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -458,27 +437,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -547,18 +506,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -678,12 +630,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -361,7 +352,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -373,7 +364,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,18 +435,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -465,27 +444,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -554,18 +513,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1052,12 +1004,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -389,18 +359,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -409,18 +367,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -469,18 +415,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -629,9 +563,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1038,12 +969,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1118,17 +1043,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -361,7 +352,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -373,7 +364,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -433,7 +424,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -444,18 +435,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -465,27 +444,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -554,18 +513,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1052,12 +1004,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -389,18 +359,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -409,18 +367,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -469,18 +415,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -629,9 +563,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1038,12 +969,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1118,17 +1043,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -82,7 +73,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -388,7 +379,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -400,7 +391,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -448,7 +439,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -460,7 +451,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -471,18 +462,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -492,27 +471,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -581,18 +540,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -725,12 +677,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -51,12 +48,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -75,9 +66,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -98,24 +86,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -416,18 +386,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -436,18 +394,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -496,18 +442,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -656,9 +590,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -746,12 +677,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -791,17 +716,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -46,12 +43,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -70,9 +61,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -93,24 +81,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -387,18 +357,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -407,18 +365,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -467,18 +413,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -627,9 +561,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -715,12 +646,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -750,17 +675,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -77,7 +68,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -359,7 +350,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -371,7 +362,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -431,7 +422,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,18 +433,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -463,27 +442,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -552,18 +511,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -684,12 +636,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1185,12 +1137,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1251,17 +1176,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/process/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -418,18 +388,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -438,18 +396,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -498,18 +444,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -658,9 +592,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -748,12 +679,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -793,17 +718,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -390,7 +381,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -402,7 +393,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -473,18 +464,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -494,27 +473,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -583,18 +542,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -727,12 +679,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/process/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/process/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/gpu/process/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -806,12 +758,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -872,17 +797,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -765,12 +717,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -831,17 +756,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1266,12 +1218,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1332,17 +1257,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1266,12 +1218,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1332,17 +1257,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -809,12 +761,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -875,17 +800,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -768,12 +720,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -834,17 +759,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1269,12 +1221,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1335,17 +1260,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1269,12 +1221,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1335,17 +1260,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -936,17 +861,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -870,12 +822,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -829,12 +781,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -895,17 +820,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1396,17 +1321,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1330,12 +1282,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1396,17 +1321,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1330,12 +1282,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -805,12 +757,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -871,17 +796,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -764,12 +716,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -830,17 +755,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1265,12 +1217,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1331,17 +1256,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1265,12 +1217,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1331,17 +1256,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -806,12 +758,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -872,17 +797,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -765,12 +717,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -831,17 +756,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1266,12 +1218,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1332,17 +1257,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1266,12 +1218,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1332,17 +1257,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -799,12 +751,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -865,17 +790,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -758,12 +710,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -824,17 +749,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1325,17 +1250,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1259,12 +1211,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1325,17 +1250,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1259,12 +1211,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -860,12 +812,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -926,17 +851,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -885,17 +810,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -819,12 +771,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1386,17 +1311,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1320,12 +1272,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1386,17 +1311,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1320,12 +1272,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -806,12 +758,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -872,17 +797,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -765,12 +717,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -831,17 +756,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1266,12 +1218,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1332,17 +1257,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1266,12 +1218,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1332,17 +1257,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -842,12 +794,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -908,17 +833,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -801,12 +753,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -867,17 +792,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1368,17 +1293,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1302,12 +1254,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1368,17 +1293,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1302,12 +1254,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -86,7 +77,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -392,7 +383,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -404,7 +395,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -452,7 +443,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -475,18 +466,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -496,27 +475,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -585,18 +544,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -804,12 +756,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -55,12 +52,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -79,9 +70,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -102,24 +90,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -420,18 +390,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -440,18 +398,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -500,18 +446,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -660,9 +594,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -760,12 +691,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -870,17 +795,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -50,12 +47,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -74,9 +65,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -97,24 +85,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -391,18 +361,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -411,18 +369,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -471,18 +417,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -631,9 +565,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -729,12 +660,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -829,17 +754,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -81,7 +72,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -363,7 +354,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -375,7 +366,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -423,7 +414,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -435,7 +426,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -446,18 +437,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -467,27 +446,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -556,18 +515,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -763,12 +715,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1330,17 +1255,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1264,12 +1216,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -40,9 +40,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -60,12 +57,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -84,9 +75,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -107,24 +95,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -436,18 +406,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -456,18 +414,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -516,18 +462,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1129,12 +1060,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1330,17 +1255,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -33,15 +33,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -91,7 +82,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -408,7 +399,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -468,7 +459,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -480,7 +471,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -491,18 +482,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -512,27 +491,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1264,12 +1216,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -94,7 +85,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -400,7 +391,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -412,7 +403,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -511,7 +502,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -534,18 +525,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -555,27 +534,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -829,18 +788,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1137,12 +1089,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -62,12 +59,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -86,9 +77,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -110,24 +98,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -428,18 +398,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -448,18 +406,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -559,18 +505,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -904,9 +838,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1034,12 +965,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1201,21 +1126,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -57,12 +54,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -81,9 +72,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -105,24 +93,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -399,18 +369,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -419,18 +377,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -530,18 +476,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -860,9 +794,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -988,12 +919,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1141,21 +1066,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -89,7 +80,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -371,7 +362,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -383,7 +374,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -482,7 +473,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -494,7 +485,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -505,18 +496,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -526,27 +505,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -785,18 +744,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -1077,12 +1029,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -67,12 +64,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,9 +82,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -444,18 +414,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -464,18 +422,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -575,18 +521,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -948,9 +882,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1418,12 +1349,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1688,21 +1613,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -416,7 +407,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -428,7 +419,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -527,7 +518,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -539,7 +530,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -550,18 +541,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -571,27 +550,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -873,18 +832,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1624,12 +1576,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -47,9 +47,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -67,12 +64,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -91,9 +82,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -115,24 +103,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -444,18 +414,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -464,18 +422,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -575,18 +521,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -948,9 +882,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1418,12 +1349,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1688,21 +1613,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -40,15 +40,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -99,7 +90,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -416,7 +407,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -428,7 +419,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -527,7 +518,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -539,7 +530,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -550,18 +541,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -571,27 +550,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -873,18 +832,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1624,12 +1576,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -417,18 +387,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -437,18 +395,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -497,18 +443,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1100,12 +1031,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1233,17 +1158,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -389,7 +380,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -401,7 +392,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -449,7 +440,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,7 +452,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -472,18 +463,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -493,27 +472,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1167,12 +1119,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -417,18 +387,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -437,18 +395,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -497,18 +443,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1100,12 +1031,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1233,17 +1158,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -389,7 +380,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -401,7 +392,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -449,7 +440,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,7 +452,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -472,18 +463,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -493,27 +472,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1167,12 +1119,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1281,17 +1206,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/host_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1226,12 +1178,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1115,12 +1046,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1281,17 +1206,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/host_hostmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1226,12 +1178,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -92,7 +83,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -409,7 +400,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -469,7 +460,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -492,18 +483,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -513,27 +492,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -810,18 +769,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1397,12 +1349,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -85,9 +76,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -108,24 +96,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -437,18 +407,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -457,18 +415,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -517,18 +463,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -885,9 +819,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1315,12 +1246,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1463,17 +1388,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -92,7 +83,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -409,7 +400,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -421,7 +412,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -469,7 +460,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -481,7 +472,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -492,18 +483,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -513,27 +492,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -810,18 +769,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1397,12 +1349,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -85,9 +76,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -108,24 +96,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -437,18 +407,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -457,18 +415,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -517,18 +463,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -885,9 +819,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1315,12 +1246,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1463,17 +1388,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1634,12 +1565,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1824,17 +1749,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1758,12 +1710,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1634,12 +1565,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1824,17 +1749,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1758,12 +1710,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1271,12 +1202,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1407,17 +1332,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1341,12 +1293,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1271,12 +1202,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1407,17 +1332,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1341,12 +1293,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1345,12 +1297,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1239,12 +1170,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1411,17 +1336,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1345,12 +1297,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1239,12 +1170,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1411,17 +1336,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1376,12 +1328,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1288,12 +1219,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1442,17 +1367,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1376,12 +1328,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1288,12 +1219,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1442,17 +1367,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -390,7 +381,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -402,7 +393,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -473,18 +464,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -494,27 +473,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -583,18 +542,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -727,12 +679,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/iis/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -418,18 +388,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -438,18 +396,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -498,18 +444,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -658,9 +592,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -748,12 +679,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -793,17 +718,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/iis/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/iis/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/iis/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -84,7 +75,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -390,7 +381,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -402,7 +393,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -450,7 +441,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -473,18 +464,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -494,27 +473,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -583,18 +542,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -727,12 +679,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -53,12 +50,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/mssql/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -77,9 +68,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -100,24 +88,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_1_0:
     transforms:
     - action: update
@@ -418,18 +388,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -438,18 +396,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -498,18 +444,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -658,9 +592,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -748,12 +679,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -793,17 +718,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - nvml/hostmetrics_1
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -78,7 +69,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -360,7 +351,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -372,7 +363,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -420,7 +411,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -432,7 +423,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -443,18 +434,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -464,27 +443,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -553,18 +512,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:
@@ -685,12 +637,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -47,12 +44,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/mssql/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -71,9 +62,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -94,24 +82,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -388,18 +358,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -408,18 +366,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -468,18 +414,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -628,9 +562,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -716,12 +647,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -751,17 +676,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/mssql/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -59,12 +56,6 @@ processors:
         match_type: regexp
         metric_names:
         - "^agent\\.googleapis\\.com/mssql/.*$$"
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -83,9 +74,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -106,24 +94,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -435,18 +405,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -455,18 +413,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -515,18 +461,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -703,9 +637,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1118,12 +1049,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1254,17 +1179,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -90,7 +81,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -407,7 +398,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -419,7 +410,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -467,7 +458,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -479,7 +470,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -490,18 +481,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -511,27 +490,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -628,18 +587,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1188,12 +1140,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -389,7 +380,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -401,7 +392,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -449,7 +440,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,7 +452,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -472,18 +463,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -493,27 +472,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1167,12 +1119,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -417,18 +387,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -437,18 +395,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -497,18 +443,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1100,12 +1031,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1233,17 +1158,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -72,7 +63,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -389,7 +380,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -401,7 +392,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -449,7 +440,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -461,7 +452,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -472,18 +463,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -493,27 +472,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -610,18 +569,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1167,12 +1119,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -36,17 +36,8 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -65,9 +56,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -88,24 +76,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -417,18 +387,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -437,18 +395,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -497,18 +443,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -685,9 +619,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1100,12 +1031,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1233,17 +1158,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - hostmetrics/hostmetrics
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis__v2_3: {}
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -430,7 +421,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,7 +433,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -502,7 +493,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -513,18 +504,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -534,27 +513,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -675,18 +634,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1250,12 +1202,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -114,24 +102,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -458,18 +428,6 @@ processors:
       new_name: workload.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -478,18 +436,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -538,18 +484,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -750,9 +684,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1167,12 +1098,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1303,17 +1228,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/iispipeline_iis__v2:
       exporters:
       - googlecloud/otel

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis__v2_3: {}
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -430,7 +421,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -442,7 +433,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -490,7 +481,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -502,7 +493,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -513,18 +504,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -534,27 +513,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -675,18 +634,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1250,12 +1202,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -114,24 +102,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -458,18 +428,6 @@ processors:
       new_name: workload.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -478,18 +436,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -538,18 +484,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -750,9 +684,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1167,12 +1098,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1303,17 +1228,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/iispipeline_iis__v2:
       exporters:
       - googlecloud/otel

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -114,24 +102,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -430,18 +400,6 @@ processors:
       new_name: workload.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -450,18 +408,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -510,18 +456,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -709,9 +643,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1126,12 +1057,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1246,17 +1171,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/iispipeline_iis:
       exporters:
       - googlecloud/otel

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis_3: {}
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -402,7 +393,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -414,7 +405,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -485,18 +476,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -506,27 +485,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -634,18 +593,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1193,12 +1145,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -114,24 +102,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -430,18 +400,6 @@ processors:
       new_name: workload.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -450,18 +408,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -510,18 +456,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -709,9 +643,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1126,12 +1057,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1246,17 +1171,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/iispipeline_iis:
       exporters:
       - googlecloud/otel

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -96,7 +87,7 @@ processors:
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
   groupbyattrs/iis_3: {}
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -402,7 +393,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -414,7 +405,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -462,7 +453,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -485,18 +476,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -506,27 +485,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -634,18 +593,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1193,12 +1145,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -644,18 +603,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -113,24 +101,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -719,9 +653,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1152,12 +1083,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -644,18 +603,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1224,12 +1176,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -113,24 +101,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -719,9 +653,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1152,12 +1083,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1290,17 +1215,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -113,24 +101,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1131,12 +1062,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1256,17 +1181,6 @@ service:
       - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: datapoint
@@ -1190,12 +1142,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -44,9 +44,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -64,12 +61,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -88,9 +79,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -113,24 +101,6 @@ processors:
     strategy: subtract_initial_point
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -442,18 +412,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -462,18 +420,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -522,18 +468,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -704,9 +638,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1131,12 +1062,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1256,17 +1181,6 @@ service:
       - metric_start_time/googlecloud/otel_metrics_0
       receivers:
       - sqlserver/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -37,15 +37,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud/otel_metrics_0:
     strategy: subtract_initial_point
@@ -414,7 +405,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -426,7 +417,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -474,7 +465,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -486,7 +477,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -497,18 +488,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -518,27 +497,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -629,18 +588,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: datapoint
@@ -1190,12 +1142,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1634,12 +1565,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1824,17 +1749,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1758,12 +1710,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1923,12 +1854,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -2150,21 +2075,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -2086,12 +2038,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1634,12 +1565,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1824,17 +1749,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1758,12 +1710,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1923,12 +1854,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -2150,21 +2075,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -2086,12 +2038,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1345,12 +1297,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1239,12 +1170,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1411,17 +1336,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1669,12 +1621,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1528,12 +1459,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1733,21 +1658,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -29,15 +29,6 @@ processors:
   agentmetrics/hostmetrics_0:
     blank_label_metrics:
     - system.cpu.utilization
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -87,7 +78,7 @@ processors:
         - otelcol_process_memory_rss
         - grpc.client.attempt.duration_count
         - googlecloudmonitoring/point_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
@@ -404,7 +395,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -416,7 +407,7 @@ processors:
         - response_code
     - action: update
       include: grpc.client.attempt.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: grpc.status
@@ -464,7 +455,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -476,7 +467,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -487,18 +478,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -508,27 +487,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -625,18 +584,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "grpc.client.attempt.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1345,12 +1297,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - metric_start_time/googlecloud_metrics_0
       receivers:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -36,9 +36,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -56,12 +53,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -80,9 +71,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - grpc.client.attempt.duration_count
@@ -103,24 +91,6 @@ processors:
     interval: 1m
   metric_start_time/googlecloud_metrics_0:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -432,18 +402,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -452,18 +410,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -512,18 +458,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -700,9 +634,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1239,12 +1170,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1411,17 +1336,6 @@ service:
       - metric_start_time/googlecloud_metrics_0
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - googlecloud
-      processors:
-      - transform/agent_prometheus_0
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - metric_start_time/googlecloud_metrics_0
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - googlecloud

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
@@ -36,15 +36,6 @@ processors:
     send_batch_max_size: 200
     send_batch_size: 200
     timeout: 200ms
-  cumulativetodelta/loggingmetrics_4:
-    include:
-      match_type: strict
-      metrics:
-      - otel_log_entry_count
-      - otel_log_entry_retry_count
-      - otel_request_count
-    initial_value: drop
-  deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
     metrics:
       exclude:
@@ -95,7 +86,7 @@ processors:
         - otelcol_exporter_sent_metric_points
         - otelcol_exporter_send_failed_metric_points
         - rpc.client.call.duration_count
-  interval/loggingmetrics_8:
+  interval/loggingmetrics_5:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
@@ -412,7 +403,7 @@ processors:
     transforms:
     - action: insert
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_retry_count
+      new_name: agent/log_entry_retry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -424,7 +415,7 @@ processors:
         - response_code
     - action: update
       include: rpc.client.call.duration_count
-      new_name: otel_request_count
+      new_name: agent/request_count
       operations:
       - action: update_label
         label: rpc.response.status_code
@@ -523,7 +514,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_sent_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -535,7 +526,7 @@ processors:
         - response_code
     - action: update
       include: otelcol_exporter_send_failed_log_records
-      new_name: otel_log_entry_count
+      new_name: agent/log_entry_count
       operations:
       - action: toggle_scalar_data_type
       - action: add_label
@@ -546,18 +537,6 @@ processors:
         label_set:
         - response_code
     - action: combine
-      include: ^otel_log_entry_count$$
-      match_type: regexp
-      new_name: otel_log_entry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_6:
-    transforms:
-    - action: combine
       include: ^agent/log_entry_count$
       match_type: regexp
       new_name: agent/log_entry_count
@@ -567,27 +546,7 @@ processors:
         label_set:
         - response_code
       submatch_case: lower
-    - action: combine
-      include: ^agent/log_entry_retry_count$
-      match_type: regexp
-      new_name: agent/log_entry_retry_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-    - action: combine
-      include: ^agent/request_count$
-      match_type: regexp
-      new_name: agent/request_count
-      operations:
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-      submatch_case: lower
-  metricstransform/loggingmetrics_9:
+  metricstransform/loggingmetrics_6:
     transforms:
     - action: update
       include: ^(.*)$$
@@ -869,18 +828,11 @@ processors:
     - context: metric
       statements:
       - extract_count_metric(true) where name == "rpc.client.call.duration"
-  transform/loggingmetrics_5:
+  transform/loggingmetrics_4:
     metric_statements:
     - context: metric
       statements:
       - set(unit, "1")
-    - context: datapoint
-      statements:
-      - set(time, Now())
-      - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
   transform/mssql_1:
     metric_statements:
     - context: scope
@@ -1669,12 +1621,9 @@ service:
       - filter/loggingmetrics_1
       - filter/loggingmetrics_2
       - metricstransform/loggingmetrics_3
-      - cumulativetodelta/loggingmetrics_4
-      - transform/loggingmetrics_5
+      - transform/loggingmetrics_4
+      - interval/loggingmetrics_5
       - metricstransform/loggingmetrics_6
-      - deltatocumulative/loggingmetrics_7
-      - interval/loggingmetrics_8
-      - metricstransform/loggingmetrics_9
       - resourcedetection/_global_0
       - resource/otlp_grpc/otlp_metrics_metrics_0
       - metric_start_time/otlp_grpc/otlp_metrics_metrics_1

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
@@ -43,9 +43,6 @@ processors:
       - otel_log_entry_count
       - otel_log_entry_retry_count
       - otel_request_count
-      - fluentbit_log_entry_count
-      - fluentbit_log_entry_retry_count
-      - fluentbit_request_count
     initial_value: drop
   deltatocumulative/loggingmetrics_7: {}
   filter/default__pipeline_hostmetrics_0:
@@ -63,12 +60,6 @@ processors:
       exclude:
         match_type: regexp
         metric_names: []
-  filter/fluentbit_0:
-    metrics:
-      include:
-        match_type: strict
-        metric_names:
-        - fluentbit_uptime
   filter/hostmetrics_1:
     metrics:
       exclude:
@@ -87,9 +78,6 @@ processors:
       include:
         match_type: strict
         metric_names:
-        - fluentbit_stackdriver_requests_total
-        - fluentbit_stackdriver_proc_records_total
-        - fluentbit_stackdriver_retried_records_total
         - otelcol_exporter_sent_log_records
         - otelcol_exporter_send_failed_log_records
         - rpc.client.call.duration_count
@@ -111,24 +99,6 @@ processors:
     interval: 1m
   metric_start_time/otlp_grpc/otlp_metrics_metrics_1:
     strategy: subtract_initial_point
-  metricstransform/fluentbit_1:
-    transforms:
-    - action: update
-      include: fluentbit_uptime
-      new_name: agent/uptime
-      operations:
-      - action: toggle_scalar_data_type
-      - action: add_label
-        new_label: version
-        new_value: google-cloud-ops-agent-logging/latest-build_distro
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
-    - action: update
-      include: ^(.*)$$
-      match_type: regexp
-      new_name: agent.googleapis.com/$${1}
   metricstransform/hostmetrics_2:
     transforms:
     - action: update
@@ -440,18 +410,6 @@ processors:
       new_name: agent.googleapis.com/$${1}
   metricstransform/loggingmetrics_3:
     transforms:
-    - action: update
-      include: fluentbit_stackdriver_retried_records_total
-      new_name: fluentbit_log_entry_retry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
     - action: insert
       include: otelcol_exporter_send_failed_log_records
       new_name: otel_log_entry_retry_count
@@ -460,18 +418,6 @@ processors:
       - action: add_label
         new_label: response_code
         new_value: "400"
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_requests_total
-      new_name: fluentbit_request_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -571,18 +517,6 @@ processors:
           value: UNIMPLEMENTED
         - new_value: "500"
           value: UNKNOWN
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - response_code
-    - action: update
-      include: fluentbit_stackdriver_proc_records_total
-      new_name: fluentbit_log_entry_count
-      operations:
-      - action: toggle_scalar_data_type
-      - action: update_label
-        label: status
-        new_label: response_code
       - action: aggregate_labels
         aggregation_type: sum
         label_set:
@@ -944,9 +878,6 @@ processors:
       statements:
       - set(time, Now())
       - set(start_time_unix_nano, 0)
-      - set(metric.name, "agent/log_entry_count") where metric.name == "fluentbit_log_entry_count"
-      - set(metric.name, "agent/log_entry_retry_count") where metric.name == "fluentbit_log_entry_retry_count"
-      - set(metric.name, "agent/request_count") where metric.name == "fluentbit_request_count"
       - set(metric.name, "agent/log_entry_count") where metric.name == "otel_log_entry_count"
       - set(metric.name, "agent/log_entry_retry_count") where metric.name == "otel_log_entry_retry_count"
       - set(metric.name, "agent/request_count") where metric.name == "otel_request_count"
@@ -1528,12 +1459,6 @@ receivers:
   prometheus/agent_prometheus:
     config:
       scrape_configs:
-      - job_name: logging-collector
-        metrics_path: /metrics
-        scrape_interval: 1m
-        static_configs:
-        - targets:
-          - 0.0.0.0:20202
       - job_name: otel-collector
         scrape_interval: 1m
         static_configs:
@@ -1733,21 +1658,6 @@ service:
       - batch/otlp_grpc/otlp_metrics_metrics_2
       receivers:
       - windowsperfcounters/mssql
-    metrics/fluentbit:
-      exporters:
-      - otlp_grpc/otlp_metrics
-      processors:
-      - transform/agent_prometheus_0
-      - transform/agent_prometheus_1
-      - transform/agent_prometheus_2
-      - filter/fluentbit_0
-      - metricstransform/fluentbit_1
-      - resourcedetection/_global_0
-      - resource/otlp_grpc/otlp_metrics_metrics_0
-      - metric_start_time/otlp_grpc/otlp_metrics_metrics_1
-      - batch/otlp_grpc/otlp_metrics_metrics_2
-      receivers:
-      - prometheus/agent_prometheus
     metrics/loggingmetrics:
       exporters:
       - otlp_grpc/otlp_metrics


### PR DESCRIPTION
## Description
Remove the legacy fluentbit-specific scrape targets, ports, and pipelines from OTel self-telemetry configuration generation, preventing OTel Collector from reporting scrape failure warnings for the deleted Fluent Bit binary.


## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
