### PR TITLE
feat(healthchecks): add trace health check for OTLP endpoint

### DIFF
--- a/internal/healthchecks/api_check.go
+++ b/internal/healthchecks/api_check.go
@@ -30,10 +30,12 @@ import (
 	"github.com/googleapis/gax-go/v2/apierror"
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
 	metricsprpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/oauth2/google"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -160,6 +162,39 @@ func createTelemetryLogsRequest(resource resourcedetector.Resource) *collogspb.E
 								Body: &commonpb.AnyValue{
 									Value: &commonpb.AnyValue_StringValue{StringValue: "Health check log entry"},
 								},
+								Attributes: []*commonpb.KeyValue{
+									{Key: "instrumentation_source", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "agent.googleapis.com/health_check"}}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createTelemetryTracesRequest(resource resourcedetector.Resource) *coltracepb.ExportTraceServiceRequest {
+	currentTimeNano := uint64(time.Now().UnixNano())
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{
+			{
+				Resource: &resourcepb.Resource{
+					Attributes: []*commonpb.KeyValue{
+						{Key: "gcp.project_id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: resource.ProjectName()}}},
+					},
+				},
+				ScopeSpans: []*tracepb.ScopeSpans{
+					{
+						Scope: &commonpb.InstrumentationScope{},
+						Spans: []*tracepb.Span{
+							{
+								TraceId:           []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+								SpanId:            []byte{1, 2, 3, 4, 5, 6, 7, 8},
+								Name:              "Health check span",
+								Kind:              tracepb.Span_SPAN_KIND_INTERNAL,
+								StartTimeUnixNano: currentTimeNano,
+								EndTimeUnixNano:   currentTimeNano,
 								Attributes: []*commonpb.KeyValue{
 									{Key: "instrumentation_source", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "agent.googleapis.com/health_check"}}},
 								},
@@ -388,6 +423,63 @@ func runTelemetryLogsCheck(logger logs.StructuredLogger, resource resourcedetect
 	return nil
 }
 
+func runTelemetryTracesCheck(logger logs.StructuredLogger, resource resourcedetector.Resource) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	creds, err := google.FindDefaultCredentials(ctx,
+		"https://www.googleapis.com/auth/trace.append",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to find default credentials: %v", err)
+	}
+
+	conn, err := grpc.NewClient(
+		"telemetry.googleapis.com:443",
+		grpc.WithTransportCredentials(credentials.NewTLS(nil)),
+		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: creds.TokenSource}),
+	)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	logger.Infof("telemetry client was created successfully")
+
+	client := coltracepb.NewTraceServiceClient(conn)
+
+	req := createTelemetryTracesRequest(resource)
+
+	_, err = client.Export(ctx, req)
+	if err != nil {
+		stat, ok := status.FromError(err)
+		if ok {
+			for _, detail := range stat.Details() {
+				if info, ok := detail.(*errdetails.ErrorInfo); ok {
+					if info.Reason == AccessTokenScopeInsufficient {
+						return TraceApiScopeErr
+					}
+				}
+			}
+			switch stat.Code() {
+			case codes.PermissionDenied:
+				if strings.Contains(stat.Message(), "disabled") {
+					return TelApiDisabledErr
+				}
+				return TelTracesApiPermissionErr
+			case codes.Unauthenticated:
+				return TelApiUnauthenticatedErr
+			case codes.DeadlineExceeded, codes.Unavailable:
+				return TelApiConnErr
+			}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return TelApiConnErr
+		}
+		return err
+	}
+	return nil
+}
+
 func (c APICheck) Name() string {
 	return "API Check"
 }
@@ -400,10 +492,11 @@ func (c APICheck) RunCheck(logger logs.StructuredLogger) error {
 
 	var monOrTelErr error
 	var logOrTelLogsErr error
+	var telTracesErr error
 	var wg sync.WaitGroup
 
-	wg.Add(2)
 	if c.otlpExporterEnabled {
+		wg.Add(3)
 		logger.Infof("Running Telemetry API checks")
 		go func() {
 			defer wg.Done()
@@ -413,7 +506,12 @@ func (c APICheck) RunCheck(logger logs.StructuredLogger) error {
 			defer wg.Done()
 			logOrTelLogsErr = runTelemetryLogsCheck(logger, resource)
 		}()
+		go func() {
+			defer wg.Done()
+			telTracesErr = runTelemetryTracesCheck(logger, resource)
+		}()
 	} else {
+		wg.Add(2)
 		logger.Infof("Running legacy API checks")
 		go func() {
 			defer wg.Done()
@@ -426,5 +524,5 @@ func (c APICheck) RunCheck(logger logs.StructuredLogger) error {
 	}
 	wg.Wait()
 
-	return errors.Join(monOrTelErr, logOrTelLogsErr)
+	return errors.Join(monOrTelErr, logOrTelLogsErr, telTracesErr)
 }

--- a/internal/healthchecks/error.go
+++ b/internal/healthchecks/error.go
@@ -117,6 +117,14 @@ var (
 		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
 		IsFatal:      true,
 	}
+	TraceApiScopeErr = HealthCheckError{
+		Code:         "TraceApiScopeErr",
+		Class:        Permission,
+		Message:      "VM is missing the https://www.googleapis.com/auth/trace.append scope.",
+		Action:       "Add the https://www.googleapis.com/auth/trace.append scope to the Compute Engine VM.",
+		ResourceLink: "https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/authorization",
+		IsFatal:      true,
+	}
 	LogApiPermissionErr = HealthCheckError{
 		Code:         "LogApiPermissionErr",
 		Class:        Permission,
@@ -191,6 +199,15 @@ var (
 		Message:      "Service account is missing the roles/telemetry.logsWriter role.",
 		Action:       "Add the roles/telemetry.logsWriter role to the Google Cloud service account.",
 		ResourceLink: "https://docs.cloud.google.com/iam/docs/roles-permissions/telemetry#telemetry.logsWriter",
+		IsFatal:      true,
+	}
+
+	TelTracesApiPermissionErr = HealthCheckError{
+		Code:         "TelTracesApiPermissionErr",
+		Class:        Permission,
+		Message:      "Service account is missing the roles/telemetry.tracesWriter role.",
+		Action:       "Add the roles/telemetry.tracesWriter role to the Google Cloud service account.",
+		ResourceLink: "https://docs.cloud.google.com/iam/docs/roles-permissions/telemetry#telemetry.tracesWriter",
 		IsFatal:      true,
 	}
 


### PR DESCRIPTION
## Description
Adds an OTLP Traces Health Check (runTelemetryTracesCheck) to run alongside the existing metrics and logging health checks when the otlp_exporter experiment is enabled in the Ops Agent.

Specifically, when otlp_exporter (c.otlpExporterEnabled) is active, the agent checks connectivity and permissions for telemetry.googleapis.com:443 trace ingestion. If traces fail to export, the check reports actionable, categorized health check errors to guide users on missing scopes or IAM roles.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
