### PR TITLE
Fix flaky VM deletion in integration tests by passing context to cleanup helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	buf.build/go/protoyaml v0.3.1
 	cloud.google.com/go/secretmanager v1.15.0
 	github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616195607-176df2c2a3d2
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616202525-aa63d8025d4e
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0
 	go.opentelemetry.io/collector/pdata v1.48.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	buf.build/go/protoyaml v0.3.1
 	cloud.google.com/go/secretmanager v1.15.0
 	github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260615151131-57f5ab772433
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616195607-176df2c2a3d2
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0
 	go.opentelemetry.io/collector/pdata v1.48.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	buf.build/go/protoyaml v0.3.1
 	cloud.google.com/go/secretmanager v1.15.0
 	github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616202525-aa63d8025d4e
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260617143844-26502c3aa0b0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0
 	go.opentelemetry.io/collector/pdata v1.48.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1v
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228 h1:K6GHKAI+PB91Fm+KEwX4q6s6xzZ/+BkOi8Kjxh0tJ6U=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228/go.mod h1:31SvkAl6ORtir1odRpTl92XpTtn52GnBAHPtCKDSePo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616195607-176df2c2a3d2 h1:eIl+wVRqcbBcjEJnLQIlj077JnALcDP9RuLgcZa25YQ=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616195607-176df2c2a3d2/go.mod h1:lBIIyBYHEqRFlp4lZM6puNw8mnJx71Ax4ldTgAVoL8A=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616202525-aa63d8025d4e h1:xa8fTPEw6gRnRxVyECFQGcHyq4o5uOAELA/afAVFXH0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616202525-aa63d8025d4e/go.mod h1:lBIIyBYHEqRFlp4lZM6puNw8mnJx71Ax4ldTgAVoL8A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 h1:owcC2UnmsZycprQ5RfRgjydWhuoxg71LUfyiQdijZuM=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1v
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228 h1:K6GHKAI+PB91Fm+KEwX4q6s6xzZ/+BkOi8Kjxh0tJ6U=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228/go.mod h1:31SvkAl6ORtir1odRpTl92XpTtn52GnBAHPtCKDSePo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616202525-aa63d8025d4e h1:xa8fTPEw6gRnRxVyECFQGcHyq4o5uOAELA/afAVFXH0=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616202525-aa63d8025d4e/go.mod h1:lBIIyBYHEqRFlp4lZM6puNw8mnJx71Ax4ldTgAVoL8A=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260617143844-26502c3aa0b0 h1:b6fgjC3dAqmYmzZ5EoV6H+98qVdf6bwAfSX1ssBdNwk=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260617143844-26502c3aa0b0/go.mod h1:lBIIyBYHEqRFlp4lZM6puNw8mnJx71Ax4ldTgAVoL8A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 h1:owcC2UnmsZycprQ5RfRgjydWhuoxg71LUfyiQdijZuM=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1v
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228 h1:K6GHKAI+PB91Fm+KEwX4q6s6xzZ/+BkOi8Kjxh0tJ6U=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228/go.mod h1:31SvkAl6ORtir1odRpTl92XpTtn52GnBAHPtCKDSePo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260615151131-57f5ab772433 h1:wgxSQUsExUxeqNchhB/TobuyV1/Cc7tuWdM2CnLtcW0=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260615151131-57f5ab772433/go.mod h1:lBIIyBYHEqRFlp4lZM6puNw8mnJx71Ax4ldTgAVoL8A=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616195607-176df2c2a3d2 h1:eIl+wVRqcbBcjEJnLQIlj077JnALcDP9RuLgcZa25YQ=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260616195607-176df2c2a3d2/go.mod h1:lBIIyBYHEqRFlp4lZM6puNw8mnJx71Ax4ldTgAVoL8A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 h1:owcC2UnmsZycprQ5RfRgjydWhuoxg71LUfyiQdijZuM=

--- a/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
@@ -1,6 +1,7 @@
 set -e
 source /etc/os-release
 MAJOR_VERSION_ID=${VERSION_ID%%.*}
