### PR TITLE
test: port integration test flakiness fixes from ops_agent_3.0 to master

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -792,6 +792,24 @@ func windowsEnvironment(environment map[string]string) string {
 	return toEnvironment(environment, `$env:%s='%s'`, "\n")
 }
 
+func disableBrokenRepos(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
+	logger.Println("Attempting to disable known broken third-party repositories...")
+	// We disable 'ciq-sigcloud-next' on Rocky Linux/RHEL VMs because depot.ciq.com
+	// frequently times out, causing package manager commands (yum/dnf) to fail.
+	// This is a systemic external infrastructure flake.
+	disableCmd := `
+if command -v dnf &>/dev/null; then
+  sudo dnf config-manager --set-disabled ciq-sigcloud-next || true
+  if [ -f /etc/yum.repos.d/ciq-sigcloud-next.repo ]; then
+    sudo sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/ciq-sigcloud-next.repo || true
+  fi
+  sudo sed -i '/\[ciq-sigcloud-next\]/,/^\[/ s/enabled=1/enabled=0/' /etc/yum.repos.d/*.repo 2>/dev/null || true
+fi
+`
+	_, err := gce.RunRemotely(ctx, logger, vm, disableCmd)
+	return err
+}
+
 // InstallOpsAgent installs the Ops Agent on the given VM. Consults the given
 // PackageLocation to determine where to install the agent from. For details
 // about PackageLocation, see the documentation for the PackageLocation struct.
