### PR TITLE
fix(self-metrics): read otlpjsonfile from beginning on startup

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -286,6 +286,7 @@ func (r AgentSelfMetrics) OpsAgentPipeline(ctx context.Context) otel.ReceiverPip
 			filepath.Join(r.OtelRuntimeDir, "feature_tracking_otlp.json")},
 		"replay_file":   true,
 		"poll_interval": time.Duration(60 * time.Second).String(),
+		"start_at":      "beginning",
 	}
 	return otel.ReceiverPipeline{
 		Receiver: otel.Component{

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
@@ -890,6 +890,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
@@ -849,6 +849,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -859,6 +859,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -859,6 +859,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
@@ -945,6 +945,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
@@ -899,6 +899,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
@@ -868,6 +868,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -985,6 +985,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -939,6 +939,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -1371,6 +1371,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -1371,6 +1371,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
@@ -941,6 +941,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
@@ -895,6 +895,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -1327,6 +1327,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -1327,6 +1327,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
@@ -949,6 +949,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
@@ -1336,6 +1336,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
@@ -1336,6 +1336,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
@@ -956,6 +956,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
@@ -910,6 +910,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -1342,6 +1342,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -1342,6 +1342,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
@@ -956,6 +956,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
@@ -910,6 +910,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -1342,6 +1342,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -1342,6 +1342,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -956,6 +956,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
@@ -910,6 +910,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -1342,6 +1342,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -1342,6 +1342,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
@@ -937,6 +937,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
@@ -891,6 +891,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -1323,6 +1323,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -1323,6 +1323,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -1093,6 +1093,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -1047,6 +1047,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -1479,6 +1479,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -1479,6 +1479,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -1007,6 +1007,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -961,6 +961,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -1393,6 +1393,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -1393,6 +1393,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -809,6 +809,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
@@ -763,6 +763,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -877,6 +877,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -877,6 +877,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -1060,6 +1060,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
@@ -1014,6 +1014,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -1446,6 +1446,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
@@ -1446,6 +1446,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -1033,6 +1033,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -987,6 +987,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -1419,6 +1419,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -1419,6 +1419,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
@@ -948,6 +948,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -1007,6 +1007,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -961,6 +961,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -1393,6 +1393,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -1393,6 +1393,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -962,6 +962,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -916,6 +916,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -1472,6 +1472,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -1472,6 +1472,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -945,6 +945,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -899,6 +899,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -1331,6 +1331,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -1331,6 +1331,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
@@ -948,6 +948,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -1063,6 +1063,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -1017,6 +1017,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -1131,6 +1131,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -1131,6 +1131,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -969,6 +969,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
@@ -923,6 +923,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -1111,6 +1111,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -1225,6 +1225,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -1225,6 +1225,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -1060,6 +1060,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
@@ -1014,6 +1014,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -1446,6 +1446,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -1446,6 +1446,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -1011,6 +1011,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -965,6 +965,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -1397,6 +1397,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -1397,6 +1397,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -1028,6 +1028,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
@@ -982,6 +982,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -1414,6 +1414,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -1414,6 +1414,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -1176,6 +1176,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -1130,6 +1130,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -1562,6 +1562,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -1562,6 +1562,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -1281,6 +1281,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -1235,6 +1235,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -1349,6 +1349,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -1349,6 +1349,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -962,6 +962,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -916,6 +916,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -1472,6 +1472,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -1472,6 +1472,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
@@ -1086,6 +1086,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
@@ -1040,6 +1040,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -1472,6 +1472,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -1472,6 +1472,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -945,6 +945,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -899,6 +899,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -1331,6 +1331,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -1331,6 +1331,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -1140,6 +1140,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -1572,6 +1572,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -1572,6 +1572,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
@@ -948,6 +948,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
@@ -996,6 +996,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
@@ -950,6 +950,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -1382,6 +1382,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -1382,6 +1382,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
@@ -996,6 +996,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
@@ -950,6 +950,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -1382,6 +1382,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -1382,6 +1382,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -948,6 +948,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -1334,6 +1334,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -1063,6 +1063,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -1017,6 +1017,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -1131,6 +1131,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -1131,6 +1131,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -969,6 +969,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
@@ -923,6 +923,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
@@ -859,6 +859,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
@@ -859,6 +859,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -1301,6 +1301,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -1301,6 +1301,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
@@ -904,6 +904,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
@@ -856,6 +856,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -1292,6 +1292,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -1292,6 +1292,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
@@ -904,6 +904,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
@@ -856,6 +856,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -1292,6 +1292,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -1292,6 +1292,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
@@ -937,6 +937,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
@@ -889,6 +889,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -1325,6 +1325,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -1325,6 +1325,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
@@ -926,6 +926,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
@@ -867,6 +867,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
@@ -1195,6 +1195,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
@@ -1195,6 +1195,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
@@ -914,6 +914,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
@@ -861,6 +861,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
@@ -1189,6 +1189,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
@@ -1189,6 +1189,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
@@ -890,6 +890,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
@@ -849,6 +849,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
@@ -1177,6 +1177,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
@@ -1177,6 +1177,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
@@ -900,6 +900,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
@@ -1019,6 +1019,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
@@ -973,6 +973,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
@@ -964,6 +964,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
@@ -918,6 +918,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
@@ -924,6 +924,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
@@ -878,6 +878,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -1271,6 +1271,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -1271,6 +1271,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -1286,6 +1286,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -1493,6 +1493,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -1493,6 +1493,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -1805,6 +1805,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -1805,6 +1805,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -1442,6 +1442,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -1442,6 +1442,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -1410,6 +1410,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -1410,6 +1410,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -1459,6 +1459,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -1459,6 +1459,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
@@ -902,6 +902,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
@@ -855,6 +855,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -1289,6 +1289,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -1271,6 +1271,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -1271,6 +1271,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -1330,6 +1330,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -1330,6 +1330,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -1272,6 +1272,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -1272,6 +1272,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -1314,6 +1314,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -1314,6 +1314,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -1278,6 +1278,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -1278,6 +1278,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -1805,6 +1805,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -1805,6 +1805,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -1410,6 +1410,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -1410,6 +1410,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:


### PR DESCRIPTION
## Description
This PR resolves a flakiness issue in integration tests (specifically observed in TestDefaultMetricsNoProxy) where the agent.googleapis.com/agent/ops_agent/enabled_receivers metric was missing the expected receiver_type and telemetry_type labels.

Root Cause
The otlpjsonfile receiver, which collects the agent's self-metrics, defaults to reading from the end of the file (start_at: end) upon startup. Due to the frequent agent restarts in integration tests, combined with replay_file: true (which uses a stateless tracker that doesn't persist offsets across restarts), the receiver repeatedly started reading from EOF. If the test finished or checked metrics before the next poll interval without new writes, the metrics written just before the restart were missed.

Fix
We now explicitly set "start_at": "beginning" in the otlpjsonfile receiver configuration within 
confgenerator/agentmetrics.go
. This guarantees that the receiver reads the metrics file from the beginning upon startup, ensuring metric continuity across restarts.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
