### PR TITLE
fix: remove deprecated RHEL SAP HA images

### DIFF
--- a/cmd/ops_agent_uap_plugin/service_windows.go
+++ b/cmd/ops_agent_uap_plugin/service_windows.go
@@ -235,7 +235,6 @@ func generateSubAgentConfigs(ctx context.Context, userConfigPath string, pluginS
 	return nil
 }
 
-
 func createWindowsJobHandle() (windows.Handle, error) {
 	jobHandle, err := windows.CreateJobObject(nil, nil)
 	if err != nil {

--- a/project.yaml
+++ b/project.yaml
@@ -78,7 +78,6 @@ targets:
           - rocky-linux-cloud:rocky-linux-8
           exhaustive:
           - rhel-cloud:rhel-8
-          - rhel-sap-cloud:rhel-8-6-sap-ha
           - rhel-sap-cloud:rhel-8-8-sap-ha
           - rhel-sap-cloud:rhel-8-10-sap-ha
           - rocky-linux-cloud:rocky-linux-8-optimized-gcp
@@ -140,7 +139,6 @@ targets:
           exhaustive:
           - rhel-cloud:rhel-9
           - rocky-linux-cloud:rocky-linux-9-optimized-gcp
-          - rhel-sap-cloud:rhel-9-0-sap-ha
           - rhel-sap-cloud:rhel-9-2-sap-ha
           - rhel-sap-cloud:rhel-9-4-sap-ha
           - rhel-sap-cloud:rhel-9-6-sap-ha


### PR DESCRIPTION
## Description
The RHEL SAP HA images `rhel-8-6-sap-ha` and `rhel-9-0-sap-ha` have been deprecated and removed from the `rhel-sap-cloud` project. This was causing nightly integration tests to fail when trying to create VMs with these images.
Since we already have newer versions (`8-8`, `8-10`, `9-2`, `9-4`, `9-6`) in `project.yaml`, we can safely remove the missing ones.
Affected targets:
- `centos8` (removed `rhel-sap-cloud:rhel-8-6-sap-ha`)
- `rockylinux9` (removed `rhel-sap-cloud:rhel-9-0-sap-ha`)
- 
## Related issue
b/519560018

## How has this been tested?
Integration tests

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