@@ -802,6 +820,12 @@ func InstallOpsAgent(ctx context.Context, logger *log.Logger, vm *gce.VM, locati
 
 	if location.artifactRegistryRegion != "" && location.repoSuffix == "" {
 		return fmt.Errorf("invalid PackageLocation: location.artifactRegistryRegion was nonempty yet location.repoSuffix was empty. location=%#v", location)
+	}
+
+	if !gce.IsWindows(vm.ImageSpec) {
+		if err := disableBrokenRepos(ctx, logger, vm); err != nil {
+			logger.Printf("Warning: failed to disable broken repos (continuing anyway): %v", err)
+		}
 	}
 
 	if gce.IsOpsAgentUAPPlugin() {

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5995,13 +5995,29 @@ func TestAppHubLogLabels(t *testing.T) {
 			"--uri",
 		}
 
-		output, err := gce.RunGcloud(ctx, logger, "", discoverMIGWorkloadArgs)
+		var migResourceString string
+
+		// AppHub discovery is asynchronous and can take several minutes. Retry for up to 3 minutes.
+		discoveryCtx, discoveryCancel := context.WithTimeout(ctx, 3*time.Minute)
+		defer discoveryCancel()
+
+		err := backoff.Retry(func() error {
+			out, err := gce.RunGcloud(discoveryCtx, logger, "", discoverMIGWorkloadArgs)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(out.Stdout) == "" {
+				return fmt.Errorf("discovered workload for %s not found yet", migVM.ManagedInstanceGroupName())
+			}
+			migResourceString = strings.Replace(strings.TrimSpace(out.Stdout), "https://apphub.googleapis.com/v1/", "", 1)
+			return nil
+		}, backoff.WithContext(backoff.NewConstantBackOff(15*time.Second), discoveryCtx))
+
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("Failed to discover AppHub workload: %v", err)
 		}
 
 		// Setup Apphub #2 : Register Managed Instance Group as AppHub workload.
-		migResourceString := strings.Replace(output.Stdout, "https://apphub.googleapis.com/v1/", "", 1)
 		registerAppHubWorkloadArgs := []string{
 			"apphub", "applications", "workloads", "create", migVM.AppHubWorkloadName(),
 			"--application=" + AppHubIntegrationTestApp,
@@ -6011,8 +6027,7 @@ func TestAppHubLogLabels(t *testing.T) {
 			"--format=json",
 		}
 
-		output, err = gce.RunGcloud(ctx, logger, "", registerAppHubWorkloadArgs)
-		if err != nil {
+		if _, err := gce.RunGcloud(ctx, logger, "", registerAppHubWorkloadArgs); err != nil {
 			t.Fatal(err)
 		}
 
@@ -6029,8 +6044,7 @@ func TestAppHubLogLabels(t *testing.T) {
 				"--format=json",
 			}
 
-			output, err = gce.RunGcloud(ctx, logger, "", deleteAppHubWorkloadArgs)
-			if err != nil {
+			if _, err := gce.RunGcloud(ctx, logger, "", deleteAppHubWorkloadArgs); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5425,6 +5425,34 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 	})
 }
 
+func waitForNetworkBlock(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
+	logger.Println("Waiting for network block to propagate...")
+	checkCmd := "curl -s -m 5 https://telemetry.googleapis.com > /dev/null"
+	if gce.IsWindows(vm.ImageSpec) {
+		checkCmd = "if ((Test-NetConnection telemetry.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded) { exit 0 } else { exit 1 }"
+	}
+
+	timeout := time.After(5 * time.Minute)
+	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for network block to propagate")
+		case <-tick.C:
+			_, err := gce.RunRemotely(ctx, logger, vm, checkCmd)
+			if err != nil {
+				logger.Printf("Network check failed as expected (network block propagated): %v", err)
+				return nil
+			}
+			logger.Println("Network check still succeeded, waiting...")
+		}
+	}
+}
+
 func TestNetworkHealthCheck(t *testing.T) {
 	t.Parallel()
 	RunForEachImageAndFeatureFlag(t, []string{OtelLoggingOTLPExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
@@ -5456,7 +5484,9 @@ func TestNetworkHealthCheck(t *testing.T) {
 		if _, err := gce.AddTagToVm(ctx, logger, vm, []string{gce.DenyEgressTrafficTag}); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(2 * time.Minute)
+		if err := waitForNetworkBlock(ctx, logger, vm); err != nil {
+			t.Fatal(err)
+		}
 
 		if _, err := gce.RunRemotely(ctx, logger, vm, agents.StartCommandForImage(vm.ImageSpec)); err != nil {
 			t.Fatal(err)

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -71,6 +71,7 @@ import (
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/agents"
 	feature_tracking_metadata "github.com/GoogleCloudPlatform/ops-agent/integration_test/feature_tracking"
 	"github.com/GoogleCloudPlatform/ops-agent/integration_test/metadata"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"go.uber.org/multierr"
 	"google.golang.org/genproto/googleapis/api/distribution"

--- a/integration_test/ops_agent_test/testdata/prometheus/setup_json_exporter.sh
+++ b/integration_test/ops_agent_test/testdata/prometheus/setup_json_exporter.sh
@@ -3,9 +3,10 @@ set -e
 declare -A ARCHMAP=([x86_64]="amd64" [aarch64]="arm64")
 ARCH="${ARCHMAP[$(uname -m)]}"
 
-# Download JSON exporter and extract to /opt/
-curl -L -o json_exporter.tar.gz \
-    "https://github.com/prometheus-community/json_exporter/releases/download/v0.5.0/json_exporter-0.5.0.linux-${ARCH}.tar.gz"
+# Copy JSON exporter from GCS and extract to /opt/
+gcloud storage cp \
+    "gs://ops-agents-public-buckets-vendored-deps/mirrored-content/github.com/prometheus-community/json_exporter/releases/download/v0.5.0/json_exporter-0.5.0.linux-${ARCH}.tar.gz" \
+    json_exporter.tar.gz
 sudo mkdir -p /opt/json_exporter
 sudo tar -xzf json_exporter.tar.gz -C /opt/json_exporter --strip-components 1
 sudo systemctl daemon-reload


### PR DESCRIPTION
## Description
This PR ports several critical integration test flakiness fixes and reliability improvements from the `ops_agent_3.0` branch back to `master`. These changes target common sources of test instability, such as asynchronous cloud resource propagation, external network dependency issues, and asynchronous workload discovery lags.

#### 1. Active Polling for Firewall Propagation (`TestNetworkHealthCheck`)
The test previously relied on a static `time.Sleep(2 * time.Minute)` to wait for a network-blocking firewall tag to apply to the GCE VM. This was both slow (when propagation was fast) and fragile (when GCP took longer than 2 minutes, causing a flake).
Implements `waitForNetworkBlock`, which actively polls `telemetry.googleapis.com` every 10 seconds (up to 5 minutes) until the connection is successfully blocked, ensuring the firewall rule is active before proceeding.

#### 2. Add Retry Logic to AppHub Workload Discovery (`TestAppHubLogLabels`)
AppHub workload discovery is an asynchronous background process on the GCP control plane and can take up to several minutes. Previously, the test queried it immediately and failed if it wasn't ready, leading to frequent flakes.
Wraps the `RunGcloud` discovery call in a robust 3-minute retry loop with a 15-second constant backoff using `github.com/cenkalti/backoff/v4`.

#### 3. Mirror `json_exporter` Dependency from GCS (`setup_json_exporter.sh`)
The Prometheus integration tests downloaded `json_exporter` directly from GitHub releases during VM setup. This was highly prone to rate-limiting, transient network drops, or GitHub downtime.
Switches the download source to our managed, high-reliability Google Cloud Storage mirror: `gs://ops-agents-public-buckets-vendored-deps`.

#### 4. Disabling of Flaky Rocky Linux 9 Repositories (`agents.go`)
CE Rocky Linux 9 images come pre-configured with the `ciq-sigcloud-next` repository enabled by default. The hosting server for this repository (`depot.ciq.com`). Because `yum`/`dnf` attempts to sync all repos before installing any package, this external outage caused the entire `InstallOpsAgent()` step to fail on Rocky 9 VMs, flaking all 27 integration tests on this distro.


## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
