### PR TITLE
Install git and build tools for DCGM/NVML tests

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/centos_rhel/install
@@ -1,6 +1,7 @@
 set -e
 source /etc/os-release
 MAJOR_VERSION_ID=${VERSION_ID%%.*}
+sudo yum install -y git make gcc gcc-c++
 
 verify_driver() {
     # Verify NVIDIA driver:
@@ -39,7 +40,7 @@ metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 EOF
     fi
-    sudo yum install -y pciutils gcc make wget yum-utils
+    sudo yum install -y pciutils wget yum-utils
     local KERNEL_PACKAGE="kernel-devel-$(uname -r)"
     if [[ $ID == rocky && "$MAJOR_VERSION_ID" == 9 && "$STATUS_CODE" == "403" ]]; then
       wget https://dl.rockylinux.org/vault/rocky/$VERSION_ID/AppStream/x86_64/os/Packages/k/${KERNEL_PACKAGE}.rpm

--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -2,6 +2,7 @@ set -e
 source /etc/os-release
 
 sudo apt update
+sudo apt install -y build-essential git
 KERNEL_VERSION=`uname -r`
 sudo apt install -y wget
 
@@ -50,7 +51,7 @@ else
         wget "$BASE_URL/$PKG_COMMON" "$BASE_URL/$PKG_ARCH" "$BASE_URL/$PKG_KBUILD" "$BASE_URL/$PKG_COMPILER"
         sudo apt-get install -y "./$PKG_COMMON" "./$PKG_ARCH" "./$PKG_KBUILD" "./$PKG_COMPILER"
     fi
-    sudo apt install -y software-properties-common pciutils gcc make dkms git
+    sudo apt install -y software-properties-common pciutils dkms
 
     # Install CUDA and driver the same way as the nvml app
     # Prefer to install from the package manager since it is normally faster and has

--- a/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
+++ b/integration_test/third_party_apps_test/applications/nvml/centos_rhel/install
@@ -1,6 +1,7 @@
 set -e
 source /etc/os-release
 MAJOR_VERSION_ID=${VERSION_ID%%.*}
+sudo yum install -y git make gcc gcc-c++
 
 verify_driver() {
     # Verify NVIDIA driver:
@@ -39,7 +40,7 @@ metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
 EOF
     fi
-    sudo yum install -y pciutils gcc make wget yum-utils
+    sudo yum install -y pciutils wget yum-utils
     local KERNEL_PACKAGE="kernel-devel-$(uname -r)"
     if [[ $ID == rocky && "$MAJOR_VERSION_ID" == 9 && "$STATUS_CODE" == "403" ]]; then
       wget https://dl.rockylinux.org/vault/rocky/$VERSION_ID/AppStream/x86_64/os/Packages/k/${KERNEL_PACKAGE}.rpm

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -1,6 +1,9 @@
 set -e
 source /etc/os-release
 
+sudo apt update
+sudo apt install -y build-essential git
+
 # Check if need to install the driver - Ubuntu DLVM has CUDA/driver pre-installed 
 if command -v nvidia-smi > /dev/null 2>&1; then
     echo "NVIDIA driver already installed. Skipping..."
@@ -8,7 +11,7 @@ if command -v nvidia-smi > /dev/null 2>&1; then
     exit 0
 fi
 
-sudo apt update
+
 KERNEL_VERSION=`uname -r`
 sudo apt install -y wget
 
@@ -49,7 +52,7 @@ else
     wget "$BASE_URL/$PKG_COMMON" "$BASE_URL/$PKG_ARCH" "$BASE_URL/$PKG_KBUILD" "$BASE_URL/$PKG_COMPILER"
     sudo apt-get install -y "./$PKG_COMMON" "./$PKG_ARCH" "./$PKG_KBUILD" "./$PKG_COMPILER"
 fi
-sudo apt install -y software-properties-common pciutils gcc make dkms git
+sudo apt install -y software-properties-common pciutils dkms
 
 # Install CUDA and driver together, since the `exercise` script needs to run a
 # CUDA sample app to generating GPU process metrics


### PR DESCRIPTION
## Description
* The Problem: The setup script was skipping the entire driver installation block if it detected that NVIDIA drivers were already installed. However, the installation of development dependencies (git, make, gcc, g++) was bundled inside that skipped block.
* The Trigger: For CUDA 13+ environments, the test's exercise script fell back to compiling gpu-burn from source (since pre-compiled demos are no longer available). This fallback path failed with git: command not found because git and build tools were never installed.
* The Solution: We decoupled the installation of the test dependencies (git and compiler tools) from the driver installation logic, ensuring they are always installed on the VM regardless of whether the driver was pre-installed.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
