### PR TITLE
test(integration): wait for fluent-bit socket release in TestMetricsPortOverrideEnv

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -6278,10 +6278,13 @@ func TestMetricsPortOverrideEnv(t *testing.T) {
 				t.Fatal(err)
 			}
 		} else {
-			// Stop the agent to avoid race conditions while setting up overrides
-			if _, err := gce.RunRemotely(ctx, logger, vm, "sudo systemctl stop google-cloud-ops-agent"); err != nil {
+			// Stop all Ops Agent services to avoid race conditions while setting up overrides
+			if _, err := gce.RunRemotely(ctx, logger, vm, "sudo systemctl stop google-cloud-ops-agent google-cloud-ops-agent-fluent-bit google-cloud-ops-agent-opentelemetry-collector"); err != nil {
 				t.Fatal(err)
 			}
+			// Give Fluent Bit time to cleanly shut down and release its listening socket.
+			// Fluent-Bit's default shutdown grace period is 5 seconds.
+			time.Sleep(10 * time.Second)
 
 			// Set up systemd overrides for Fluent Bit
 			fbOverrideDir := "/etc/systemd/system/google-cloud-ops-agent-fluent-bit.service.d"
@@ -6310,11 +6313,8 @@ Environment="%s=40002"
 				t.Fatal(err)
 			}
 
-			// Reload systemd and restart agent
-			if _, err := gce.RunRemotely(ctx, logger, vm, "sudo systemctl daemon-reload"); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := gce.RunRemotely(ctx, logger, vm, "sudo systemctl start google-cloud-ops-agent"); err != nil {
+			// Reload systemd and restart all agent services
+			if _, err := gce.RunRemotely(ctx, logger, vm, "sudo systemctl daemon-reload && sudo systemctl restart google-cloud-ops-agent google-cloud-ops-agent-fluent-bit google-cloud-ops-agent-opentelemetry-collector"); err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
## Description
In `TestMetricsPortOverrideEnv` on Linux, the test stops the Ops Agent service, writes the systemd drop-in `override.conf` files to remap ports to `40001`/`40002`, and immediately starts the service.
Because `google-cloud-ops-agent.service` is a `Type=oneshot` parent unit, stopping it causes systemd to initiate asynchronous graceful teardown of `google-cloud-ops-agent-fluent-bit.service`. Fluent Bit has a 5-second shutdown grace period to flush buffers and close connections before releasing its socket.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
