### PR TITLE
transformation_test: allow pipeline to drain before interrupting otelopscol

### DIFF
--- a/transformation_test/otlp_helpers_test.go
+++ b/transformation_test/otlp_helpers_test.go
@@ -44,14 +44,11 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 		Exporters: map[otel.ExporterType]otel.ExporterComponents{
 			otel.OTLP_Logs: {
 				ProcessorsByType: map[string][]otel.Component{
-					// Batch with 1.5s timeout to group in the same log request
-					// all late entries flushed from a multiline parser after 1s.
 					"logs": {
 						otel.GCPProjectID("fake-project"),
 						otel.DisableOtlpRoundTrip(),
 						otel.PreserveInstrumentationScope(),
 						otel.CopyServiceResourceLabels(),
-						otel.BatchProcessor(500, 500, "1500ms"),
 					},
 				},
 				Exporter: otel.Component{
@@ -63,6 +60,12 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 						},
 						"sending_queue": map[string]any{
 							"enabled": true,
+						},
+						// Exporter batcher groups all late entries flushed from multiline parser after 1s
+						"batcher": map[string]any{
+							"min_size":      500,
+							"max_size":      500,
+							"flush_timeout": "1500ms",
 						},
 					},
 				},

--- a/transformation_test/otlp_helpers_test.go
+++ b/transformation_test/otlp_helpers_test.go
@@ -44,11 +44,14 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 		Exporters: map[otel.ExporterType]otel.ExporterComponents{
 			otel.OTLP_Logs: {
 				ProcessorsByType: map[string][]otel.Component{
+					// Batch with 1.5s timeout to group in the same log request
+					// all late entries flushed from a multiline parser after 1s.
 					"logs": {
 						otel.GCPProjectID("fake-project"),
 						otel.DisableOtlpRoundTrip(),
 						otel.PreserveInstrumentationScope(),
 						otel.CopyServiceResourceLabels(),
+						otel.BatchProcessor(500, 500, "1500ms"),
 					},
 				},
 				Exporter: otel.Component{
@@ -60,12 +63,6 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 						},
 						"sending_queue": map[string]any{
 							"enabled": true,
-						},
-						// Exporter batcher groups all late entries flushed from multiline parser after 1s
-						"batcher": map[string]any{
-							"min_size":      500,
-							"max_size":      500,
-							"flush_timeout": "1500ms",
 						},
 					},
 				},

--- a/transformation_test/otlp_helpers_test.go
+++ b/transformation_test/otlp_helpers_test.go
@@ -44,14 +44,11 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 		Exporters: map[otel.ExporterType]otel.ExporterComponents{
 			otel.OTLP_Logs: {
 				ProcessorsByType: map[string][]otel.Component{
-					// Batch with 1.5s timeout to group in the same log request
-					// all late entries flushed from a multiline parser after 1s.
 					"logs": {
 						otel.GCPProjectID("fake-project"),
 						otel.DisableOtlpRoundTrip(),
 						otel.PreserveInstrumentationScope(),
 						otel.CopyServiceResourceLabels(),
-						otel.BatchProcessor(500, 500, "1500ms"),
 					},
 				},
 				Exporter: otel.Component{
@@ -63,6 +60,9 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 						},
 						"sending_queue": map[string]any{
 							"enabled": true,
+							"batch": map[string]any{
+								"flush_timeout": "1500ms",
+							},
 						},
 					},
 				},

--- a/transformation_test/otlp_helpers_test.go
+++ b/transformation_test/otlp_helpers_test.go
@@ -61,6 +61,9 @@ func (transformationConfig transformationTest) generateOTelOTLPExporterConfig(ct
 						"tls": map[string]any{
 							"insecure": true, // We must use insecure TLS because our mock server on localhost does not have certificates installed.
 						},
+						"sending_queue": map[string]any{
+							"enabled": true,
+						},
 					},
 				},
 			},

--- a/transformation_test/transformation_test.go
+++ b/transformation_test/transformation_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -611,10 +612,20 @@ func (transformationConfig transformationTest) runOTelTestInner(t *testing.T, na
 			if strings.HasPrefix(msg, "Consuming files") {
 				consumingCount += 1
 				if consumingCount == 3 {
-					// We've processed the entire input file. Signal the collector to stop.
-					if err := cmd.Process.Signal(os.Interrupt); err != nil {
-						t.Errorf("failed to signal process: %v", err)
-					}
+					// We've processed the entire input file. Give the pipeline a window to finish
+					// executing transform processors and draining multiline log batches (up to 1000ms
+					// for force_flush_period) before sending SIGTERM for graceful shutdown.
+					go func() {
+						time.Sleep(1000 * time.Millisecond)
+						if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+							t.Logf("failed to signal process: %v", err)
+						}
+						// Fallback: If otelopscol fails to stop gracefully, force kill it.
+						time.Sleep(10 * time.Second)
+						if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+							_ = cmd.Process.Kill()
+						}
+					}()
 				}
 			}
 			stacktrace, ok := log["stacktrace"].(string)


### PR DESCRIPTION
## Description

In `transformation_test`, `otelopscol` is signaled to terminate (`os.Interrupt`) as soon as the `fileconsumer` receiver logs the `"Consuming files"` log message 3 times.
On slower runners and emulated CPU environments (such as ARM64 `aarch64` under QEMU during Debian package builds), the signal was being delivered within 2ms of file consumption starting—shutting down the receiver and pipeline before the OTTL transformation statements and gRPC export batch could finish processing. This caused occasional empty payload drops and test failures (e.g. `TestTransformationTests/logging_processor-couchdb/otel-otlpexporter`).

## Related issue
b/543358344

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
