### PR TITLE
Improve distro detector logs to explicitly list added and removed distro families

### DIFF
--- a/cloudbuild/new-distro-detector/run.sh
+++ b/cloudbuild/new-distro-detector/run.sh
@@ -54,17 +54,32 @@ LAST_KNOWN_LIST="gs://stackdriver-test-143416-new-distro-detector/list_of_famili
 gcloud storage -q cp "${LAST_KNOWN_LIST}" - \
   | tee known_families.txt
 
-# If there is a difference, print the diff, and...
-if ! diff --ignore-all-space --ignore-blank-lines known_families.txt current_families.txt; then
-  # Print instructions for handling the error.
-  # Set +x temporarily so that the banner is only printed once.
+# Calculate added and removed distro families explicitly instead of using raw diff.
+ADDED="$(comm -13 <(sort known_families.txt) <(sort current_families.txt) | sed '/^$/d')"
+REMOVED="$(comm -23 <(sort known_families.txt) <(sort current_families.txt) | sed '/^$/d')"
+
+if [ -n "${ADDED}" ] || [ -n "${REMOVED}" ]; then
+  # Print explicit lists and instructions for handling the error.
+  # Set +x temporarily so that the banner is only printed once and remains easy to read.
   set +x
   echo '
-    ####################################################
-    #  See go/sdi-new-distro-detector#handling-errors  #
-    #  for instructions on handling this error.        #
-    ####################################################
-  '
+================================================================
+                    DISTRO CHANGES DETECTED                     
+================================================================'
+  if [ -n "${ADDED}" ]; then
+    echo "NEW DISTRO FAMILY ADDED (requires triage):"
+    echo "${ADDED}" | sed 's/^/  + /'
+    echo ""
+  fi
+  if [ -n "${REMOVED}" ]; then
+    echo "DISTRO FAMILY DEPRECATED / REMOVED:"
+    echo "${REMOVED}" | sed 's/^/  - /'
+    echo ""
+  fi
+  echo '####################################################
+#  See go/sdi-new-distro-detector#handling-errors  #
+#  for instructions on handling this error.        #
+####################################################'
   set -x
   # Upload the current list to the GCS bucket so that the next run passes.
   gcloud storage -q cp current_families.txt "${LAST_KNOWN_LIST}"


### PR DESCRIPTION
## Description

Currently, when the New/Deprecated Distro Detector (`cloudbuild/new-distro-detector/run.sh`) identifies changes in available GCE distro families, it simply outputs the result of `diff`. The resulting `<` and `>` lines are difficult to parse in Cloud Build logs and issue reports without remembering which file corresponded to which side of the comparison.
This PR replaces the raw `diff` comparison with explicit set difference calculations using `comm`, separating newly introduced distro families from removed or deprecated ones into clear, unambiguous sections.
## Sample Output
### Before (Raw `diff`)
```text
66d66
< sles-15-sp4-sap
76d75
< sles-sap-15-sp4-hardened
```
### After (New Format)
```text
================================================================
                    DISTRO CHANGES DETECTED                     
================================================================
NEW DISTRO FAMILY ADDED (requires triage):
  + rocky-linux-10
  + ubuntu-2404-lts-amd64

DISTRO FAMILY DEPRECATED / REMOVED:
  - sles-15-sp4-sap
  - sles-sap-15-sp4-hardened

####################################################
#  See go/sdi-new-distro-detector#handling-errors  #
#  for instructions on handling this error.        #
####################################################
```
## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
