### PR TITLE
integration_test: retry Debian/Ubuntu APT and dpkg lock errors during agent installation

### DIFF
--- a/integration_test/agents/agents.go
+++ b/integration_test/agents/agents.go
@@ -637,6 +637,8 @@ func FetchPackageVersions(ctx context.Context, logger *log.Logger, vm *gce.VM, p
 // isRetriableInstallError checks to see if the error may be transient.
 func isRetriableInstallError(imageSpec string, err error) bool {
 	if strings.Contains(err.Error(), "Could not refresh zypper repositories.") ||
+		strings.Contains(err.Error(), "Could not get lock") ||
+		strings.Contains(err.Error(), "Unable to acquire the dpkg frontend lock") ||
 		strings.Contains(err.Error(), "Credentials are invalid") ||
 		strings.Contains(err.Error(), "Resource temporarily unavailable") ||
 		strings.Contains(err.Error(), "System management is locked by the application") {


### PR DESCRIPTION
## Description
On freshly booted Debian and Ubuntu instances, background system services (such as unattended-upgrades or apt-daily.service) can hold /var/lib/dpkg/lock-frontend or /var/lib/apt/lists/lock.

Add these error patterns to isRetriableInstallError so RunInstallFuncWithRetry retries InstallOpsAgent with backoff instead of failing immediately.

## Related issue
b/545189309

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
