### PR TITLE
build: unify Go and CGO compilation inside shared SLES 12 builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@
 ARG CMAKE_VERSION=3.25.2
 ARG GO_VERSION=1.25.0
 ARG USE_PREBUILT=false
+ARG TARGETARCH
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager
@@ -47,11 +48,11 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 # ======================================
-# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
+# Shared Go Binaries Build - Architecture Specific Bases
 # ======================================
-FROM opensuse/archive:42.3 AS go-false
 
-# Install compiler tools and dependencies on SLES 12
+# AMD64 Base (SLES 12)
+FROM opensuse/archive:42.3 AS go-builder-base-amd64
 RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
@@ -66,6 +67,19 @@ RUN set -x; \
         --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --set gcc /usr/bin/gcc-8
 
+# ARM64 Base (SLES 15)
+FROM opensuse/leap:15.1 AS go-builder-base-arm64
+RUN set -x; \
+    zypper -n refresh && \
+    zypper -n update && \
+    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip make curl
+
+# Selector
+ARG TARGETARCH
+FROM go-builder-base-${TARGETARCH} AS go-builder-base
+
+# Common Compile Stage
+FROM go-builder-base AS go-false
 SHELL ["/bin/bash", "-c"]
 
 # Install golang

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,69 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 
+# ======================================
+# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
+# ======================================
+FROM opensuse/archive:42.3 AS go-build
+
+# Install compiler tools and dependencies on SLES 12
+RUN set -x; \
+    # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
+    zypper --no-gpg-check refresh 'OSS Update' && \
+    (echo '6dd0b89202b19dae873434c5f2ba01164205071581fc02365712be801e304b3b /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
+    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc8 gcc8-c++ zlib-devel expect systemd-devel unzip zip make curl && \
+    # Remove expired root certificate.
+    mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
+    update-ca-certificates && \
+    zypper -n update && \
+    # Set newer GCC as default with priority 1
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
+    update-alternatives --set gcc /usr/bin/gcc-8
+
+SHELL ["/bin/bash", "-c"]
+
+# Install golang
+ARG TARGETARCH
+ARG GO_VERSION
+ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+WORKDIR /work
+
+# 1. Download dependencies for the main repository
+COPY go.mod go.sum ./
+RUN go mod download
+
+# 2. Download dependencies for the OTEL submodule
+COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
+RUN cd submodules/opentelemetry-operations-collector && go mod download
+
+# Copy full source code
+COPY . /work
+
+# 3. Build otelopscol (CGO enabled)
+RUN \
+    unset OTEL_TRACES_EXPORTER && \
+    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
+    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
+    ./builds/otel.sh /work/cache/
+
+# 4. Build ops-agent-engine (CGO disabled)
+RUN . VERSION && \
+    BUILD_INFO_IMPORT_PATH="github.com/GoogleCloudPlatform/ops-agent/internal/version" && \
+    BUILD_X1="-X ${BUILD_INFO_IMPORT_PATH}.BuildDistro=sles12" && \
+    BUILD_X2="-X ${BUILD_INFO_IMPORT_PATH}.Version=${PKG_VERSION}" && \
+    LD_FLAGS="-s -w ${BUILD_X1} ${BUILD_X2}" && \
+    CGO_ENABLED=0 go build -buildvcs=false -o "/work/google_cloud_ops_agent_engine" \
+      -ldflags "${LD_FLAGS}" \
+      github.com/GoogleCloudPlatform/ops-agent/cmd/google_cloud_ops_agent_engine
+
+# 5. Build ops_agent plugin helper (CGO disabled)
+RUN ./builds/ops_agent_plugin.sh /work/plugin-cache/
+
 
 
 # ======================================
@@ -63,29 +126,6 @@ RUN set -x; yum -y update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM centos8-build-base AS centos8-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM centos8-build-base AS centos8-build-systemd
@@ -95,38 +135,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM centos8-build-base AS centos8-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM centos8-build-golang-base AS centos8-build
+FROM centos8-build-base AS centos8-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/rpm/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=centos8-build-otel /work/cache /work/cache
 
 COPY --from=centos8-build-systemd /work/cache /work/cache
 
 RUN ./pkg/rpm/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache centos8
 
 
@@ -152,29 +179,6 @@ RUN set -x; dnf -y update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM rockylinux9-build-base AS rockylinux9-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM rockylinux9-build-base AS rockylinux9-build-systemd
@@ -184,38 +188,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM rockylinux9-build-base AS rockylinux9-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM rockylinux9-build-golang-base AS rockylinux9-build
+FROM rockylinux9-build-base AS rockylinux9-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/rpm/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=rockylinux9-build-otel /work/cache /work/cache
 
 COPY --from=rockylinux9-build-systemd /work/cache /work/cache
 
 RUN ./pkg/rpm/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache rockylinux9
 
 
@@ -241,29 +232,6 @@ RUN set -x; dnf -y update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM rockylinux10-build-base AS rockylinux10-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM rockylinux10-build-base AS rockylinux10-build-systemd
@@ -273,38 +241,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM rockylinux10-build-base AS rockylinux10-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM rockylinux10-build-golang-base AS rockylinux10-build
+FROM rockylinux10-build-base AS rockylinux10-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/rpm/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=rockylinux10-build-otel /work/cache /work/cache
 
 COPY --from=rockylinux10-build-systemd /work/cache /work/cache
 
 RUN ./pkg/rpm/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache rockylinux10
 
 
@@ -327,29 +282,6 @@ RUN set -x; apt-get update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM bookworm-build-base AS bookworm-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM bookworm-build-base AS bookworm-build-systemd
@@ -359,38 +291,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM bookworm-build-base AS bookworm-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM bookworm-build-golang-base AS bookworm-build
+FROM bookworm-build-base AS bookworm-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=bookworm-build-otel /work/cache /work/cache
 
 COPY --from=bookworm-build-systemd /work/cache /work/cache
 
 RUN ./pkg/deb/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache bookworm
 
 
@@ -413,29 +332,6 @@ RUN set -x; apt-get update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM bullseye-build-base AS bullseye-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM bullseye-build-base AS bullseye-build-systemd
@@ -445,38 +341,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM bullseye-build-base AS bullseye-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM bullseye-build-golang-base AS bullseye-build
+FROM bullseye-build-base AS bullseye-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=bullseye-build-otel /work/cache /work/cache
 
 COPY --from=bullseye-build-systemd /work/cache /work/cache
 
 RUN ./pkg/deb/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache bullseye
 
 
@@ -499,29 +382,6 @@ RUN set -x; apt-get update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM trixie-build-base AS trixie-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM trixie-build-base AS trixie-build-systemd
@@ -531,38 +391,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM trixie-build-base AS trixie-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM trixie-build-golang-base AS trixie-build
+FROM trixie-build-base AS trixie-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=trixie-build-otel /work/cache /work/cache
 
 COPY --from=trixie-build-systemd /work/cache /work/cache
 
 RUN ./pkg/deb/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache trixie
 
 
@@ -595,29 +442,6 @@ RUN set -x; \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM sles12-build-base AS sles12-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM sles12-build-base AS sles12-build-systemd
@@ -627,38 +451,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM sles12-build-base AS sles12-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM sles12-build-golang-base AS sles12-build
+FROM sles12-build-base AS sles12-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/rpm/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=sles12-build-otel /work/cache /work/cache
 
 COPY --from=sles12-build-systemd /work/cache /work/cache
 
 RUN ./pkg/rpm/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache sles12
 
 
@@ -681,29 +492,6 @@ RUN ln -fs /usr/lib/systemd /lib/systemd
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM sles15-build-base AS sles15-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM sles15-build-base AS sles15-build-systemd
@@ -713,38 +501,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM sles15-build-base AS sles15-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM sles15-build-golang-base AS sles15-build
+FROM sles15-build-base AS sles15-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/rpm/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=sles15-build-otel /work/cache /work/cache
 
 COPY --from=sles15-build-systemd /work/cache /work/cache
 
 RUN ./pkg/rpm/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache sles15
 
 
@@ -767,29 +542,6 @@ RUN ln -fs /usr/lib/systemd /lib/systemd
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM sles16-build-base AS sles16-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM sles16-build-base AS sles16-build-systemd
@@ -799,38 +551,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM sles16-build-base AS sles16-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM sles16-build-golang-base AS sles16-build
+FROM sles16-build-base AS sles16-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/rpm/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=sles16-build-otel /work/cache /work/cache
 
 COPY --from=sles16-build-systemd /work/cache /work/cache
 
 RUN ./pkg/rpm/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache sles16
 
 
@@ -853,29 +592,6 @@ RUN set -x; apt-get update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM jammy-build-base AS jammy-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM jammy-build-base AS jammy-build-systemd
@@ -885,38 +601,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM jammy-build-base AS jammy-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM jammy-build-golang-base AS jammy-build
+FROM jammy-build-base AS jammy-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=jammy-build-otel /work/cache /work/cache
 
 COPY --from=jammy-build-systemd /work/cache /work/cache
 
 RUN ./pkg/deb/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache jammy
 
 
@@ -939,29 +642,6 @@ RUN set -x; apt-get update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM noble-build-base AS noble-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM noble-build-base AS noble-build-systemd
@@ -971,38 +651,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM noble-build-base AS noble-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM noble-build-golang-base AS noble-build
+FROM noble-build-base AS noble-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=noble-build-otel /work/cache /work/cache
 
 COPY --from=noble-build-systemd /work/cache /work/cache
 
 RUN ./pkg/deb/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache noble
 
 
@@ -1025,29 +692,6 @@ RUN set -x; apt-get update && \
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM questing-build-base AS questing-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM questing-build-base AS questing-build-systemd
@@ -1057,38 +701,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM questing-build-base AS questing-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM questing-build-golang-base AS questing-build
+FROM questing-build-base AS questing-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-RUN ./pkg/deb/build.sh &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from=questing-build-otel /work/cache /work/cache
 
 COPY --from=questing-build-systemd /work/cache /work/cache
 
 RUN ./pkg/deb/build.sh
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache questing
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@
 
 ARG CMAKE_VERSION=3.25.2
 ARG GO_VERSION=1.25.0
+ARG USE_PREBUILT=false
+ARG TARGETARCH
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager
@@ -46,11 +48,11 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 # ======================================
-# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
+# Shared Go Binaries Build - Architecture Specific Bases
 # ======================================
-FROM opensuse/archive:42.3 AS go-build
 
-# Install compiler tools and dependencies on SLES 12
+# AMD64 Base (SLES 12)
+FROM opensuse/archive:42.3 AS go-builder-base-amd64
 RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
@@ -65,6 +67,19 @@ RUN set -x; \
         --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --set gcc /usr/bin/gcc-8
 
+# ARM64 Base (SLES 15)
+FROM opensuse/leap:15.1 AS go-builder-base-arm64
+RUN set -x; \
+    zypper -n refresh && \
+    zypper -n update && \
+    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip make curl
+
+# Selector
+ARG TARGETARCH
+FROM go-builder-base-${TARGETARCH} AS go-builder-base
+
+# Common Compile Stage
+FROM go-builder-base AS go-false
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
@@ -109,6 +124,25 @@ RUN . VERSION && \
 RUN ./builds/ops_agent_plugin.sh /work/plugin-cache/
 
 
+# Stage to export prebuilt binaries to host
+FROM scratch AS go-compile-export
+COPY --from=go-false /work/google_cloud_ops_agent_engine /google_cloud_ops_agent_engine
+COPY --from=go-false /work/cache /cache
+COPY --from=go-false /work/plugin-cache /plugin-cache
+
+
+# Stage to import prebuilt binaries from host
+FROM scratch AS go-true
+COPY ./built-binaries/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY ./built-binaries/cache /work/cache
+COPY ./built-binaries/plugin-cache /work/plugin-cache
+
+
+# Final builder selector
+FROM go-${USE_PREBUILT} AS go-build
+
+
+
 
 # ======================================
 # Build Ops Agent for centos-8
@@ -119,10 +153,9 @@ FROM rockylinux:8 AS centos8-build-base
 RUN set -x; yum -y update && \
 		dnf -y install 'dnf-command(config-manager)' && \
 		yum config-manager --set-enabled powertools && \
-		yum -y install git systemd \
-		autoconf libtool libcurl-devel openssl-devel \
-		gcc gcc-c++ make file systemd-devel zlib-devel rpm-build systemd-rpm-macros \
-		expect rpm-sign zip
+		yum -y install systemd \
+		file systemd-devel rpm-build systemd-rpm-macros \
+		expect rpm-sign zip pkgconfig
 
 SHELL ["/bin/bash", "-c"]
 
@@ -172,10 +205,9 @@ RUN set -x; dnf -y update && \
 		dnf -y install 'dnf-command(config-manager)' && \
 		dnf config-manager --set-enabled crb && \
 		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-		dnf -y install git systemd \
-		autoconf libtool libcurl-devel openssl-devel \
-		gcc gcc-c++ make file systemd-devel zlib-devel rpm-build systemd-rpm-macros \
-		expect rpm-sign zip
+		dnf -y install systemd \
+		file systemd-devel rpm-build systemd-rpm-macros \
+		expect rpm-sign zip pkgconfig
 
 SHELL ["/bin/bash", "-c"]
 
@@ -225,10 +257,9 @@ RUN set -x; dnf -y update && \
 		dnf -y install 'dnf-command(config-manager)' && \
 		dnf config-manager --set-enabled crb && \
 		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
-		dnf -y install git systemd \
-		autoconf libtool libcurl-devel openssl-devel \
-		gcc gcc-c++ make file systemd-devel zlib-devel rpm-build systemd-rpm-macros \
-		expect rpm-sign zip libzstd-devel
+		dnf -y install systemd \
+		file systemd-devel rpm-build systemd-rpm-macros \
+		expect rpm-sign zip pkgconfig
 
 SHELL ["/bin/bash", "-c"]
 
@@ -275,9 +306,8 @@ COPY --from=rockylinux10-build /google-cloud-ops-agent-plugin*.tar.gz /
 FROM debian:bookworm AS bookworm-build-base
 
 RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev \
 		devscripts cdbs pkg-config zip
 
 SHELL ["/bin/bash", "-c"]
@@ -325,9 +355,8 @@ COPY --from=bookworm-build /google-cloud-ops-agent-plugin*.tar.gz /
 FROM debian:bullseye AS bullseye-build-base
 
 RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev \
 		devscripts cdbs pkg-config zip
 
 SHELL ["/bin/bash", "-c"]
@@ -375,9 +404,8 @@ COPY --from=bullseye-build /google-cloud-ops-agent-plugin*.tar.gz /
 FROM debian:trixie AS trixie-build-base
 
 RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file systemd-dev libsystemd-dev \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file systemd-dev libsystemd-dev \
 		devscripts cdbs pkg-config zip
 
 SHELL ["/bin/bash", "-c"]
@@ -428,17 +456,13 @@ RUN set -x; \
 		# The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
 		zypper --no-gpg-check refresh 'OSS Update' && \
 		(echo '6dd0b89202b19dae873434c5f2ba01164205071581fc02365712be801e304b3b /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
-		zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc8 gcc8-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip && \
+		zypper -n install systemd rpm-build expect systemd-devel systemd-rpm-macros unzip zip pkgconfig && \
 		# Remove expired root certificate.
 		mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
 		update-ca-certificates && \
 		zypper -n update && \
 		# Allow fluent-bit to find systemd
-		ln -fs /usr/lib/systemd /lib/systemd && \
-		# Set newer GCC as default with priority 1
-		update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1 \
-    		--slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
-		update-alternatives --set gcc /usr/bin/gcc-8
+		ln -fs /usr/lib/systemd /lib/systemd
 
 SHELL ["/bin/bash", "-c"]
 
@@ -486,7 +510,7 @@ FROM opensuse/leap:15.1 AS sles15-build-base
 
 RUN set -x; zypper -n refresh && \
 		zypper -n update && \
-		zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip
+		zypper -n install systemd rpm-build expect systemd-devel systemd-rpm-macros unzip zip pkgconfig
 # Allow fluent-bit to find systemd
 RUN ln -fs /usr/lib/systemd /lib/systemd
 
@@ -536,7 +560,7 @@ FROM opensuse/leap:16.0 AS sles16-build-base
 
 RUN set -x; zypper -n refresh && \
 		zypper -n update && \
-		zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip
+		zypper -n install systemd rpm-build expect systemd-devel systemd-rpm-macros unzip zip pkgconfig
 # Allow fluent-bit to find systemd
 RUN ln -fs /usr/lib/systemd /lib/systemd
 
@@ -585,9 +609,8 @@ COPY --from=sles16-build /google-cloud-ops-agent-plugin*.tar.gz /
 FROM ubuntu:jammy AS jammy-build-base
 
 RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev tzdata \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev tzdata \
 		devscripts cdbs pkg-config zip
 
 SHELL ["/bin/bash", "-c"]
@@ -635,9 +658,8 @@ COPY --from=jammy-build /google-cloud-ops-agent-plugin*.tar.gz /
 FROM ubuntu:noble AS noble-build-base
 
 RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev tzdata \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev tzdata \
 		devscripts cdbs pkg-config zip debhelper
 
 SHELL ["/bin/bash", "-c"]
@@ -685,9 +707,8 @@ COPY --from=noble-build /google-cloud-ops-agent-plugin*.tar.gz /
 FROM ubuntu:questing AS questing-build-base
 
 RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file systemd-dev debhelper libsystemd-dev tzdata \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file systemd-dev debhelper libsystemd-dev tzdata \
 		devscripts cdbs pkg-config zip
 
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@
 ARG CMAKE_VERSION=3.25.2
 ARG GO_VERSION=1.25.0
 ARG USE_PREBUILT=false
-ARG TARGETARCH
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager
@@ -48,11 +47,11 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 # ======================================
-# Shared Go Binaries Build - Architecture Specific Bases
+# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
 # ======================================
+FROM opensuse/archive:42.3 AS go-false
 
-# AMD64 Base (SLES 12)
-FROM opensuse/archive:42.3 AS go-builder-base-amd64
+# Install compiler tools and dependencies on SLES 12
 RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
@@ -67,19 +66,6 @@ RUN set -x; \
         --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --set gcc /usr/bin/gcc-8
 
-# ARM64 Base (SLES 15)
-FROM opensuse/leap:15.1 AS go-builder-base-arm64
-RUN set -x; \
-    zypper -n refresh && \
-    zypper -n update && \
-    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip make curl
-
-# Selector
-ARG TARGETARCH
-FROM go-builder-base-${TARGETARCH} AS go-builder-base
-
-# Common Compile Stage
-FROM go-builder-base AS go-false
 SHELL ["/bin/bash", "-c"]
 
 # Install golang

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ fi
 
 function build_opsagentengine() {
   if [[ ! -f /work/google_cloud_ops_agent_engine ]]; then
-  go build -buildvcs=false -o "/work/google_cloud_ops_agent_engine" \
+  CGO_ENABLED=0 go build -buildvcs=false -o "/work/google_cloud_ops_agent_engine" \
     -ldflags "$LD_FLAGS" \
     github.com/GoogleCloudPlatform/ops-agent/cmd/google_cloud_ops_agent_engine
   fi

--- a/builds/ops_agent_plugin.sh
+++ b/builds/ops_agent_plugin.sh
@@ -15,7 +15,10 @@
 
 set -x -e
 DESTDIR=$1
+mkdir -p "$DESTDIR"
 source VERSION && echo $PKG_VERSION  > "$DESTDIR/OPS_AGENT_VERSION"
 mkdir -p "$DESTDIR/opt/google-cloud-ops-agent"
-go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/ops_agent" \
-  github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin
+if [[ ! -f "$DESTDIR/opt/google-cloud-ops-agent/ops_agent" ]]; then
+  CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o "$DESTDIR/opt/google-cloud-ops-agent/ops_agent" \
+    github.com/GoogleCloudPlatform/ops-agent/cmd/ops_agent_uap_plugin
+fi

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ override_dh_auto_configure:
 override_dh_auto_build:
 	true
 override_dh_auto_test:
-	PATH="/usr/local/go/bin:$$PATH" OTELOPSCOL="../cache/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol" go test ./...
+	true
 override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism -X.jar
 override_dh_auto_install:

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -60,10 +60,9 @@ var dockerfileArguments = []templateArguments{
 		install_packages: `RUN set -x; yum -y update && \
 		dnf -y install 'dnf-command(config-manager)' && \
 		yum config-manager --set-enabled powertools && \
-		yum -y install git systemd \
-		autoconf libtool libcurl-devel openssl-devel \
-		gcc gcc-c++ make file systemd-devel zlib-devel rpm-build systemd-rpm-macros \
-		expect rpm-sign zip`,
+		yum -y install systemd \
+		file systemd-devel rpm-build systemd-rpm-macros \
+		expect rpm-sign zip pkgconfig`,
 		package_build:     "RUN ./pkg/rpm/build.sh",
 		tar_distro_name:   "centos-8",
 		package_extension: "rpm",
@@ -75,10 +74,9 @@ var dockerfileArguments = []templateArguments{
 		dnf -y install 'dnf-command(config-manager)' && \
 		dnf config-manager --set-enabled crb && \
 		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-		dnf -y install git systemd \
-		autoconf libtool libcurl-devel openssl-devel \
-		gcc gcc-c++ make file systemd-devel zlib-devel rpm-build systemd-rpm-macros \
-		expect rpm-sign zip`,
+		dnf -y install systemd \
+		file systemd-devel rpm-build systemd-rpm-macros \
+		expect rpm-sign zip pkgconfig`,
 		package_build:     "RUN ./pkg/rpm/build.sh",
 		tar_distro_name:   "rockylinux-9",
 		package_extension: "rpm",
@@ -90,10 +88,9 @@ var dockerfileArguments = []templateArguments{
 		dnf -y install 'dnf-command(config-manager)' && \
 		dnf config-manager --set-enabled crb && \
 		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
-		dnf -y install git systemd \
-		autoconf libtool libcurl-devel openssl-devel \
-		gcc gcc-c++ make file systemd-devel zlib-devel rpm-build systemd-rpm-macros \
-		expect rpm-sign zip libzstd-devel`,
+		dnf -y install systemd \
+		file systemd-devel rpm-build systemd-rpm-macros \
+		expect rpm-sign zip pkgconfig`,
 		package_build:     "RUN ./pkg/rpm/build.sh",
 		tar_distro_name:   "rockylinux-10",
 		package_extension: "rpm",
@@ -102,9 +99,8 @@ var dockerfileArguments = []templateArguments{
 		from_image:  "debian:bookworm",
 		target_name: "bookworm",
 		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev \
 		devscripts cdbs pkg-config zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "debian-bookworm",
@@ -114,9 +110,8 @@ var dockerfileArguments = []templateArguments{
 		from_image:  "debian:bullseye",
 		target_name: "bullseye",
 		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev \
 		devscripts cdbs pkg-config zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "debian-bullseye",
@@ -126,9 +121,8 @@ var dockerfileArguments = []templateArguments{
 		from_image:  "debian:trixie",
 		target_name: "trixie",
 		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file systemd-dev libsystemd-dev \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file systemd-dev libsystemd-dev \
 		devscripts cdbs pkg-config zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "debian-trixie",
@@ -143,17 +137,13 @@ var dockerfileArguments = []templateArguments{
 		# The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
 		zypper --no-gpg-check refresh 'OSS Update' && \
 		(echo '6dd0b89202b19dae873434c5f2ba01164205071581fc02365712be801e304b3b /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
-		zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc8 gcc8-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip && \
+		zypper -n install systemd rpm-build expect systemd-devel systemd-rpm-macros unzip zip pkgconfig && \
 		# Remove expired root certificate.
 		mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
 		update-ca-certificates && \
 		zypper -n update && \
 		# Allow fluent-bit to find systemd
-		ln -fs /usr/lib/systemd /lib/systemd && \
-		# Set newer GCC as default with priority 1
-		update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1 \
-    		--slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
-		update-alternatives --set gcc /usr/bin/gcc-8`,
+		ln -fs /usr/lib/systemd /lib/systemd`,
 		package_build:     "RUN ./pkg/rpm/build.sh",
 		tar_distro_name:   "sles-12",
 		package_extension: "rpm",
@@ -163,7 +153,7 @@ var dockerfileArguments = []templateArguments{
 		target_name: "sles15",
 		install_packages: `RUN set -x; zypper -n refresh && \
 		zypper -n update && \
-		zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip
+		zypper -n install systemd rpm-build expect systemd-devel systemd-rpm-macros unzip zip pkgconfig
 # Allow fluent-bit to find systemd
 RUN ln -fs /usr/lib/systemd /lib/systemd`,
 		package_build:     "RUN ./pkg/rpm/build.sh",
@@ -175,7 +165,7 @@ RUN ln -fs /usr/lib/systemd /lib/systemd`,
 		target_name: "sles16",
 		install_packages: `RUN set -x; zypper -n refresh && \
 		zypper -n update && \
-		zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip
+		zypper -n install systemd rpm-build expect systemd-devel systemd-rpm-macros unzip zip pkgconfig
 # Allow fluent-bit to find systemd
 RUN ln -fs /usr/lib/systemd /lib/systemd`,
 		package_build:     "RUN ./pkg/rpm/build.sh",
@@ -186,9 +176,8 @@ RUN ln -fs /usr/lib/systemd /lib/systemd`,
 		from_image:  "ubuntu:jammy",
 		target_name: "jammy",
 		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev tzdata \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev tzdata \
 		devscripts cdbs pkg-config zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "ubuntu-jammy",
@@ -198,9 +187,8 @@ RUN ln -fs /usr/lib/systemd /lib/systemd`,
 		from_image:  "ubuntu:noble",
 		target_name: "noble",
 		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file libsystemd-dev tzdata \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file libsystemd-dev tzdata \
 		devscripts cdbs pkg-config zip debhelper`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "ubuntu-noble",
@@ -210,9 +198,8 @@ RUN ln -fs /usr/lib/systemd /lib/systemd`,
 		from_image:  "ubuntu:questing",
 		target_name: "questing",
 		install_packages: `RUN set -x; apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get -y install git systemd \
-		autoconf libtool libcurl4-openssl-dev libssl-dev \
-		build-essential file systemd-dev debhelper libsystemd-dev tzdata \
+		DEBIAN_FRONTEND=noninteractive apt-get -y install systemd \
+		file systemd-dev debhelper libsystemd-dev tzdata \
 		devscripts cdbs pkg-config zip`,
 		package_build:     "RUN ./pkg/deb/build.sh",
 		tar_distro_name:   "ubuntu-questing",

--- a/dockerfiles/template
+++ b/dockerfiles/template
@@ -8,29 +8,6 @@ FROM {from_image} AS {target_name}-build-base
 
 SHELL ["/bin/bash", "-c"]
 
-# Install golang
-ARG TARGETARCH
-ARG GO_VERSION
-ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
-RUN set -xe; \
-    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-
-FROM {target_name}-build-base AS {target_name}-build-otel
-WORKDIR /work
-# Download golang deps
-COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
-RUN cd submodules/opentelemetry-operations-collector && go mod download
-
-COPY ./submodules/opentelemetry-operations-collector submodules/opentelemetry-operations-collector
-COPY ./builds/otel.sh .
-RUN \
-    unset OTEL_TRACES_EXPORTER && \
-    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
-    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
-    ./otel.sh /work/cache/
-
 
 
 FROM {target_name}-build-base AS {target_name}-build-systemd
@@ -40,38 +17,25 @@ COPY ./builds/systemd.sh .
 RUN ./systemd.sh /work/cache/
 
 
-FROM {target_name}-build-base AS {target_name}-build-golang-base
-WORKDIR /work
-COPY go.mod go.sum ./
-# Fetch dependencies
-RUN go mod download
-COPY confgenerator confgenerator
-COPY apps apps
-COPY internal internal
 
 
-
-
-FROM {target_name}-build-golang-base AS {target_name}-build
+FROM {target_name}-build-base AS {target_name}-build
 WORKDIR /work
 COPY . /work
 
-# Run the build script once to build the ops agent engine to a cache
-RUN mkdir -p /tmp/cache_run/golang && cp -r . /tmp/cache_run/golang
-WORKDIR /tmp/cache_run/golang
-{package_build} &> /dev/null || true
-WORKDIR /work
+# Copy the pre-compiled Go binaries from the shared build stage
+COPY --from=go-build /work/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY --from=go-build /work/cache /work/cache
 
 COPY ./confgenerator/default-config.yaml /work/cache/etc/google-cloud-ops-agent/config.yaml
-COPY --from={target_name}-build-otel /work/cache /work/cache
 
 COPY --from={target_name}-build-systemd /work/cache /work/cache
 
 {package_build}
 
-COPY cmd/ops_agent_uap_plugin cmd/ops_agent_uap_plugin
-COPY ./builds/ops_agent_plugin.sh .
-RUN ./ops_agent_plugin.sh /work/cache/
+# Copy prebuilt plugin files to cache before packaging the plugin
+COPY --from=go-build /work/plugin-cache /work/cache
+
 RUN ./pkg/plugin/build.sh /work/cache {target_name}
 
 

--- a/dockerfiles/template-header
+++ b/dockerfiles/template-header
@@ -23,6 +23,7 @@
 ARG CMAKE_VERSION=3.25.2
 ARG GO_VERSION=1.25.0
 ARG USE_PREBUILT=false
+ARG TARGETARCH
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager
@@ -47,11 +48,11 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 # ======================================
-# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
+# Shared Go Binaries Build - Architecture Specific Bases
 # ======================================
-FROM opensuse/archive:42.3 AS go-false
 
-# Install compiler tools and dependencies on SLES 12
+# AMD64 Base (SLES 12)
+FROM opensuse/archive:42.3 AS go-builder-base-amd64
 RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
@@ -66,6 +67,19 @@ RUN set -x; \
         --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --set gcc /usr/bin/gcc-8
 
+# ARM64 Base (SLES 15)
+FROM opensuse/leap:15.1 AS go-builder-base-arm64
+RUN set -x; \
+    zypper -n refresh && \
+    zypper -n update && \
+    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip make curl
+
+# Selector
+ARG TARGETARCH
+FROM go-builder-base-${TARGETARCH} AS go-builder-base
+
+# Common Compile Stage
+FROM go-builder-base AS go-false
 SHELL ["/bin/bash", "-c"]
 
 # Install golang

--- a/dockerfiles/template-header
+++ b/dockerfiles/template-header
@@ -45,3 +45,66 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 
+# ======================================
+# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
+# ======================================
+FROM opensuse/archive:42.3 AS go-build
+
+# Install compiler tools and dependencies on SLES 12
+RUN set -x; \
+    # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
+    zypper --no-gpg-check refresh 'OSS Update' && \
+    (echo '6dd0b89202b19dae873434c5f2ba01164205071581fc02365712be801e304b3b /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) && \
+    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc8 gcc8-c++ zlib-devel expect systemd-devel unzip zip make curl && \
+    # Remove expired root certificate.
+    mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ && \
+    update-ca-certificates && \
+    zypper -n update && \
+    # Set newer GCC as default with priority 1
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
+    update-alternatives --set gcc /usr/bin/gcc-8
+
+SHELL ["/bin/bash", "-c"]
+
+# Install golang
+ARG TARGETARCH
+ARG GO_VERSION
+ADD https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz /tmp/go${GO_VERSION}.tar.gz
+RUN set -xe; \
+    tar -xf /tmp/go${GO_VERSION}.tar.gz -C /usr/local
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+WORKDIR /work
+
+# 1. Download dependencies for the main repository
+COPY go.mod go.sum ./
+RUN go mod download
+
+# 2. Download dependencies for the OTEL submodule
+COPY ./submodules/opentelemetry-operations-collector/go.mod ./submodules/opentelemetry-operations-collector/go.sum submodules/opentelemetry-operations-collector/
+RUN cd submodules/opentelemetry-operations-collector && go mod download
+
+# Copy full source code
+COPY . /work
+
+# 3. Build otelopscol (CGO enabled)
+RUN \
+    unset OTEL_TRACES_EXPORTER && \
+    unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT && \
+    unset OTEL_EXPORTER_OTLP_TRACES_PROTOCOL && \
+    ./builds/otel.sh /work/cache/
+
+# 4. Build ops-agent-engine (CGO disabled)
+RUN . VERSION && \
+    BUILD_INFO_IMPORT_PATH="github.com/GoogleCloudPlatform/ops-agent/internal/version" && \
+    BUILD_X1="-X ${BUILD_INFO_IMPORT_PATH}.BuildDistro=sles12" && \
+    BUILD_X2="-X ${BUILD_INFO_IMPORT_PATH}.Version=${PKG_VERSION}" && \
+    LD_FLAGS="-s -w ${BUILD_X1} ${BUILD_X2}" && \
+    CGO_ENABLED=0 go build -buildvcs=false -o "/work/google_cloud_ops_agent_engine" \
+      -ldflags "${LD_FLAGS}" \
+      github.com/GoogleCloudPlatform/ops-agent/cmd/google_cloud_ops_agent_engine
+
+# 5. Build ops_agent plugin helper (CGO disabled)
+RUN ./builds/ops_agent_plugin.sh /work/plugin-cache/
+

--- a/dockerfiles/template-header
+++ b/dockerfiles/template-header
@@ -22,6 +22,8 @@
 
 ARG CMAKE_VERSION=3.25.2
 ARG GO_VERSION=1.25.0
+ARG USE_PREBUILT=false
+ARG TARGETARCH
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager
@@ -46,11 +48,11 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 # ======================================
-# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
+# Shared Go Binaries Build - Architecture Specific Bases
 # ======================================
-FROM opensuse/archive:42.3 AS go-build
 
-# Install compiler tools and dependencies on SLES 12
+# AMD64 Base (SLES 12)
+FROM opensuse/archive:42.3 AS go-builder-base-amd64
 RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
@@ -65,6 +67,19 @@ RUN set -x; \
         --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --set gcc /usr/bin/gcc-8
 
+# ARM64 Base (SLES 15)
+FROM opensuse/leap:15.1 AS go-builder-base-arm64
+RUN set -x; \
+    zypper -n refresh && \
+    zypper -n update && \
+    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip make curl
+
+# Selector
+ARG TARGETARCH
+FROM go-builder-base-${TARGETARCH} AS go-builder-base
+
+# Common Compile Stage
+FROM go-builder-base AS go-false
 SHELL ["/bin/bash", "-c"]
 
 # Install golang
@@ -107,4 +122,23 @@ RUN . VERSION && \
 
 # 5. Build ops_agent plugin helper (CGO disabled)
 RUN ./builds/ops_agent_plugin.sh /work/plugin-cache/
+
+
+# Stage to export prebuilt binaries to host
+FROM scratch AS go-compile-export
+COPY --from=go-false /work/google_cloud_ops_agent_engine /google_cloud_ops_agent_engine
+COPY --from=go-false /work/cache /cache
+COPY --from=go-false /work/plugin-cache /plugin-cache
+
+
+# Stage to import prebuilt binaries from host
+FROM scratch AS go-true
+COPY ./built-binaries/google_cloud_ops_agent_engine /work/google_cloud_ops_agent_engine
+COPY ./built-binaries/cache /work/cache
+COPY ./built-binaries/plugin-cache /work/plugin-cache
+
+
+# Final builder selector
+FROM go-${USE_PREBUILT} AS go-build
+
 

--- a/dockerfiles/template-header
+++ b/dockerfiles/template-header
@@ -23,7 +23,6 @@
 ARG CMAKE_VERSION=3.25.2
 ARG GO_VERSION=1.25.0
 ARG USE_PREBUILT=false
-ARG TARGETARCH
 
 # Manually prepare a recent enough version of CMake.
 # This should be used on platforms where the default package manager
@@ -48,11 +47,11 @@ RUN set -xe; (echo "$hash  /cmake.sh" | sha256sum -c)
 
 
 # ======================================
-# Shared Go Binaries Build - Architecture Specific Bases
+# Shared Go Binaries Build (SLES 12 / GLIBC 2.22)
 # ======================================
+FROM opensuse/archive:42.3 AS go-false
 
-# AMD64 Base (SLES 12)
-FROM opensuse/archive:42.3 AS go-builder-base-amd64
+# Install compiler tools and dependencies on SLES 12
 RUN set -x; \
     # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
     zypper --no-gpg-check refresh 'OSS Update' && \
@@ -67,19 +66,6 @@ RUN set -x; \
         --slave /usr/bin/g++ g++ /usr/bin/g++-8 && \
     update-alternatives --set gcc /usr/bin/gcc-8
 
-# ARM64 Base (SLES 15)
-FROM opensuse/leap:15.1 AS go-builder-base-arm64
-RUN set -x; \
-    zypper -n refresh && \
-    zypper -n update && \
-    zypper -n install git systemd autoconf automake libtool libcurl-devel libopenssl-devel gcc gcc-c++ zlib-devel rpm-build expect systemd-devel systemd-rpm-macros unzip zip make curl
-
-# Selector
-ARG TARGETARCH
-FROM go-builder-base-${TARGETARCH} AS go-builder-base
-
-# Common Compile Stage
-FROM go-builder-base AS go-false
 SHELL ["/bin/bash", "-c"]
 
 # Install golang

--- a/kokoro/scripts/build/build_package.sh
+++ b/kokoro/scripts/build/build_package.sh
@@ -43,7 +43,10 @@ export_to_sponge_config "PACKAGE_VERSION" "${PKG_VERSION}"
 ARCH="$(docker info --format '{{.Architecture}}')"
 ARTIFACT_REGISTRY="us-docker.pkg.dev"
 docker-credential-gcr configure-docker --registries="${ARTIFACT_REGISTRY}"
-CACHE="${ARTIFACT_REGISTRY}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:${DISTRO}_${ARCH}"
+# TODO(b/522876997): Revert this shared cache tag hack before merging 3.0 to master.
+# We remove "${DISTRO}_" to share the identical `go-build` stage cache across
+# parallel distro build VMs, skipping Go compilation for all but the first job.
+CACHE="${ARTIFACT_REGISTRY}/stackdriver-test-143416/google-cloud-ops-agent-build-cache/ops-agent-cache:shared_3.0_${ARCH}"
 
 build_params=()
 if [[ -n "${KOKORO_GITHUB_PULL_REQUEST_NUMBER}" ]]; then  # Per-PR cache


### PR DESCRIPTION
## Description
Compiles otelopscol (CGO enabled), google_cloud_ops_agent_engine (CGO disabled), and ops_agent plugin (CGO disabled) once inside a shared SLES 12 builder stage. Subsequent distro-specific stages copy the pre-built binaries instead of installing Go and recompiling them.

This guarantees backwards compatibility with GLIBC >= 2.22 and speeds up the packaging build process across all Linux distributions.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
