### PR TITLE
Fix unbound variable error for GCLOUD_LITE_BLAZE_PATH in go_test.sh

### DIFF
--- a/kokoro/scripts/test/go_test.sh
+++ b/kokoro/scripts/test/go_test.sh
@@ -33,8 +33,8 @@
 #   * AGENTS_TO_TEST: comma-separated list of agents to test.
 #   * SCRIPTS_DIR: path to installation scripts to test.
 # os_config_test and gcloud_policies_test:
-#   * GCLOUD_LITE_BLAZE_PATH: path to just-built copy of gcloud_lite to use for
-#     testing.
+#   * GCLOUD_BLAZE_PATH (or legacy GCLOUD_LITE_BLAZE_PATH): path to just-built
+#     copy of gcloud to use for testing.
 # ops_agent_policies_test:
 #   * POLICIES_DIR: path to policy .yaml files to test.
 #   * ZONE: a single zone to run tests in (ZONES is ignored).
@@ -185,7 +185,7 @@ else
 fi
 
 if [[ "${TEST_SUITE_NAME}" == "os_config_test" || "${TEST_SUITE_NAME}" == "gcloud_policies_test" ]]; then
-  GCLOUD_TO_TEST="${KOKORO_BLAZE_DIR}/${GCLOUD_LITE_BLAZE_PATH}"
+  GCLOUD_TO_TEST="${KOKORO_BLAZE_DIR}/${GCLOUD_BLAZE_PATH:-${GCLOUD_LITE_BLAZE_PATH:-}}"
   export GCLOUD_TO_TEST
 fi
 


### PR DESCRIPTION
## Description
In Kokoro configurations, GCLOUD_LITE_BLAZE_PATH was updated to GCLOUD_BLAZE_PATH.
Update go_test.sh to use GCLOUD_BLAZE_PATH with a fallback to GCLOUD_LITE_BLAZE_PATH, preventing unbound variable script crashes under set -u.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
