### PR TITLE
Refactor Windows Service Manager to use explicit service descriptions

### DIFF
--- a/cmd/ops_agent_windows/install_windows.go
+++ b/cmd/ops_agent_windows/install_windows.go
@@ -87,14 +87,13 @@ func install() error {
 	if diagnosticError != nil {
 		return diagnosticError
 	}
-
 	fluentBitError := cleanupFluentBit(m)
 	if fluentBitError != nil {
 		return fluentBitError
 	}
 
-	handles := make([]*mgr.Service, len(services))
-	for i, s := range services {
+	handles := make([]*mgr.Service, 2)
+	for i, s := range []serviceDescription{mainServiceDescription, otelServiceDescription} {
 		// Registering with the event log is required to suppress the "The description for Event ID 1 from source Google Cloud Ops Agent cannot be found" message in the logs.
 		if err := eventlog.InstallAsEventCreate(s.name, eventlog.Error|eventlog.Warning|eventlog.Info); err != nil {
 			// Ignore error since it likely means the event log already exists.
@@ -102,7 +101,7 @@ func install() error {
 		deps := []string{"rpcss"}
 		if i > 0 {
 			// All services depend on the config generation service.
-			deps = append(deps, services[0].name)
+			deps = append(deps, mainServiceDescription.name)
 		}
 		serviceHandle, err := m.OpenService(s.name)
 		if err == nil {
@@ -145,9 +144,11 @@ func install() error {
 	}
 
 	// Automatically (re)start the Ops Agent service.
-	for i := len(services) - 1; i >= 0; i-- {
-		if err := stopService(handles[i], 30*time.Second); err != nil {
-			return fmt.Errorf("failed to stop service: %v, error: %v", services[i].name, err)
+	for i, s := range []serviceDescription{otelServiceDescription, mainServiceDescription} {
+		// Stop OTel first (index 0 in reverse), then Main (index 1).
+		handleIndex := 1 - i // maps i=0 -> handles[1] (otel), i=1 -> handles[0] (main)
+		if err := stopService(handles[handleIndex], 30*time.Second); err != nil {
+			return fmt.Errorf("failed to stop service: %v, error: %v", s.name, err)
 		}
 	}
 	return handles[0].Start()
@@ -161,9 +162,8 @@ func uninstall() error {
 	defer m.Disconnect()
 	var errs error
 
-	// Have to remove the services in reverse order.
-	for i := len(services) - 1; i >= 0; i-- {
-		s := services[i]
+	// Have to remove the services in reverse order (otel first, then main).
+	for _, s := range []serviceDescription{otelServiceDescription, mainServiceDescription} {
 		serviceHandle, err := m.OpenService(s.name)
 		if err != nil {
 			// Service does not exist, so nothing to delete.

--- a/cmd/ops_agent_windows/main_windows.go
+++ b/cmd/ops_agent_windows/main_windows.go
@@ -74,12 +74,17 @@ func main() {
 	}
 }
 
-var services []struct {
+type serviceDescription struct {
 	name        string
 	displayName string
 	exepath     string
 	args        []string
 }
+
+var (
+	mainServiceDescription serviceDescription
+	otelServiceDescription serviceDescription
+)
 
 func init() {
 	if err := initServices(); err != nil {
@@ -113,30 +118,22 @@ func initServices() error {
 	}
 
 	// TODO: Write meaningful descriptions for these services
-	services = []struct {
-		name        string
-		displayName string
-		exepath     string
-		args        []string
-	}{
-		{
-			serviceName,
-			serviceDisplayName,
-			self,
-			[]string{
-				"-in", filepath.Join(base, "../config/config.yaml"),
-				"-out", configOutDir,
-			},
+	mainServiceDescription = serviceDescription{
+		name:        serviceName,
+		displayName: serviceDisplayName,
+		exepath:     self,
+		args: []string{
+			"-in", filepath.Join(base, "../config/config.yaml"),
+			"-out", configOutDir,
 		},
-		{
-			fmt.Sprintf("%s-opentelemetry-collector", serviceName),
-			fmt.Sprintf("%s - Metrics Agent", serviceDisplayName),
-			filepath.Join(base, "google-cloud-metrics-agent_windows_amd64.exe"),
-			[]string{
-				"--config=" + filepath.Join(configOutDir, `otel\otel.yaml`),
-			},
+	}
+	otelServiceDescription = serviceDescription{
+		name:        fmt.Sprintf("%s-opentelemetry-collector", serviceName),
+		displayName: fmt.Sprintf("%s - Metrics Agent", serviceDisplayName),
+		exepath:     filepath.Join(base, "google-cloud-metrics-agent_windows_amd64.exe"),
+		args: []string{
+			"--config=" + filepath.Join(configOutDir, `otel\otel.yaml`),
 		},
-
 	}
 	return nil
 }

--- a/cmd/ops_agent_windows/run_windows.go
+++ b/cmd/ops_agent_windows/run_windows.go
@@ -188,18 +188,16 @@ func (s *service) startSubagents() error {
 		return err
 	}
 	defer manager.Disconnect()
-	for _, svc := range services[1:] {
-		handle, err := manager.OpenService(svc.name)
-		if err != nil {
-			// service not found?
-			return err
-		}
-		defer handle.Close()
-		if err := handle.Start(); err != nil {
-			// TODO: Should we be ignoring failures for partial startup?
-			if !errors.Is(err, windows.ERROR_SERVICE_ALREADY_RUNNING) {
-				s.log.Error(EngineEventID, fmt.Sprintf("failed to start %q: %v", svc.name, err))
-			}
+	handle, err := manager.OpenService(otelServiceDescription.name)
+	if err != nil {
+		// service not found?
+		return err
+	}
+	defer handle.Close()
+	if err := handle.Start(); err != nil {
+		// TODO: Should we be ignoring failures for partial startup?
+		if !errors.Is(err, windows.ERROR_SERVICE_ALREADY_RUNNING) {
+			s.log.Error(EngineEventID, fmt.Sprintf("failed to start %q: %v", otelServiceDescription.name, err))
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description
As part of the PR review feedback, we have completely decommissioned the generic 'services' slice of anonymous structs since Fluent Bit is deleted and there is now only one sub-service (OTel collector) left:

- Replaced 'services' slice with strongly-typed global variables 'mainServiceDescription' and 'otelServiceDescription'.
- Simplified 'install_windows.go' and 'install()' / 'uninstall()' routines to install/uninstall main and OTel services explicitly, removing complex index-based reverse loop iterations.
- Simplified 'run_windows.go' and 'startSubagents()' to directly open and start the OTel sub-service without loop overhead.
- Cleanly formatted all files and verified 100% green Windows cross-compilation builds.
-
## Related issue
b/517494318

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
