### PR TITLE
test: fix TestRestartVM timeouts by preventing systemctl 10-line log truncation

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5331,13 +5331,13 @@ func waitForExpectedHealthCheckResults(ctx context.Context, logger *log.Logger, 
 
 	backoffPolicy := backoff.WithContext(backoff.NewConstantBackOff(5*time.Second), ctx)
 	return backoff.Retry(func() error {
-		cmdOut, err := gce.RunRemotely(ctx, logger, vm, getRecentServiceOutputForImage(vm.ImageSpec))
+		output, err := getHealthCheckResultsForImage(ctx, logger, vm)
 		if err != nil {
 			return err
 		}
 		for name, expected := range checks {
-			if !strings.Contains(cmdOut.Stdout, healthCheckResultMessage(name, expected, "")) {
-				return fmt.Errorf("expected %s check to %s in service output:\n%s", name, expected, cmdOut.Stdout)
+			if !strings.Contains(output, healthCheckResultMessage(name, expected, "")) {
+				return fmt.Errorf("expected %s check to %s in service output:\n%s", name, expected, output)
 			}
 		}
 		return nil

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5353,7 +5353,7 @@ func getRecentServiceOutputForImage(imageSpec string) string {
 		}, ";")
 		return cmd
 	}
-	return "sudo systemctl status google-cloud-ops-agent"
+	return "sudo journalctl -b 0 -u google-cloud-ops-agent --no-pager"
 }
 
 func getHealthCheckResultsForImage(ctx context.Context, logger *log.Logger, vm *gce.VM) (string, error) {


### PR DESCRIPTION
## Description
Replaces `systemctl status google-cloud-ops-agent` with `journalctl -b 0 -u google-cloud-ops-agent --no-pager` in `getRecentServiceOutputForImage`.

In integration tests like `TestRestartVM`, `waitForExpectedHealthCheckResults` periodically polls `getRecentServiceOutputForImage` to confirm that `Network`, `Ports`, and `API` healthchecks have logged `[PASS]`.
1. **Fixes Log Truncation:** Previously, `systemctl status` capped output to the last 10 log lines. On service startup, after healthchecks printed `[PASS]`, sub-daemons (Fluent Bit & OTel Collector) frequently output >7 lines of startup logs, pushing the `[PASS]` messages out of `systemctl status`'s 10-line window. This caused false timeout failures even though healthchecks had passed.
2. **Prevents Pre-Reboot False Positives:** Using `-b 0` (`--boot=0`) ensures `journalctl` queries logs **strictly from the current post-reboot boot session**, ignoring any healthcheck pass messages generated prior to `gce.RestartInstance`.
3. 

## Related issue

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
