### PR TITLE
Add Removal of windows fluentbit service

### DIFF
--- a/cmd/ops_agent_windows/install_windows.go
+++ b/cmd/ops_agent_windows/install_windows.go
@@ -16,10 +16,13 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/kardianos/osext"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
 	"golang.org/x/sys/windows/svc/mgr"
@@ -50,6 +53,29 @@ func uninstallDiagnosticService(m *mgr.Mgr) error {
 	return nil
 }
 
+func cleanupFluentBit(m *mgr.Mgr) error {
+	fluentBitServiceHandle, err := m.OpenService("google-cloud-ops-agent-fluent-bit")
+	if err == nil {
+		defer fluentBitServiceHandle.Close()
+		if err := stopService(fluentBitServiceHandle, 30*time.Second); err != nil {
+			return fmt.Errorf("failed to stop the fluent-bit Windows service: %w", err)
+		}
+		if err := fluentBitServiceHandle.Delete(); err != nil {
+			return fmt.Errorf("failed to delete the fluent-bit Windows service: %w", err)
+		}
+	}
+
+	base, err := osext.ExecutableFolder()
+	if err != nil {
+		return fmt.Errorf("could not determine binary path: %w", err)
+	}
+	fluentBitDir := filepath.Join(base, "../subagents/fluent-bit")
+	if err := os.RemoveAll(fluentBitDir); err != nil {
+		return fmt.Errorf("failed to remove fluent-bit directory: %w", err)
+	}
+	return nil
+}
+
 func install() error {
 	m, err := mgr.Connect()
 	if err != nil {
@@ -60,6 +86,11 @@ func install() error {
 	diagnosticError := uninstallDiagnosticService(m)
 	if diagnosticError != nil {
 		return diagnosticError
+	}
+
+	fluentBitError := cleanupFluentBit(m)
+	if fluentBitError != nil {
+		return fluentBitError
 	}
 
 	handles := make([]*mgr.Service, len(services))
@@ -152,6 +183,11 @@ func uninstall() error {
 	diagnosticError := uninstallDiagnosticService(m)
 	if diagnosticError != nil {
 		errs = multierror.Append(errs, diagnosticError)
+	}
+
+	fluentBitError := cleanupFluentBit(m)
+	if fluentBitError != nil {
+		errs = multierror.Append(errs, fluentBitError)
 	}
 	return errs
 }


### PR DESCRIPTION
## Description
When upgrading the Ops Agent from a 2.x version (which included Fluent Bit) to 3.0 (which completely removes Fluent Bit), the old google-cloud-ops-agent-fluent-bit Windows service and its binary files (located under subagents/fluent-bit/) can be left behind.

This happens because the new installer only knows about the current services (wrapper and OTel collector) and doesn't touch the old ones. If the old uninstaller fails to clean them up (e.g., if the service was stuck running or files were locked), they remain on the system. This causes reinstall or upgrade integration tests to fail because the old service/binaries are still present.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
