### PR TITLE
chore: cleanup obsolete otlp feature flags and experiments

### DIFF
--- a/confgenerator/testdata/goldens/combined-receiver_otlp/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otlp_logging

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otlp_exporter,otlp_logging,otel_logging

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otlp_exporter,otlp_logging

--- a/confgenerator/testdata/goldens/invalid-logging-otel-processor_modify_fields_unsupported_field/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/invalid-logging-otel-processor_modify_fields_unsupported_field/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging,otlp_logging

--- a/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/invalid-logging-otel-unsupported_processor/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging,otlp_logging

--- a/confgenerator/testdata/goldens/invalid-metrics-exporter_otlphttp_invalid_processor/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/invalid-metrics-exporter_otlphttp_invalid_processor/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otlp_exporter

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging,otlp_logging

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otlp_exporter

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otlp_exporter

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/EXPERIMENTAL_FEATURES
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/EXPERIMENTAL_FEATURES
@@ -1,1 +1,0 @@
-otel_logging

--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -1233,30 +1233,6 @@ func GetOtelConfigPath(imageSpec string) string {
 	return "/var/run/google-cloud-ops-agent/otel.yaml"
 }
 
-const (
-	OTLPLoggingFeatureFlag      = "otlp_logging"
-	OtlpHttpExporterFeatureFlag = "otlp_exporter"
-	DefaultFeatureFlag          = "default"
-)
-
-// setExperimentalFeatures sets the EXPERIMENTAL_FEATURES environment variable.
-func setExperimentalFeatures(ctx context.Context, logger *log.Logger, vm *gce.VM, feature string) error {
-	return gce.SetEnvironmentVariables(ctx, logger, vm, map[string]string{"EXPERIMENTAL_FEATURES": feature})
-}
-
-// SetupOpsAgentWithFeatureFlag configures the VM and the config depending on the selected feature flag.
-func SetupOpsAgentWithFeatureFlag(ctx context.Context, logger *log.Logger, vm *gce.VM, config string, feature string) error {
-	if feature == "" || feature == DefaultFeatureFlag {
-		return SetupOpsAgent(ctx, logger, vm, config)
-	}
-
-	// Set experimental feature environment variable.
-	if err := setExperimentalFeatures(ctx, logger, vm, feature); err != nil {
-		return err
-	}
-
-	return SetupOpsAgent(ctx, logger, vm, config)
-}
 
 func verifyRPMPackageSigned(ctx context.Context, logger *log.Logger, vm *gce.VM, location PackageLocation) error {
 	if !IsRPMBased(vm.ImageSpec) {

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -215,25 +215,7 @@ func retrieveOtelConfig(ctx context.Context, logger *log.Logger, vm *gce.VM) (co
 	return gce.RetrieveContent(ctx, logger, vm, agents.GetOtelConfigPath(vm.ImageSpec))
 }
 
-// RunForEachImageAndFeatureFlag runs a subtest for each image and provide feature flags.
-func RunForEachImageAndFeatureFlag(t *testing.T, features []string, testBody func(t *testing.T, imageSpec string, feature string)) {
-	t.Helper()
-	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
-		t.Parallel()
-		t.Run(agents.DefaultFeatureFlag, func(t *testing.T) {
-			testBody(t, imageSpec, agents.DefaultFeatureFlag)
-		})
-		for _, feature := range features {
-			t.Run(feature, func(t *testing.T) {
-				// Feature flags currently don't work with how Ops Agent UAP Plugin runs.
-				if gce.IsOpsAgentUAPPlugin() {
-					t.SkipNow()
-				}
-				testBody(t, imageSpec, feature)
-			})
-		}
-	})
-}
+
 
 func TestParseMultilineFileJava(t *testing.T) {
 	t.Skip("Disabled until native OTel multiline parsing is implemented.")
@@ -729,7 +711,7 @@ Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.7.1 <[REDACTED_EM
 
 func TestCustomLogFile(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		logPath := logPathForImage(vm.ImageSpec)
@@ -895,7 +877,7 @@ func TestKillChildJobsWhenPluginServerProcessTerminates(t *testing.T) {
 
 func TestCustomLogFormat(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 
@@ -923,7 +905,7 @@ func TestCustomLogFormat(t *testing.T) {
         exporters: [google]
 `, logPath, "%Y-%m-%dT%H:%M:%S.%L%z")
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1070,7 +1052,7 @@ func TestHTTPRequestLog(t *testing.T) {
 
 func TestLogEntrySpecialFields(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := agents.CommonSetup(t, imageSpec)
 		file1 := fmt.Sprintf("%s_1", logPathForImage(vm.ImageSpec))
@@ -1093,7 +1075,7 @@ logging:
           - json
 `
 		config := fmt.Sprintf(configStr, file1)
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger.ToMainLog(), vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1324,7 +1306,7 @@ func TestProcessorOrder(t *testing.T) {
 
 func TestSyslogTCP(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -1354,7 +1336,7 @@ func TestSyslogTCP(t *testing.T) {
         exporters: [google]
 `
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1389,7 +1371,7 @@ func TestSyslogTCP(t *testing.T) {
 
 func TestSyslogUDP(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -1413,7 +1395,7 @@ func TestSyslogUDP(t *testing.T) {
         exporters: [google]
 `
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1433,7 +1415,7 @@ func TestSyslogUDP(t *testing.T) {
 
 func TestExcludeLogs(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		file1 := fmt.Sprintf("%s_1", logPathForImage(vm.ImageSpec))
@@ -1473,7 +1455,7 @@ func TestExcludeLogs(t *testing.T) {
         processors: [json, exclude2]
 `, file1, file2)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1522,7 +1504,7 @@ func TestExcludeLogs(t *testing.T) {
 
 func TestExcludeLogsParseJsonOrder(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		file1 := fmt.Sprintf("%s_1", logPathForImage(vm.ImageSpec))
@@ -1572,7 +1554,7 @@ func TestExcludeLogsParseJsonOrder(t *testing.T) {
         exporters: [google]
 `, file1, file2)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1601,7 +1583,7 @@ func TestExcludeLogsParseJsonOrder(t *testing.T) {
 
 func TestExcludeLogsModifyFieldsOrder(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		file1 := fmt.Sprintf("%s_1", logPathForImage(vm.ImageSpec))
@@ -1665,7 +1647,7 @@ func TestExcludeLogsModifyFieldsOrder(t *testing.T) {
         processors: [json, exclude_trace, modify]
 `, file1, file2, file3)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1695,7 +1677,7 @@ func TestExcludeLogsModifyFieldsOrder(t *testing.T) {
 
 func TestModifyFields(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, nil, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		file1 := fmt.Sprintf("%s_1", logPathForImage(vm.ImageSpec))
@@ -1756,7 +1738,7 @@ func TestModifyFields(t *testing.T) {
         exporters: [google]
 `, file1)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1881,7 +1863,7 @@ func TestResourceNameLabel(t *testing.T) {
 
 func TestLogFilePathLabel(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		file1 := fmt.Sprintf("%s_1", logPathForImage(vm.ImageSpec))
@@ -1903,7 +1885,7 @@ func TestLogFilePathLabel(t *testing.T) {
         processors: [json]
 `, file1)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2105,7 +2087,7 @@ func TestTCPLog(t *testing.T) {
 func TestFluentForwardLog(t *testing.T) {
 	t.Skip("Fluent Bit is removed; OTel fluent forward log test is skipped.")
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
@@ -2121,7 +2103,7 @@ func TestFluentForwardLog(t *testing.T) {
       fluent_pipeline:
         receivers: [fluent_logs]
 `
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2152,7 +2134,7 @@ func TestFluentForwardLog(t *testing.T) {
 
 func TestWindowsEventLog(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if !gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -2173,7 +2155,7 @@ func TestWindowsEventLog(t *testing.T) {
         receivers: [windows_event_log]
         exporters: [google]
 `
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2197,7 +2179,7 @@ func TestWindowsEventLog(t *testing.T) {
 
 func TestWindowsEventLogV1UnsupportedChannel(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if !gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -2218,7 +2200,7 @@ func TestWindowsEventLogV1UnsupportedChannel(t *testing.T) {
       default_pipeline:
         receivers: [%s]
 `, log, channel, log)
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2232,7 +2214,7 @@ func TestWindowsEventLogV1UnsupportedChannel(t *testing.T) {
 
 func TestWindowsEventLogV2(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if !gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -2273,7 +2255,7 @@ func TestWindowsEventLogV2(t *testing.T) {
       pipeline_xml:
         receivers: [winlog2_xml]
 `
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2480,7 +2462,7 @@ func hasKeyWithValueType[V any](m map[string]any, k string) bool {
 
 func TestWindowsEventLogWithNonDefaultTimeZone(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if !gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -2489,7 +2471,7 @@ func TestWindowsEventLogWithNonDefaultTimeZone(t *testing.T) {
 		if _, err := gce.RunRemotely(ctx, logger, vm, `Set-TimeZone -Id "Eastern Standard Time"`); err != nil {
 			t.Fatal(err)
 		}
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, "", feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2515,7 +2497,7 @@ func TestWindowsEventLogWithNonDefaultTimeZone(t *testing.T) {
 
 func TestSystemdLog(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -2532,7 +2514,7 @@ func TestSystemdLog(t *testing.T) {
         receivers: [systemd_logs]
 `
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2567,11 +2549,11 @@ func TestSystemdLog(t *testing.T) {
 
 func TestSystemLogByDefault(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, "", feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2714,10 +2696,10 @@ func testDefaultMetrics(ctx context.Context, t *testing.T, logger *log.Logger, v
 
 func TestDefaultMetricsNoProxy(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, "", feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2732,7 +2714,7 @@ func TestDefaultMetricsNoProxy(t *testing.T) {
 // go/sdi-integ-test#proxy-testing
 func TestDefaultMetricsWithProxy(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if !gce.IsWindows(imageSpec) {
 			t.Skip("Proxy test is currently only supported on windows.")
@@ -2749,7 +2731,7 @@ func TestDefaultMetricsWithProxy(t *testing.T) {
 		if err := gce.SetEnvironmentVariables(ctx, logger, vm, settings); err != nil {
 			t.Fatal(err)
 		}
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, "", feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2909,7 +2891,7 @@ func TestGoogleSecretManagerProvider(t *testing.T) {
 }
 func TestPrometheusMetrics(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 
@@ -2963,7 +2945,7 @@ func TestPrometheusMetrics(t *testing.T) {
           - prometheus
 `
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, promConfig, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, promConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3094,7 +3076,7 @@ func TestPrometheusMetrics(t *testing.T) {
 
 func TestPrometheusMetricsWithMetadata(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		metadataKey, metadataValue := "test", "${test:value}"
 		escapedMetadataValue := "_{test:value}"
@@ -3124,7 +3106,7 @@ func TestPrometheusMetricsWithMetadata(t *testing.T) {
           - prometheus
 `, metadataKey, metadataKey)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger.ToMainLog(), vm, promConfig, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger.ToMainLog(), vm, promConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3160,7 +3142,7 @@ func getCommonLabels(vm *gce.VM) []*metadata.MetricLabel {
 // The JSON exporter will connect to a http server that serve static JSON files
 func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		// TODO: Set up JSON exporter stuff on Windows
 		if gce.IsWindows(imageSpec) {
@@ -3264,7 +3246,7 @@ func TestPrometheusMetricsWithJSONExporter(t *testing.T) {
       prom_pipeline:
         receivers: [prom_app]
 `
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3908,7 +3890,7 @@ func buildGoBinary(ctx context.Context, logger *log.Logger, vm *gce.VM, source, 
 // correctly received and processed
 func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []mockPrometheusCheck) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -3959,7 +3941,7 @@ func testPrometheusMetrics(t *testing.T, opsAgentConfig string, testChecks []moc
 			t.Fatalf("Http server failed to start with stdout %s and stderr %s", liveCheckOut.Stdout, liveCheckOut.Stderr)
 		}
 		// 3. Config and start the agent
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, opsAgentConfig, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, opsAgentConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -4742,7 +4724,7 @@ func runGoCode(ctx context.Context, logger *log.Logger, vm *gce.VM, content io.R
 
 func TestOTLPMetricsGCM(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		otlpConfig := `
@@ -4762,7 +4744,7 @@ traces:
   service:
     pipelines:
 `
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, otlpConfig, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -4999,8 +4981,8 @@ traces:
   service:
     pipelines:
 `
-		// Only run the test for the OTLP http exporter
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, otlpConfig, agents.OtlpHttpExporterFeatureFlag); err != nil {
+		// Run the test with default exporter (OTLP)
+		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -5242,11 +5224,8 @@ metrics:
 
 func TestOTLPLogsWithOtlpExporter(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{OTLPLoggingOTLPExporterFeatureFlag, agents.OTLPLoggingFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
-		if feature == agents.DefaultFeatureFlag {
-			t.Skip("This test requires otlp_logging+otlp_exporter experimental flags to be enabled")
-		}
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 		otlpConfig := `
 combined:
@@ -5267,7 +5246,7 @@ metrics:
   service:
     pipelines:
 `
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, otlpConfig, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, otlpConfig); err != nil {
 			t.Fatal(err)
 		}
 
@@ -5427,7 +5406,7 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 
 func TestNetworkHealthCheck(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if !isHealthCheckTestImage(imageSpec) {
 			t.SkipNow()
@@ -5435,7 +5414,7 @@ func TestNetworkHealthCheck(t *testing.T) {
 
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, "", feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -5562,7 +5541,7 @@ func TestDisableSelfLogCollection(t *testing.T) {
 
 func TestBufferLimitSizeOpsAgent(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		if gce.IsWindows(imageSpec) {
 			t.SkipNow()
@@ -5812,7 +5791,7 @@ func TestLogCompression(t *testing.T) {
 
 func TestFileOffset(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
@@ -5833,7 +5812,7 @@ func TestFileOffset(t *testing.T) {
 			t.Fatalf("Error writing dummy log lines: %v", err)
 		}
 
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 			t.Fatal(err)
 		}
 
@@ -6127,7 +6106,7 @@ func TestUninstallRemovesService(t *testing.T) {
 
 func TestMetricsPortOverrideEnv(t *testing.T) {
 	t.Parallel()
-	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
+	gce.RunForEachImage(t, func(t *testing.T, imageSpec string) {
 		t.Parallel()
 		// Windows support added below
 		if gce.IsOpsAgentUAPPlugin() {
@@ -6136,7 +6115,7 @@ func TestMetricsPortOverrideEnv(t *testing.T) {
 		ctx, logger, vm := setupMainLogAndVM(t, imageSpec)
 
 		// Setup agent with default config first
-		if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, "", feature); err != nil {
+		if err := agents.SetupOpsAgent(ctx, logger, vm, ""); err != nil {
 			t.Fatal(err)
 		}
 

--- a/integration_test/soak_test/cmd/launcher/main.go
+++ b/integration_test/soak_test/cmd/launcher/main.go
@@ -76,7 +76,6 @@ var (
 	ttl     = os.Getenv("TTL")
 	distro  = os.Getenv("DISTRO")
 	vmName  = os.Getenv("VM_NAME")
-	feature = os.Getenv("FEATURE")
 )
 
 //go:embed log_generator.py
@@ -122,9 +121,6 @@ func mainErr() error {
 	}
 	if ttl == "" {
 		return errors.New("Env variable TTL cannot be empty")
-	}
-	if feature == "" {
-		feature = agents.DefaultFeatureFlag
 	}
 
 	// Create the VM.
@@ -177,7 +173,7 @@ func mainErr() error {
         - generator_debug_logs
         exporters: [google]
 `, logPath, debugLogPath)
-	if err := agents.SetupOpsAgentWithFeatureFlag(ctx, logger, vm, config, feature); err != nil {
+	if err := agents.SetupOpsAgent(ctx, logger, vm, config); err != nil {
 		return err
 	}
 

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -552,7 +552,7 @@ func assertMetric(ctx context.Context, logger *log.Logger, vm *gce.VM, metric *m
 // and ensures that the agent uploads data from the app.
 // Returns an error (nil on success), and a boolean indicating whether the error
 // is retryable.
-func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, app string, integrationMetadata metadata.IntegrationMetadata, exporter string) (retry bool, err error) {
+func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce.VM, app string, integrationMetadata metadata.IntegrationMetadata) (retry bool, err error) {
 	folder, err := distroFolder(vm)
 	if err != nil {
 		return nonRetryable, err
@@ -588,11 +588,6 @@ func runSingleTest(ctx context.Context, logger *logging.DirectoryLogger, vm *gce
 		logger.ToMainLog().Printf("Restarting VM instance returned err=%v, see VM_restart.txt for details.", err)
 		if err != nil {
 			return nonRetryable, err
-		}
-	}
-	if exporter == "otlphttp" {
-		if err := setExperimentalFeatures(ctx, logger.ToMainLog(), vm, "otlp_exporter"); err != nil {
-			return nonRetryable, fmt.Errorf("error setting EXPERIMENTAL_FEATURES: %v", err)
 		}
 	}
 	if err := agents.InstallOpsAgent(ctx, logger.ToMainLog(), vm, agents.LocationFromEnvVars()); err != nil {
@@ -1031,90 +1026,88 @@ func TestThirdPartyApps(t *testing.T) {
 	// Execute tests
 	for _, tc := range tests {
 		tc := tc // https://golang.org/doc/faq#closures_and_goroutines
-		for _, exporter := range []string{"otlphttp", "googlecloudmonitoring"} {
-			testName := tc.imageSpec + "/" + exporter + "/" + tc.app
-			if tc.gpu != nil {
-				testName = testName + "/" + tc.gpu.fullName
+		testName := tc.imageSpec + "/" + tc.app
+		if tc.gpu != nil {
+			testName = testName + "/" + tc.gpu.fullName
+		}
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.skipReason != "" {
+				t.Skip(tc.skipReason)
 			}
 
-			t.Run(testName, func(t *testing.T) {
-				t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
+			defer cancel()
+			gcloudConfigDir := t.TempDir()
+			if err := gce.SetupGcloudConfigDir(ctx, gcloudConfigDir); err != nil {
+				t.Fatalf("Unable to set up a gcloud config directory: %v", err)
+			}
+			ctx = gce.WithGcloudConfigDir(ctx, gcloudConfigDir)
 
-				if tc.skipReason != "" {
-					t.Skip(tc.skipReason)
+			var err error
+			for attempt := 1; attempt <= 4; attempt++ {
+				logger := gce.SetupLogger(t)
+				logger.ToMainLog().Println("Calling SetupVM(). For details, see VM_initialization.txt.")
+				options := gce.VMOptions{
+					ImageSpec:            tc.imageSpec,
+					TimeToLive:           "3h",
+					MachineType:          agents.RecommendedMachineType(tc.imageSpec),
+					ExtraCreateArguments: nil,
+				}
+				if tc.gpu != nil {
+					options.ExtraCreateArguments = append(
+						options.ExtraCreateArguments,
+						fmt.Sprintf("--accelerator=count=%s,type=%s", getAcceleratorCount(tc.gpu.machineType), tc.gpu.fullName),
+						"--maintenance-policy=TERMINATE")
+					options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-size=100GB")
+					options.MachineType = tc.gpu.machineType
+					options.Zone = tc.gpu.availableZone
+				}
+				if tc.imageSpec == SAPHANAImageSpec {
+					// This image needs an SSD in order to be performant enough.
+					options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-type=pd-ssd")
+				}
+				if tc.app == OracleDBApp {
+					options.MachineType = "e2-highmem-8"
+					if gce.IsARM(tc.imageSpec) {
+						// T2A doesn't have a highmem line, so pick the standard machine that's specced at least
+						// as well as e2-highmem-8.
+						options.MachineType = "t2a-standard-16"
+					}
+					options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-size=150GB", "--boot-disk-type=pd-ssd")
+				}
+				if strings.Contains(tc.app, ElasticsearchApp) && strings.Contains(options.MachineType, "-standard-2") {
+					// elasticsearch(9) tends to OOM on -standard-2, so go one step up
+					options.MachineType = "e2-highmem-2"
+					if gce.IsARM(tc.imageSpec) {
+						options.MachineType = "t2a-standard-4"
+					}
 				}
 
-				ctx, cancel := context.WithTimeout(context.Background(), gce.SuggestedTimeout)
-				defer cancel()
-				gcloudConfigDir := t.TempDir()
-				if err := gce.SetupGcloudConfigDir(ctx, gcloudConfigDir); err != nil {
-					t.Fatalf("Unable to set up a gcloud config directory: %v", err)
+				vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)
+				logger.ToMainLog().Printf("VM is ready: %#v", vm)
+
+				var retryable bool
+				retryable, err = runSingleTest(ctx, logger, vm, tc.app, tc.metadata)
+				t.Logf("Attempt %v of %s test of %s finished with err=%v, retryable=%v", attempt, tc.imageSpec, tc.app, err, retryable)
+				if err == nil {
+					return
 				}
-				ctx = gce.WithGcloudConfigDir(ctx, gcloudConfigDir)
-
-				var err error
-				for attempt := 1; attempt <= 4; attempt++ {
-					logger := gce.SetupLogger(t)
-					logger.ToMainLog().Println("Calling SetupVM(). For details, see VM_initialization.txt.")
-					options := gce.VMOptions{
-						ImageSpec:            tc.imageSpec,
-						TimeToLive:           "3h",
-						MachineType:          agents.RecommendedMachineType(tc.imageSpec),
-						ExtraCreateArguments: nil,
-					}
-					if tc.gpu != nil {
-						options.ExtraCreateArguments = append(
-							options.ExtraCreateArguments,
-							fmt.Sprintf("--accelerator=count=%s,type=%s", getAcceleratorCount(tc.gpu.machineType), tc.gpu.fullName),
-							"--maintenance-policy=TERMINATE")
-						options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-size=100GB")
-						options.MachineType = tc.gpu.machineType
-						options.Zone = tc.gpu.availableZone
-					}
-					if tc.imageSpec == SAPHANAImageSpec {
-						// This image needs an SSD in order to be performant enough.
-						options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-type=pd-ssd")
-					}
-					if tc.app == OracleDBApp {
-						options.MachineType = "e2-highmem-8"
-						if gce.IsARM(tc.imageSpec) {
-							// T2A doesn't have a highmem line, so pick the standard machine that's specced at least
-							// as well as e2-highmem-8.
-							options.MachineType = "t2a-standard-16"
-						}
-						options.ExtraCreateArguments = append(options.ExtraCreateArguments, "--boot-disk-size=150GB", "--boot-disk-type=pd-ssd")
-					}
-					if strings.Contains(tc.app, ElasticsearchApp) && strings.Contains(options.MachineType, "-standard-2") {
-						// elasticsearch(9) tends to OOM on -standard-2, so go one step up
-						options.MachineType = "e2-highmem-2"
-						if gce.IsARM(tc.imageSpec) {
-							options.MachineType = "t2a-standard-4"
-						}
-					}
-
-					vm := gce.SetupVM(ctx, t, logger.ToFile("VM_initialization.txt"), options)
-					logger.ToMainLog().Printf("VM is ready: %#v", vm)
-
-					var retryable bool
-					retryable, err = runSingleTest(ctx, logger, vm, tc.app, tc.metadata, exporter)
-					t.Logf("Attempt %v of %s test of %s finished with err=%v, retryable=%v", attempt, tc.imageSpec, tc.app, err, retryable)
-					if err == nil {
-						return
-					}
-					agents.RunOpsAgentDiagnostics(ctx, logger, vm)
-					if !retryable {
-						t.Fatalf("Non-retryable error: %v", err)
-					}
-					// If we got here, we're going to retry runSingleTest(). The VM we spawned
-					// won't be deleted until the end of t.Run(), (SetupVM() registers it for cleanup
-					// at the end of t.Run()), so to avoid accumulating too many idle VMs while we
-					// do our retries, we preemptively delete the VM now.
-					if deleteErr := gce.DeleteInstance(logger.ToMainLog(), vm); deleteErr != nil {
-						t.Errorf("Deleting VM %v failed: %v", vm.Name, deleteErr)
-					}
+				agents.RunOpsAgentDiagnostics(ctx, logger, vm)
+				if !retryable {
+					t.Fatalf("Non-retryable error: %v", err)
 				}
-				t.Errorf("Final attempt failed: %v", err)
-			})
-		}
+				// If we got here, we're going to retry runSingleTest(). The VM we spawned
+				// won't be deleted until the end of t.Run(), (SetupVM() registers it for cleanup
+				// at the end of t.Run()), so to avoid accumulating too many idle VMs while we
+				// do our retries, we preemptively delete the VM now.
+				if deleteErr := gce.DeleteInstance(logger.ToMainLog(), vm); deleteErr != nil {
+					t.Errorf("Deleting VM %v failed: %v", vm.Name, deleteErr)
+				}
+			}
+			t.Errorf("Final attempt failed: %v", err)
+		})
 	}
 }

--- a/transformation_test/otlp_helpers_test.go
+++ b/transformation_test/otlp_helpers_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator"
 	"github.com/GoogleCloudPlatform/ops-agent/confgenerator/otel"
-	"github.com/GoogleCloudPlatform/ops-agent/internal/experiments"
 	"github.com/goccy/go-yaml"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
@@ -28,8 +27,6 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 	pi := transformationConfig.pipelineInstance(abs)
 	pi.RID = "my-log-name"
 	pi.Backend = confgenerator.BackendOTel
-
-	ctx = experiments.ContextWithExperiments(ctx, map[string]bool{"otlp_exporter": true})
 
 	rps, pls, err := pi.OTelComponents(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description
Remove OTLP-related feature flags (otlp_exporter, otlp_logging, otel_logging) from integration tests and transformation tests, as OTLP is now the default exporter and logging backend. Also remove dead EXPERIMENTAL_FEATURES files from confgenerator testdata. Remove now redundant RunForEachImage and SetupOpsAgentWithFeatureFlag helpers from integration tests, calling gce.RunForEachImage and SetupOpsAgent directly.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
