### PR TITLE
Fix Windows E2E runner OOM flakes by capping parallelism to 100

### DIFF
--- a/kokoro/config/test/ops_agent/presubmit/windows_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/windows_x86_64.gcl
@@ -5,6 +5,7 @@ config build = common.ops_agent_test {
     environment {
       TARGET = 'windows'
       ARCH = 'x86_64'
+      TEST_PARALLEL = '30'
     }
   }
 }

--- a/kokoro/config/test/ops_agent/presubmit/windows_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/windows_x86_64.gcl
@@ -5,7 +5,7 @@ config build = common.ops_agent_test {
     environment {
       TARGET = 'windows'
       ARCH = 'x86_64'
-      TEST_PARALLEL = '30'
+      TEST_PARALLEL = '100'
     }
   }
 }

--- a/kokoro/config/test/ops_agent/presubmit/windows_x86_64_uap_plugin.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/windows_x86_64_uap_plugin.gcl
@@ -6,7 +6,7 @@ config build = common.ops_agent_test {
       TARGET = 'windows'
       ARCH = 'x86_64'
       IS_OPS_AGENT_UAP_PLUGIN = 'true'
-      TEST_PARALLEL = '30'
+      TEST_PARALLEL = '100'
     }
   }
 }

--- a/kokoro/config/test/ops_agent/presubmit/windows_x86_64_uap_plugin.gcl
+++ b/kokoro/config/test/ops_agent/presubmit/windows_x86_64_uap_plugin.gcl
@@ -6,6 +6,7 @@ config build = common.ops_agent_test {
       TARGET = 'windows'
       ARCH = 'x86_64'
       IS_OPS_AGENT_UAP_PLUGIN = 'true'
+      TEST_PARALLEL = '30'
     }
   }
 }

--- a/kokoro/config/test/ops_agent/release/windows_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/windows_x86_64.gcl
@@ -5,6 +5,7 @@ config build = common.ops_agent_test {
     environment {
       TARGET = 'windows'
       ARCH = 'x86_64'
+      TEST_PARALLEL = '30'
     }
   }
 }

--- a/kokoro/config/test/ops_agent/release/windows_x86_64.gcl
+++ b/kokoro/config/test/ops_agent/release/windows_x86_64.gcl
@@ -5,7 +5,7 @@ config build = common.ops_agent_test {
     environment {
       TARGET = 'windows'
       ARCH = 'x86_64'
-      TEST_PARALLEL = '30'
+      TEST_PARALLEL = '100'
     }
   }
 }

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -204,7 +204,7 @@ fi
 
 # Set up some command line flags for "go test".
 go_test_args=(
-  -test.parallel=1000
+  -test.parallel="${TEST_PARALLEL:-1000}"
   -tags=integration_test
   -timeout=3h
 )


### PR DESCRIPTION
## Description
We parametrize the E2E test parallelism in go_test.sh, keeping the default at 1000 to preserve Linux build speed. We then surgically cap the parallelism at 100 in all Windows GCL configurations (release, presubmit, and UAP plugin) to prevent the runner from OOMing and hitting GCE project quotas.

## Related issue
b/526572049

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
