### PR TITLE
Cap global integration test parallelism to 150 to prevent runner OOMs

### DIFF
--- a/kokoro/config/test/common.gcl
+++ b/kokoro/config/test/common.gcl
@@ -40,6 +40,10 @@ template config go_test = common {
       // Using the internal IP address also avoids issues with the firewall.
       USE_INTERNAL_IP = 'true'
 
+      // Cap integration test parallelism to prevent runner memory exhaustion (OOM)
+      // and regional GCE quota exhaustion.
+      TEST_PARALLEL = '150'
+
       // TRANSFERS_BUCKET and SERVICE_EMAIL are always modified as a pair.
       // when the build is running trusted (reviewed) code, it's OK to set
       // this to 'stackdriver-test-143416-file-transfers' and use

--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -204,7 +204,7 @@ fi
 
 # Set up some command line flags for "go test".
 go_test_args=(
-  -test.parallel="${TEST_PARALLEL:-1000}"
+  -test.parallel="${TEST_PARALLEL:-150}"
   -tags=integration_test
   -timeout=3h
 )


### PR DESCRIPTION
## Description
This PR defines a global, safe default of 150 for TEST_PARALLEL inside the base go_test template in kokoro/config/test/common.gcl.

This change globally stabilizes the entire 21-distribution E2E integration test pipeline against runner memory exhaustion (OOM) while simultaneously delivering a performance speedup by eliminating GCE VM boot storms and hypervisor resource contention.

## Related issue
b/526572049

## How has this been tested?

rockylinux10/x86_64	1 hour, 9 minutes	19 minutes, 50 seconds	⚡ -49m 10s (-71.3%) — SAVED 50 MINS!
ubuntu2404/x86_64	33 minutes, 53 seconds	23 minutes, 6 seconds	⚡ -10m 47s (-31.8%) — SAVED 11 MINS!
sles12/x86_64	31 minutes, 50 seconds	26 minutes, 9 seconds	⚡ -5m 41s (-17.9%) — SAVED 6 MINS!
debian12/x86_64	21 minutes, 20 seconds	18 minutes, 52 seconds	⚡ -2m 28s (-11.6%) — SAVED 2.5 MINS!
debian13/x86_64	20 minutes, 0 seconds	18 minutes, 45 seconds	-1m 15s (-6.2%)
debian11/x86_64	18 minutes, 38 seconds	18 minutes, 25 seconds	-0m 13s (-1.2%)
ubuntu2204/x86_64	26 minutes, 29 seconds	27 minutes, 4 seconds	+0m 35s (+2.2%) — (Virtually identical)


## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
