### PR TITLE
test(3p): skip flaky MySQL third-party app tests on Rocky Linux 10

### DIFF
--- a/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
+++ b/integration_test/third_party_apps_test/applications/mysql/metadata.yaml
@@ -37,6 +37,10 @@ platforms_to_skip:
   - debian-cloud:debian-12-arm64
   - debian-cloud:debian-13
   - debian-cloud:debian-13-arm64
+  - rocky-linux-cloud:rocky-linux-10
+  - rocky-linux-cloud:rocky-linux-10-arm64
+  - rocky-linux-cloud:rocky-linux-10-optimized-gcp
+  - rocky-linux-cloud:rocky-linux-10-optimized-gcp-arm64
   - suse-cloud:sles-12
   - suse-cloud:sles-15-arm64
   - suse-sap-cloud:sles-12-sp5-sap


### PR DESCRIPTION
## Description
 Added all four Rocky Linux 10 variants (rocky-linux-10, rocky-linux-10-arm64, rocky-linux-10-optimized-gcp, and rocky-linux-10-optimized-gcp-arm64) to platforms_to_skip in mysql/metadata.yaml.

## Related issue
b/533038592

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
