### PR TITLE
test(integration): harden network block wait in health check tests

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5428,9 +5428,26 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 
 func waitForNetworkBlock(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
 	logger.Println("Waiting for network block to propagate...")
-	checkCmd := "curl -s -m 5 https://telemetry.googleapis.com > /dev/null"
+	// The deny egress firewall rule is eventually consistent. We want to wait
+	// until ALL key endpoints are blocked before proceeding, to ensure the health
+	// checks consistently detect the block.
+	checkCmd := `if curl -s -m 5 https://telemetry.googleapis.com > /dev/null || \
+   curl -s -m 5 https://dl.google.com > /dev/null || \
+   curl -s -m 5 https://packages.cloud.google.com > /dev/null; then
+  exit 0
+else
+  exit 1
+fi`
 	if gce.IsWindows(vm.ImageSpec) {
-		checkCmd = "if ((Test-NetConnection telemetry.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded) { exit 0 } else { exit 1 }"
+		checkCmd = `if (
+  (Test-NetConnection telemetry.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
+  (Test-NetConnection dl.google.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
+  (Test-NetConnection packages.cloud.google.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded
+) {
+  exit 0
+} else {
+  exit 1
+}`
 	}
 
 	timeout := time.After(5 * time.Minute)
@@ -5446,10 +5463,10 @@ func waitForNetworkBlock(ctx context.Context, logger *log.Logger, vm *gce.VM) er
 		case <-tick.C:
 			_, err := gce.RunRemotely(ctx, logger, vm, checkCmd)
 			if err != nil {
-				logger.Printf("Network check failed as expected (network block propagated): %v", err)
+				logger.Printf("Network check failed as expected (all endpoints blocked): %v", err)
 				return nil
 			}
-			logger.Println("Network check still succeeded, waiting...")
+			logger.Println("At least one network endpoint is still reachable, waiting...")
 		}
 	}
 }


### PR DESCRIPTION
## Description
TestNetworkHealthCheck occasionally flakes (reporting false passes on blocked endpoints) because the deny-egress firewall rule propagation is eventually consistent.

The existing waitForNetworkBlock helper only polled a single telemetry endpoint (telemetry.googleapis.com) to determine if the block was active. However, because GCP firewall rules propagate to different IP ranges at slightly different times, other endpoints (like package repositories or download servers) could still be reachable when the health check started, causing the test to fail its assertions.

Solution
Hardened waitForNetworkBlock to poll all three critical endpoints that are verified by the health checks:

telemetry.googleapis.com (Telemetry API)
dl.google.com (Download/DL API)
packages.cloud.google.com (Packages API)
The helper now waits until all three endpoints are completely unreachable (all connections fail) before allowing the test to proceed. If any endpoint is still reachable, it continues polling, ensuring the firewall block has fully propagated across all relevant ranges.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
