### PR TITLE
fix(logging): rename attributes.gcp.source_location.function to func

### DIFF
--- a/confgenerator/filter/internal/ast/ast.go
+++ b/confgenerator/filter/internal/ast/ast.go
@@ -99,6 +99,9 @@ func (m Target) ottlPath() ([]string, error) {
 		}
 	}
 	if len(unquoted) >= 1 {
+		if unquoted[0] == "sourceLocation" && len(unquoted) > 1 && unquoted[1] == "function" {
+			unquoted[1] = "func"
+		}
 		if v, ok := logEntryRootStructMapToOTel[unquoted[0]]; ok {
 			otel = append(v, unquoted[1:]...)
 		}

--- a/confgenerator/filter/internal/ast/ast_test.go
+++ b/confgenerator/filter/internal/ast/ast_test.go
@@ -88,6 +88,12 @@ func TestValidPath(t *testing.T) {
 			`attributes["gcp.source_location"]["line"]`,
 		},
 		{
+			Target{"sourceLocation", "function"},
+			"sourceLocation.function",
+			[]string{"attributes", "gcp.source_location", "func"},
+			`attributes["gcp.source_location"]["func"]`,
+		},
+		{
 			Target{"labels", "custom"},
 			"labels.custom",
 			[]string{"attributes", "custom"},

--- a/confgenerator/logging_processors.go
+++ b/confgenerator/logging_processors.go
@@ -114,6 +114,15 @@ func (p ParserShared) SpecialFieldsStatements(ctx context.Context) ottl.Statemen
 		}
 		statements = statements.Append(s)
 	}
+
+	funcOld := ottl.LValue{"attributes", "gcp.source_location", "function"}
+	funcNew := ottl.LValue{"attributes", "gcp.source_location", "func"}
+
+	statements = statements.Append(ottl.NewStatements(
+		funcNew.SetIf(funcOld, funcOld.IsPresent()),
+		funcOld.DeleteIf(funcNew.IsPresent()),
+	))
+
 	return statements
 }
 

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -878,6 +878,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -834,6 +834,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -924,6 +924,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -924,6 +924,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -849,6 +849,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -805,6 +805,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1019,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1019,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -849,6 +849,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -909,6 +911,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -805,6 +805,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -865,6 +867,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -907,6 +907,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -967,6 +969,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -863,6 +863,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -923,6 +925,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -953,6 +953,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1015,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -953,6 +953,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1015,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -883,6 +883,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -839,6 +839,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -929,6 +929,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -929,6 +929,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -845,6 +845,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -901,6 +903,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -957,6 +961,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1019,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -801,6 +801,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -857,6 +859,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -913,6 +917,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -969,6 +975,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -891,6 +891,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -947,6 +949,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1003,6 +1007,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -1059,6 +1065,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -891,6 +891,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline1_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -947,6 +949,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_0:
     error_mode: ignore
     log_statements:
@@ -1003,6 +1007,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_sample__logs_1:
     error_mode: ignore
     log_statements:
@@ -1059,6 +1065,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -907,6 +907,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -967,6 +969,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1027,6 +1031,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1087,6 +1093,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -863,6 +863,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -923,6 +925,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -983,6 +987,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1043,6 +1049,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -953,6 +953,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1015,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1073,6 +1077,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1133,6 +1139,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -953,6 +953,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_log__source__id2_0:
     error_mode: ignore
     log_statements:
@@ -1013,6 +1015,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline3_test__syslog__source__id__tcp_0:
     error_mode: ignore
     log_statements:
@@ -1073,6 +1077,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline4_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -1133,6 +1139,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -849,6 +849,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -805,6 +805,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1019,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_1_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_default__pipeline_windows__event__log_2_0:
     error_mode: ignore
     log_statements:
@@ -1015,6 +1019,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -994,6 +994,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -950,6 +950,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -1040,6 +1040,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -1040,6 +1040,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -849,6 +849,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -909,6 +911,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -805,6 +805,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -865,6 +867,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/ops_agent_0:
     error_mode: ignore
     metric_statements:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -895,6 +895,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/logs_pipeline2_test__syslog__source__id__udp_0:
     error_mode: ignore
     log_statements:
@@ -955,6 +957,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/mssql_1:
     metric_statements:
     - context: scope

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -890,6 +890,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/iis__access_1:
     error_mode: ignore
     log_statements:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -890,6 +890,8 @@ processors:
       - set(cache["__setif_value"], cache["value"])
       - replace_pattern(cache["__setif_value"], "^projects/([^/]*)/traces/", "")
       - set(trace_id.string, cache["__setif_value"]) where (cache != nil and cache["value"] != nil)
+      - set(attributes["gcp.source_location"]["func"], attributes["gcp.source_location"]["function"]) where (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil)
+      - delete_key(attributes["gcp.source_location"], "function") where ((attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["function"] != nil) and (attributes != nil and attributes["gcp.source_location"] != nil and attributes["gcp.source_location"]["func"] != nil))
   transform/iis__access_1:
     error_mode: ignore
     log_statements:

--- a/transformation_test/testdata/ops_agent_test-TestLogEntrySpecialFields/output_otel.yaml
+++ b/transformation_test/testdata/ops_agent_test-TestLogEntrySpecialFields/output_otel.yaml
@@ -38,7 +38,7 @@
               - key: file
                 value:
                   stringValue: file
-              - key: function
+              - key: func
                 value:
                   stringValue: function
               - key: line


### PR DESCRIPTION
Updates OTTL configuration generation and AST filter query parsing to correctly map sourceLocation.function string values into OpenTelemetry's expected attributes.gcp.source_location.func structured attribute format.
Re-enables sourceLocation.function query assertions in integration tests (TestLogEntrySpecialFields).

## Description
<!--- Describe your changes in detail. -->

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
