### PR TITLE
test: deflake TestMetricsPortOverrideEnv with backoff polling

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -6298,37 +6298,47 @@ Environment="%s=40002"
 			}
 		}
 
-		// Wait for agent to start up
-		time.Sleep(20 * time.Second)
-
-		// Verify that we can scrape metrics from the new ports
-		// Fluent Bit metrics on 40002
-		var fbMetricsOut, otelMetricsOut gce.CommandOutput
-		var err error
-
+		// Verify that we can scrape metrics from the new ports with retries (waiting up to 60s for agent startup)
+		fbCmd := "curl -s localhost:40002/metrics"
 		if gce.IsWindows(imageSpec) {
-			fbMetricsOut, err = gce.RunRemotely(ctx, logger, vm, "Invoke-RestMethod -Uri http://localhost:40002/metrics")
-		} else {
-			fbMetricsOut, err = gce.RunRemotely(ctx, logger, vm, "curl -s localhost:40002/metrics")
+			fbCmd = "Invoke-RestMethod -Uri http://localhost:40002/metrics"
 		}
-		if err != nil {
+		fbBackoff := backoff.WithContext(
+			backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 30),
+			ctx,
+		)
+		if err := backoff.Retry(func() error {
+			out, err := gce.RunRemotely(ctx, logger, vm, fbCmd)
+			if err != nil {
+				return err
+			}
+			if !strings.Contains(out.Stdout, "fluentbit_uptime") {
+				return fmt.Errorf("fluentbit_uptime not found in metrics output: %s", out.Stdout)
+			}
+			return nil
+		}, fbBackoff); err != nil {
 			t.Fatalf("Failed to scrape Fluent Bit metrics on port 40002: %v", err)
 		}
-		if !strings.Contains(fbMetricsOut.Stdout, "fluentbit_uptime") {
-			t.Fatalf("Fluent Bit metrics on port 40002 do not contain expected content. Output: %s", fbMetricsOut.Stdout)
-		}
 
-		// OTel Collector metrics on 40001
+		otelCmd := "curl -s localhost:40001/metrics"
 		if gce.IsWindows(imageSpec) {
-			otelMetricsOut, err = gce.RunRemotely(ctx, logger, vm, "Invoke-RestMethod -Uri http://localhost:40001/metrics")
-		} else {
-			otelMetricsOut, err = gce.RunRemotely(ctx, logger, vm, "curl -s localhost:40001/metrics")
+			otelCmd = "Invoke-RestMethod -Uri http://localhost:40001/metrics"
 		}
-		if err != nil {
+		otelBackoff := backoff.WithContext(
+			backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 30),
+			ctx,
+		)
+		if err := backoff.Retry(func() error {
+			out, err := gce.RunRemotely(ctx, logger, vm, otelCmd)
+			if err != nil {
+				return err
+			}
+			if !strings.Contains(out.Stdout, "otelcol_") {
+				return fmt.Errorf("otelcol_ not found in metrics output: %s", out.Stdout)
+			}
+			return nil
+		}, otelBackoff); err != nil {
 			t.Fatalf("Failed to scrape OTel Collector metrics on port 40001: %v", err)
-		}
-		if !strings.Contains(otelMetricsOut.Stdout, "otelcol_") {
-			t.Fatalf("OTel Collector metrics on port 40001 do not contain expected content. Output: %s", otelMetricsOut.Stdout)
 		}
 	})
 }

--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -6224,6 +6224,27 @@ func TestUninstallRemovesService(t *testing.T) {
 	})
 }
 
+func verifyMetricsPort(ctx context.Context, logger *log.Logger, vm *gce.VM, port int, expectedContent string) error {
+	cmd := fmt.Sprintf("curl -s localhost:%d/metrics", port)
+	if gce.IsWindows(vm.ImageSpec) {
+		cmd = fmt.Sprintf("Invoke-RestMethod -Uri http://localhost:%d/metrics", port)
+	}
+	b := backoff.WithContext(
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 30),
+		ctx,
+	)
+	return backoff.Retry(func() error {
+		out, err := gce.RunRemotely(ctx, logger, vm, cmd)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(out.Stdout, expectedContent) {
+			return fmt.Errorf("%q not found in metrics output on port %d: %s", expectedContent, port, out.Stdout)
+		}
+		return nil
+	}, b)
+}
+
 func TestMetricsPortOverrideEnv(t *testing.T) {
 	t.Parallel()
 	RunForEachImageAndFeatureFlag(t, []string{agents.OtlpHttpExporterFeatureFlag}, func(t *testing.T, imageSpec string, feature string) {
@@ -6299,45 +6320,10 @@ Environment="%s=40002"
 		}
 
 		// Verify that we can scrape metrics from the new ports with retries (waiting up to 60s for agent startup)
-		fbCmd := "curl -s localhost:40002/metrics"
-		if gce.IsWindows(imageSpec) {
-			fbCmd = "Invoke-RestMethod -Uri http://localhost:40002/metrics"
-		}
-		fbBackoff := backoff.WithContext(
-			backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 30),
-			ctx,
-		)
-		if err := backoff.Retry(func() error {
-			out, err := gce.RunRemotely(ctx, logger, vm, fbCmd)
-			if err != nil {
-				return err
-			}
-			if !strings.Contains(out.Stdout, "fluentbit_uptime") {
-				return fmt.Errorf("fluentbit_uptime not found in metrics output: %s", out.Stdout)
-			}
-			return nil
-		}, fbBackoff); err != nil {
+		if err := verifyMetricsPort(ctx, logger, vm, 40002, "fluentbit_uptime"); err != nil {
 			t.Fatalf("Failed to scrape Fluent Bit metrics on port 40002: %v", err)
 		}
-
-		otelCmd := "curl -s localhost:40001/metrics"
-		if gce.IsWindows(imageSpec) {
-			otelCmd = "Invoke-RestMethod -Uri http://localhost:40001/metrics"
-		}
-		otelBackoff := backoff.WithContext(
-			backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 30),
-			ctx,
-		)
-		if err := backoff.Retry(func() error {
-			out, err := gce.RunRemotely(ctx, logger, vm, otelCmd)
-			if err != nil {
-				return err
-			}
-			if !strings.Contains(out.Stdout, "otelcol_") {
-				return fmt.Errorf("otelcol_ not found in metrics output: %s", out.Stdout)
-			}
-			return nil
-		}, otelBackoff); err != nil {
+		if err := verifyMetricsPort(ctx, logger, vm, 40001, "otelcol_"); err != nil {
 			t.Fatalf("Failed to scrape OTel Collector metrics on port 40001: %v", err)
 		}
 	})


### PR DESCRIPTION
## Description
Replace the hardcoded 20-second sleep and single-shot curl call in TestMetricsPortOverrideEnv with backoff polling loops (waiting up to 60 seconds with a 2-second interval).

This ensures slow OS distros and ARM64 architectures have sufficient time to reload systemd and initialize HTTP metrics servers on ports 40001 and 40002 without triggering false connection refused errors.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