+sudo yum install -y git make gcc gcc-c++
 
 verify_driver() {
     # Verify NVIDIA driver:
@@ -39,7 +40,7 @@ metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 EOF
     fi
-    sudo yum install -y pciutils gcc make wget yum-utils
+    sudo yum install -y pciutils wget yum-utils
     local KERNEL_PACKAGE="kernel-devel-$(uname -r)"
     if [[ $ID == rocky && "$MAJOR_VERSION_ID" == 9 && "$STATUS_CODE" == "403" ]]; then
       wget https://dl.rockylinux.org/vault/rocky/$VERSION_ID/AppStream/x86_64/os/Packages/k/${KERNEL_PACKAGE}.rpm

--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -2,6 +2,7 @@ set -e
 source /etc/os-release
 
 sudo apt update
+sudo apt install -y build-essential git
 KERNEL_VERSION=`uname -r`
 sudo apt install -y wget
 
@@ -50,7 +51,7 @@ else
         wget "$BASE_URL/$PKG_COMMON" "$BASE_URL/$PKG_ARCH" "$BASE_URL/$PKG_KBUILD" "$BASE_URL/$PKG_COMPILER"
         sudo apt-get install -y "./$PKG_COMMON" "./$PKG_ARCH" "./$PKG_KBUILD" "./$PKG_COMPILER"
     fi
-    sudo apt install -y software-properties-common pciutils gcc make dkms git
+    sudo apt install -y software-properties-common pciutils dkms
 
     # Install CUDA and driver the same way as the nvml app
     # Prefer to install from the package manager since it is normally faster and has

--- a/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
@@ -1,6 +1,7 @@
 set -e
 source /etc/os-release
 MAJOR_VERSION_ID=${VERSION_ID%%.*}
+sudo yum install -y git make gcc gcc-c++
 
 verify_driver() {
     # Verify NVIDIA driver:
@@ -39,7 +40,7 @@ metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 EOF
     fi
-    sudo yum install -y pciutils gcc make wget yum-utils
+    sudo yum install -y pciutils wget yum-utils
     local KERNEL_PACKAGE="kernel-devel-$(uname -r)"
     if [[ $ID == rocky && "$MAJOR_VERSION_ID" == 9 && "$STATUS_CODE" == "403" ]]; then
       wget https://dl.rockylinux.org/vault/rocky/$VERSION_ID/AppStream/x86_64/os/Packages/k/${KERNEL_PACKAGE}.rpm

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -1,6 +1,9 @@
 set -e
 source /etc/os-release
 
+sudo apt update
+sudo apt install -y build-essential git
+
 # Check if need to install the driver - Ubuntu DLVM has CUDA/driver pre-installed 
 if command -v nvidia-smi > /dev/null 2>&1; then
     echo "NVIDIA driver already installed. Skipping..."
@@ -8,7 +11,7 @@ if command -v nvidia-smi > /dev/null 2>&1; then
     exit 0
 fi
 
-sudo apt update
+
 KERNEL_VERSION=`uname -r`
 sudo apt install -y wget
 
@@ -49,7 +52,7 @@ else
     wget "$BASE_URL/$PKG_COMMON" "$BASE_URL/$PKG_ARCH" "$BASE_URL/$PKG_KBUILD" "$BASE_URL/$PKG_COMPILER"
     sudo apt-get install -y "./$PKG_COMMON" "./$PKG_ARCH" "./$PKG_KBUILD" "./$PKG_COMPILER"
 fi
-sudo apt install -y software-properties-common pciutils gcc make dkms git
+sudo apt install -y software-properties-common pciutils dkms
 
 # Install CUDA and driver together, since the `exercise` script needs to run a
 # CUDA sample app to generating GPU process metrics

--- a/integration_test/third_party_apps_test/main_test.go
+++ b/integration_test/third_party_apps_test/main_test.go
@@ -1109,7 +1109,7 @@ func TestThirdPartyApps(t *testing.T) {
 					// won't be deleted until the end of t.Run(), (SetupVM() registers it for cleanup
 					// at the end of t.Run()), so to avoid accumulating too many idle VMs while we
 					// do our retries, we preemptively delete the VM now.
-					if deleteErr := gce.DeleteInstance(logger.ToMainLog(), vm); deleteErr != nil {
+					if deleteErr := gce.DeleteInstance(ctx, logger.ToMainLog(), vm); deleteErr != nil {
 						t.Errorf("Deleting VM %v failed: %v", vm.Name, deleteErr)
 					}
 				}


### PR DESCRIPTION
## Description
This PR addresses the flaky VM deletion failures in integration tests by updating callers to pass the test context to GCE deletion helpers, enabling configuration isolation.

It depends on the submodule changes in opentelemetry-operations-collector (which add context support to DeleteInstance).

## Related issue
b/524713087

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
