### PR TITLE
Fix Rocky Linux 9 GPU driver installation in third-party app tests

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
@@ -57,8 +57,8 @@ EOF
     fi
 
     # Installing latest version of NVIDIA CUDA and driver
-    local CUDA_VERSION=12.9.0
-    local CUDA_BUNDLED_DRIVER_VERSION=575.51.03
+    local CUDA_VERSION=13.0.0
+    local CUDA_BUNDLED_DRIVER_VERSION=580.65.06
     echo "Installing CUDA Toolkit $CUDA_VERSION from CUDA installer with bundled driver $CUDA_BUNDLED_DRIVER_VERSION"
     curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
     sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --silent
@@ -85,7 +85,7 @@ install_cuda_from_package_manager() {
     fi
     install_driver_package
     # TODO(b/377558109): remove the temporary fix once the repo is updated
-    sudo yum -y install cuda-toolkit-12-9 cuda-demo*
+    sudo yum -y install cuda-toolkit-13-0 cuda-demo*
     verify_driver
 }
 
@@ -124,8 +124,8 @@ try_install() {
 
 handle_rhel9() {
     install_driver_package() {
-        # Ref: https://developer.nvidia.com/cuda-12-9-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-        sudo yum -y module install nvidia-driver:575-dkms
+        # Ref: https://developer.nvidia.com/cuda-13-0-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=9&target_type=rpm_network
+        sudo yum -y module install nvidia-driver:580-dkms
     }
 }
 

--- a/integration_test/third_party_apps_test/applications/dcgmv1/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgmv1/centos_rhel/install
@@ -57,8 +57,8 @@ EOF
     fi
 
     # Installing latest version of NVIDIA CUDA and driver
-    local CUDA_VERSION=12.9.0
-    local CUDA_BUNDLED_DRIVER_VERSION=575.51.03
+    local CUDA_VERSION=13.0.0
+    local CUDA_BUNDLED_DRIVER_VERSION=580.65.06
     echo "Installing CUDA Toolkit $CUDA_VERSION from CUDA installer with bundled driver $CUDA_BUNDLED_DRIVER_VERSION"
     curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
     sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --silent
@@ -85,7 +85,7 @@ install_cuda_from_package_manager() {
     fi
     install_driver_package
     # TODO(b/377558109): remove the temporary fix once the repo is updated
-    sudo yum -y install cuda-toolkit-12-9 cuda-demo*
+    sudo yum -y install cuda-toolkit-13-0 cuda-demo*
     verify_driver
 }
 
@@ -124,8 +124,8 @@ try_install() {
 
 handle_rhel9() {
     install_driver_package() {
-        # Ref: https://developer.nvidia.com/cuda-12-9-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-        sudo yum -y module install nvidia-driver:575-dkms
+        # Ref: https://developer.nvidia.com/cuda-13-0-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=9&target_type=rpm_network
+        sudo yum -y module install nvidia-driver:580-dkms
     }
 }
 

--- a/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
@@ -57,8 +57,8 @@ EOF
     fi
 
     # Installing latest version of NVIDIA CUDA and driver
-    local CUDA_VERSION=12.9.0
-    local CUDA_BUNDLED_DRIVER_VERSION=575.51.03
+    local CUDA_VERSION=13.0.0
+    local CUDA_BUNDLED_DRIVER_VERSION=580.65.06
     echo "Installing CUDA Toolkit $CUDA_VERSION from CUDA installer with bundled driver $CUDA_BUNDLED_DRIVER_VERSION"
     curl -fSsl -O https://developer.download.nvidia.com/compute/cuda/$CUDA_VERSION/local_installers/cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run
     sudo sh cuda_${CUDA_VERSION}_${CUDA_BUNDLED_DRIVER_VERSION}_linux.run --silent
@@ -85,7 +85,7 @@ install_cuda_from_package_manager() {
     fi
     install_driver_package
     # TODO(b/377558109): remove the temporary fix once the repo is updated
-    sudo yum -y install cuda-toolkit-12-9 cuda-demo*
+    sudo yum -y install cuda-toolkit-13-0 cuda-demo*
     verify_driver
 }
 
@@ -114,8 +114,8 @@ try_install() {
 
 handle_rhel9() {
     install_driver_package() {
-        # Ref: https://developer.nvidia.com/cuda-12-9-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=8&target_type=rpm_network
-        sudo yum -y module install nvidia-driver:575-dkms
+        # Ref: https://developer.nvidia.com/cuda-13-0-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=RHEL&target_version=9&target_type=rpm_network
+        sudo yum -y module install nvidia-driver:580-dkms
     }
 }
 


### PR DESCRIPTION
## Description
This PR fixes the GPU driver installation failure in third-party app integration tests (`dcgm`, `dcgmv1`, `nvml`) on Rocky Linux 9.

### Root Cause
The `rocky-linux-9` GCE image family was recently updated (v20260615) to a version using the `5.14.0-687` kernel (Rocky Linux 9.8). The previously pinned NVIDIA driver version (`575.57.08`) failed to compile (via DKMS) on this newer kernel, causing VM initialization to fail.

### Changes
*   **Package Manager:** Updated the NVIDIA driver module stream from `nvidia-driver:575-dkms` to `nvidia-driver:580-dkms` and the CUDA toolkit package from `cuda-toolkit-12-9` to `cuda-toolkit-13-0` for Rocky Linux 9.
*   **Runfile Fallback:** Updated the fallback CUDA runfile installer version from `12.9.0` (bundled driver `575.51.03`) to `13.0.0` (bundled driver `580.65.06`) to match the driver upgrade.
These updates ensure compatibility with the `5.14.0-687` kernel.

## Related issue
b/524667677

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
