### PR TITLE
fix(logging): correctly map sourceLocation.function to structured OTel function.name attributes

### DIFF
--- a/confgenerator/filter/internal/ast/ast.go
+++ b/confgenerator/filter/internal/ast/ast.go
@@ -101,6 +101,11 @@ func (m Target) ottlPath() ([]string, error) {
 	if len(unquoted) >= 1 {
 		if v, ok := logEntryRootStructMapToOTel[unquoted[0]]; ok {
 			otel = append(v, unquoted[1:]...)
+			if unquoted[0] == "sourceLocation" && len(unquoted) > 1 && unquoted[1] == "function" {
+				if len(unquoted) == 2 || unquoted[2] != "name" {
+					otel = append(otel, "name")
+				}
+			}
 		}
 	}
 	if otel == nil {

--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -114,6 +114,18 @@ func (p ParserShared) SpecialFieldsStatements(ctx context.Context) ottl.Statemen
 		}
 		statements = statements.Append(s)
 	}
+
+	funcName := ottl.LValue{"attributes", "gcp.source_location", "function", "name"}
+	funcStr := ottl.LValue{"attributes", "gcp.source_location", "function"}
+	cacheFunc := ottl.LValue{"cache", "__func_name"}
+
+	statements = statements.Append(ottl.NewStatements(
+		cacheFunc.SetIf(funcStr, funcStr.IsString()),
+		funcStr.SetIf(ottl.RValue("{}"), cacheFunc.IsPresent()),
+		funcName.SetIf(cacheFunc, cacheFunc.IsPresent()),
+		cacheFunc.Delete(),
+	))
+
 	return statements
 }
 

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -878,6 +878,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -834,6 +834,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -924,6 +924,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -924,6 +924,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -849,6 +849,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -805,6 +805,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1023,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1023,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -849,6 +849,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -909,6 +913,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -805,6 +805,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -865,6 +869,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -907,6 +907,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -967,6 +971,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -863,6 +863,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -923,6 +927,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -953,6 +953,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1017,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -953,6 +953,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1017,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -883,6 +883,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -839,6 +839,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -929,6 +929,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -929,6 +929,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -845,6 +845,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -901,6 +905,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -957,6 +965,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1025,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -801,6 +801,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -857,6 +861,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -913,6 +921,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -969,6 +981,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -891,6 +891,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -947,6 +951,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1003,6 +1011,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -1059,6 +1071,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -891,6 +891,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -947,6 +951,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1003,6 +1011,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -1059,6 +1071,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -907,6 +907,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -967,6 +971,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1027,6 +1035,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1087,6 +1099,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -863,6 +863,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -923,6 +927,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -983,6 +991,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1043,6 +1055,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -953,6 +953,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1017,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1073,6 +1081,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1133,6 +1145,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -953,6 +953,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1017,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1073,6 +1081,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1133,6 +1145,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -849,6 +849,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -805,6 +805,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1023,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1023,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -994,6 +994,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -950,6 +950,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -1040,6 +1040,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -1040,6 +1040,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -849,6 +849,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -909,6 +913,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -805,6 +805,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -865,6 +869,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -895,6 +895,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +959,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -890,6 +890,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/iis__access_1:
     error_mode: ignore
     log_statements:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -890,6 +890,10 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(cache["__func_name"], attributes["gcp.source_location"]["function"]) where IsString(attributes["gcp.source_location"]["function"])
+      - set(attributes["gcp.source_location"]["function"], {}) where (cache != nil and cache["__func_name"] != nil)
+      - set(attributes["gcp.source_location"]["function"]["name"], cache["__func_name"]) where (cache != nil and cache["__func_name"] != nil)
+      - delete_key(cache, "__func_name") where (cache != nil and cache["__func_name"] != nil)
   transform/iis__access_1:
     error_mode: ignore
     log_statements:

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -1092,13 +1092,14 @@ logging:
 
 		// Expect to see the log with the special fields to be placed to the top
 		// level of the LogEntry and the rest to jsonPayload.
-		// N.B. operation and sourceLocation.function are currently not working under OTel logging due to exporter/ingestion gaps.
+		// N.B. operation is currently not working under OTel logging due to exporter gaps.
 		// Tracked in b/517603547.
 		expectedTrace := fmt.Sprintf("projects/%s/traces/0123456789abcdef0123456789abcdef", vm.Project)
 		if err := gce.WaitForLog(ctx, logger.ToMainLog(), vm, "f1", time.Hour,
 			fmt.Sprintf(`severity="WARNING" AND `+
 				`labels.label1="value1" AND labels.label2="value2" AND `+
 				`sourceLocation.file="file" AND sourceLocation.line="1" AND `+
+				`sourceLocation.function="function" AND `+
 				`trace=%q AND `+
 				`spanId="0f1e2d3c4b5a6f7e" AND `+
 				`jsonPayload.normal_field="value"`, expectedTrace)); err != nil {


### PR DESCRIPTION
## Description
Updates OTTL configuration generation and AST filter query parsing to correctly map `sourceLocation.function` string values into OpenTelemetry's expected `attributes.gcp.source_location.function.name` structured attribute format.
Re-enables `sourceLocation.function` query assertions in integration tests (`TestLogEntrySpecialFields`).

## Related issue
b/517603547

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
