### PR TITLE
Fix TestNetworkHealthCheck flakiness by waiting for logging and monitoring endpoints to block

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5428,9 +5428,26 @@ func TestPortsAndAPIHealthChecks(t *testing.T) {
 
 func waitForNetworkBlock(ctx context.Context, logger *log.Logger, vm *gce.VM) error {
 	logger.Println("Waiting for network block to propagate...")
-	checkCmd := "curl -s -m 5 https://telemetry.googleapis.com > /dev/null"
+	// The deny egress firewall rule is eventually consistent. We want to wait
+	// until ALL key endpoints are blocked before proceeding, to ensure the health
+	// checks consistently detect the block.
+	checkCmd := `if curl -s -m 5 https://telemetry.googleapis.com > /dev/null || \
+   curl -s -m 5 https://dl.google.com > /dev/null || \
+   curl -s -m 5 https://packages.cloud.google.com > /dev/null; then
+  exit 0
+else
+  exit 1
+fi`
 	if gce.IsWindows(vm.ImageSpec) {
-		checkCmd = "if ((Test-NetConnection telemetry.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded) { exit 0 } else { exit 1 }"
+		checkCmd = `if (
+  (Test-NetConnection telemetry.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
+  (Test-NetConnection dl.google.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
+  (Test-NetConnection packages.cloud.google.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded
+) {
+  exit 0
+} else {
+  exit 1
+}`
 	}
 
 	timeout := time.After(5 * time.Minute)
@@ -5446,10 +5463,10 @@ func waitForNetworkBlock(ctx context.Context, logger *log.Logger, vm *gce.VM) er
 		case <-tick.C:
 			_, err := gce.RunRemotely(ctx, logger, vm, checkCmd)
 			if err != nil {
-				logger.Printf("Network check failed as expected (network block propagated): %v", err)
+				logger.Printf("Network check failed as expected (all endpoints blocked): %v", err)
 				return nil
 			}
-			logger.Println("Network check still succeeded, waiting...")
+			logger.Println("At least one network endpoint is still reachable, waiting...")
 		}
 	}
 }

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5432,6 +5432,8 @@ func waitForNetworkBlock(ctx context.Context, logger *log.Logger, vm *gce.VM) er
 	// until ALL key endpoints are blocked before proceeding, to ensure the health
 	// checks consistently detect the block.
 	checkCmd := `if curl -s -m 5 https://telemetry.googleapis.com > /dev/null || \
+   curl -s -m 5 https://logging.googleapis.com > /dev/null || \
+   curl -s -m 5 https://monitoring.googleapis.com > /dev/null || \
    curl -s -m 5 https://dl.google.com > /dev/null || \
    curl -s -m 5 https://packages.cloud.google.com > /dev/null; then
   exit 0
@@ -5441,6 +5443,8 @@ fi`
 	if gce.IsWindows(vm.ImageSpec) {
 		checkCmd = `if (
   (Test-NetConnection telemetry.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
+  (Test-NetConnection logging.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
+  (Test-NetConnection monitoring.googleapis.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
   (Test-NetConnection dl.google.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded -or
   (Test-NetConnection packages.cloud.google.com -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded
 ) {


### PR DESCRIPTION
## Description
Updates `waitForNetworkBlock` in `integration_test/ops_agent_test/main_test.go` to explicitly verify that `logging.googleapis.com` and `monitoring.googleapis.com` are blocked (in addition to `telemetry`, `dl`, and `packages`) before proceeding with the network health check assertions.

### Why
When the `DenyEgressTrafficTag` (`test-ops-agent-deny-egress-traffic-tag`) is attached to a test VM, GCE firewall rule enforcement propagates across different destination IP routing tables with eventual consistency. 
Previously, `waitForNetworkBlock` only checked whether `telemetry.googleapis.com`, `dl.google.com`, and `packages.cloud.google.com` were blocked. Once those three endpoints timed out, the test runner immediately executed the agent's health checks. However, connections to `logging.googleapis.com` and `monitoring.googleapis.com` would frequently remain open for a few seconds longer, causing `TestNetworkHealthCheck` to fail when the API checks unexpectedly returned `PASS` instead of `FAIL`.

## Related issue
b/532086232

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
