### PR TITLE
fix(mssql): update expected label to performance_counter.object_name

### DIFF
--- a/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mssql/metadata.yaml
@@ -72,7 +72,7 @@ expected_metrics:
     kind: GAUGE
     monitored_resources: [gce_instance]
     labels:
-      - name: performance_counter_object_name
+      - name: performance_counter.object_name
         value_regex: .*
   - type: workload.googleapis.com/sqlserver.page.split.rate
     value_type: DOUBLE


### PR DESCRIPTION
## Description
This PR updates the integration test expectation for the Microsoft SQL Server v2 metrics.

Following the migration to the upstream OTLP exporter (otlp_grpc) and the removal of the legacy GCM exporter in [acc7bcc86](https://github.com/GoogleCloudPlatform/ops-agent/commit/acc7bcc861c2bea1e37870417f2838a9c8ff98c3), metrics are now ingested via the native OTLP endpoint.

Unlike the legacy exporter, which sanitized metric label keys by replacing dots with underscores, the OTLP ingestion path preserves dots. As a result, the sqlserver receiver's performance_counter.object_name label (defined in upstream sqlserverreceiver) is now ingested as-is with the dot.

Changes
Updated integration_test/third_party_apps_test/applications/mssql/metadata.yaml to expect performance_counter.object_name instead of performance_counter_object_name.
We are accepting this breaking change to align with upstream OpenTelemetry semantic conventions and GCM's native OTLP support.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
