### PR TITLE
fix(self-metrics): read otlpjsonfile from beginning on startup

### DIFF
--- a/confgenerator/agentmetrics.go
+++ b/confgenerator/agentmetrics.go
@@ -421,6 +421,7 @@ func (r AgentSelfMetrics) OpsAgentPipeline(ctx context.Context) otel.ReceiverPip
 			filepath.Join(r.OtelRuntimeDir, "feature_tracking_otlp.json")},
 		"replay_file":   true,
 		"poll_interval": time.Duration(60 * time.Second).String(),
+		"start_at":      "beginning",
 	}
 	return ConvertGCMSystemExporterToOtlpExporter(otel.ReceiverPipeline{
 		Receiver: otel.Component{

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux-gpu/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/linux/otel.yaml
@@ -705,6 +705,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -652,6 +652,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -652,6 +652,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-custom_use_built_in_receivers/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-quoted_map_keys/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/all-user_config_file_deleted/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-dataproc/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/builtin/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux-gpu/otel.yaml
@@ -809,6 +809,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/linux/otel.yaml
@@ -778,6 +778,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows-2012/otel.yaml
@@ -1180,6 +1180,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp/golden/windows/otel.yaml
@@ -1180,6 +1180,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux-gpu/otel.yaml
@@ -775,6 +775,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/linux/otel.yaml
@@ -744,6 +744,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows-2012/otel.yaml
@@ -1146,6 +1146,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring/golden/windows/otel.yaml
@@ -1146,6 +1146,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux-gpu/otel.yaml
@@ -783,6 +783,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/linux/otel.yaml
@@ -751,6 +751,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows-2012/otel.yaml
@@ -1155,6 +1155,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlecloudmonitoring_with_processor/golden/windows/otel.yaml
@@ -1155,6 +1155,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux-gpu/otel.yaml
@@ -780,6 +780,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/linux/otel.yaml
@@ -749,6 +749,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows-2012/otel.yaml
@@ -1151,6 +1151,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_googlemanagedprometheus/golden/windows/otel.yaml
@@ -1151,6 +1151,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux-gpu/otel.yaml
@@ -780,6 +780,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/linux/otel.yaml
@@ -749,6 +749,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows-2012/otel.yaml
@@ -1151,6 +1151,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_grpcendpoint/golden/windows/otel.yaml
@@ -1151,6 +1151,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -780,6 +780,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/linux/otel.yaml
@@ -749,6 +749,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -1151,6 +1151,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_multiple_pipelines/golden/windows/otel.yaml
@@ -1151,6 +1151,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux-gpu/otel.yaml
@@ -768,6 +768,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/linux/otel.yaml
@@ -737,6 +737,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows-2012/otel.yaml
@@ -1139,6 +1139,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_no_traces/golden/windows/otel.yaml
@@ -1139,6 +1139,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -1193,6 +1193,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -1147,6 +1147,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -1579,6 +1579,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otel_logging_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -1579,6 +1579,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux-gpu/otel.yaml
@@ -1107,6 +1107,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/linux/otel.yaml
@@ -1061,6 +1061,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows-2012/otel.yaml
@@ -1493,6 +1493,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/combined-receiver_otlp_otlpgrpc_exporter/golden/windows/otel.yaml
@@ -1493,6 +1493,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-default-log-rotation_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_false/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/global-service_default_self_log_file_collection_true/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-custom_log_level/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_no_otel/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-default_overrides_disable_all/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -901,6 +901,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1177,6 +1177,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel.yaml
@@ -870,6 +870,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/linux/otel_otlp_exporter.yaml
@@ -1131,6 +1131,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -1272,6 +1272,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1563,6 +1563,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel.yaml
@@ -1272,6 +1272,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_exclude_logs/golden/windows/otel_otlp_exporter.yaml
@@ -1563,6 +1563,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -874,6 +874,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel.yaml
@@ -843,6 +843,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/linux/otel_otlp_exporter.yaml
@@ -1104,6 +1104,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -1245,6 +1245,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1536,6 +1536,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel.yaml
@@ -1245,6 +1245,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields/golden/windows/otel_otlp_exporter.yaml
@@ -1536,6 +1536,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux-gpu/otel.yaml
@@ -789,6 +789,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/linux/otel.yaml
@@ -758,6 +758,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows-2012/otel.yaml
@@ -1160,6 +1160,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_modify_fields_ruby_regex/golden/windows/otel.yaml
@@ -1160,6 +1160,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel.yaml
@@ -841,6 +841,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1117,6 +1117,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel.yaml
@@ -810,6 +810,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/linux/otel_otlp_exporter.yaml
@@ -1071,6 +1071,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel.yaml
@@ -1212,6 +1212,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1503,6 +1503,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel.yaml
@@ -1212,6 +1212,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_json/golden/windows/otel_otlp_exporter.yaml
@@ -1503,6 +1503,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -796,6 +796,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1072,6 +1072,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -765,6 +765,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/linux/otel_otlp_exporter.yaml
@@ -1026,6 +1026,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -1277,6 +1277,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1568,6 +1568,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -1277,6 +1277,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-processor_parse_regex_type_on_default_pipeline/golden/windows/otel_otlp_exporter.yaml
@@ -1568,6 +1568,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -786,6 +786,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1062,6 +1062,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/linux/otel_otlp_exporter.yaml
@@ -1016,6 +1016,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1448,6 +1448,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_files_refresh_interval/golden/windows/otel_otlp_exporter.yaml
@@ -1448,6 +1448,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel.yaml
@@ -789,6 +789,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1065,6 +1065,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel.yaml
@@ -758,6 +758,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/linux/otel_otlp_exporter.yaml
@@ -1019,6 +1019,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel.yaml
@@ -1160,6 +1160,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1451,6 +1451,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel.yaml
@@ -1160,6 +1160,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_forward/golden/windows/otel_otlp_exporter.yaml
@@ -1451,6 +1451,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -876,6 +876,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel.yaml
@@ -845,6 +845,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/linux/otel_otlp_exporter.yaml
@@ -1106,6 +1106,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel.yaml
@@ -1247,6 +1247,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1538,6 +1538,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel.yaml
@@ -1247,6 +1247,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_kafka/golden/windows/otel_otlp_exporter.yaml
@@ -1538,6 +1538,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -1080,6 +1080,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1356,6 +1356,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel.yaml
@@ -1049,6 +1049,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/linux/otel_otlp_exporter.yaml
@@ -1310,6 +1310,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -1451,6 +1451,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1742,6 +1742,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel.yaml
@@ -1451,6 +1451,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mongodb/golden/windows/otel_otlp_exporter.yaml
@@ -1742,6 +1742,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -1418,6 +1418,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1694,6 +1694,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel.yaml
@@ -1387,6 +1387,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/linux/otel_otlp_exporter.yaml
@@ -1648,6 +1648,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel.yaml
@@ -1789,6 +1789,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows-2012/otel_otlp_exporter.yaml
@@ -2080,6 +2080,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel.yaml
@@ -1789,6 +1789,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_mysql/golden/windows/otel_otlp_exporter.yaml
@@ -2080,6 +2080,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -1049,6 +1049,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1325,6 +1325,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel.yaml
@@ -1018,6 +1018,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/linux/otel_otlp_exporter.yaml
@@ -1279,6 +1279,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel.yaml
@@ -1420,6 +1420,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1711,6 +1711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel.yaml
@@ -1420,6 +1420,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_nginx/golden/windows/otel_otlp_exporter.yaml
@@ -1711,6 +1711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -890,6 +890,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1166,6 +1166,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -859,6 +859,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/linux/otel_otlp_exporter.yaml
@@ -1120,6 +1120,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -943,6 +943,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1234,6 +1234,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -943,6 +943,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_syslog_type_multiple_receivers/golden/windows/otel_otlp_exporter.yaml
@@ -1234,6 +1234,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -810,6 +810,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1086,6 +1086,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-receiver_systemd/golden/linux/otel_otlp_exporter.yaml
@@ -1040,6 +1040,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux-gpu/otel.yaml
@@ -824,6 +824,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux-gpu/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux-gpu/otel_otlp_exporter.yaml
@@ -1100,6 +1100,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux/otel.yaml
@@ -793,6 +793,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/linux/otel_otlp_exporter.yaml
@@ -1054,6 +1054,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows-2012/otel.yaml
@@ -1195,6 +1195,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1486,6 +1486,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows/otel.yaml
@@ -1195,6 +1195,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/logging-otel-ruby_regex/golden/windows/otel_otlp_exporter.yaml
@@ -1486,6 +1486,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_exclude_logs_contains/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_modify_fields/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_order/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_json_and_parse_regex_types/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_journald_receiver/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_not_first/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_processor_not_in_use/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_languages/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_three_processors_same_language/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_languages/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_multiline_two_processors/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-processor_parse_regex_type_on_default_pipeline/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_apache_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchbase/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_couchdb/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_elasticsearch_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_log_file_path/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_refresh_interval/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_files_type_multiple_receivers/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_flink/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_conflicting_id/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_multiple_receivers_with_dot/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_forward_omitting_optional_parameters/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hadoop_refresh_interval/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_hbase/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_jetty/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_kafka_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mongodb/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_mysql_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_nginx_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_oracledb_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_postgresql_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_rabbitmq/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_redis_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_saphana_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_solr/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux-gpu/otel.yaml
@@ -678,6 +678,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/linux/otel.yaml
@@ -647,6 +647,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_syslog_type_multiple_receivers/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_systemd/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_duplicated_port_but_not_used/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tcp_omitting_optional_parameters/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_varnish/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_vault/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_wildfly/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/logging-receiver_zookeeper_custom/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-custom_log_level/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux-gpu/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-default_overrides_disable_all/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux-gpu/otel.yaml
@@ -1031,6 +1031,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/linux/otel.yaml
@@ -985,6 +985,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows-2012/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-exporter_prometheus_otlp/golden/windows/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux-gpu/otel.yaml
@@ -715,6 +715,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/linux/otel.yaml
@@ -715,6 +715,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows-2012/otel.yaml
@@ -1127,6 +1127,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_all_nvml_metrics_individually/golden/windows/otel.yaml
@@ -1127,6 +1127,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux-gpu/otel.yaml
@@ -743,6 +743,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_individual/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux-gpu/otel.yaml
@@ -745,6 +745,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/linux/otel.yaml
@@ -712,6 +712,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows-2012/otel.yaml
@@ -1118,6 +1118,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_by_prefixes/golden/windows/otel.yaml
@@ -1118,6 +1118,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux-gpu/otel.yaml
@@ -745,6 +745,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/linux/otel.yaml
@@ -712,6 +712,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows-2012/otel.yaml
@@ -1118,6 +1118,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_globs/golden/windows/otel.yaml
@@ -1118,6 +1118,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux-gpu/otel.yaml
@@ -743,6 +743,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_metrics_type_filter_with_special_chars/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux-gpu/otel.yaml
@@ -786,6 +786,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/linux/otel.yaml
@@ -753,6 +753,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows-2012/otel.yaml
@@ -1159,6 +1159,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_exclude_workload_metrics/golden/windows/otel.yaml
@@ -1159,6 +1159,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux-gpu/otel.yaml
@@ -767,6 +767,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/linux/otel.yaml
@@ -723,6 +723,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows-2012/otel.yaml
@@ -1051,6 +1051,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_three_exclude_metrics_processors_not_disable_nvml/golden/windows/otel.yaml
@@ -1051,6 +1051,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/linux/otel.yaml
@@ -717,6 +717,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows-2012/otel.yaml
@@ -1045,6 +1045,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-processor_two_exclude_metrics_processors/golden/windows/otel.yaml
@@ -1045,6 +1045,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux-gpu/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/linux/otel.yaml
@@ -705,6 +705,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows-2012/otel.yaml
@@ -1033,6 +1033,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver-no-collection_interval/golden/windows/otel.yaml
@@ -1033,6 +1033,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_activemq_no_jvm/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux-gpu/otel.yaml
@@ -783,6 +783,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/linux/otel.yaml
@@ -752,6 +752,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows-2012/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_aerospike/golden/windows/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux-gpu/otel.yaml
@@ -784,6 +784,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/linux/otel.yaml
@@ -753,6 +753,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows-2012/otel.yaml
@@ -1155,6 +1155,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache/golden/windows/otel.yaml
@@ -1155,6 +1155,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux-gpu/otel.yaml
@@ -784,6 +784,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/linux/otel.yaml
@@ -753,6 +753,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows-2012/otel.yaml
@@ -1155,6 +1155,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_apache_custom/golden/windows/otel.yaml
@@ -1155,6 +1155,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_cassandra_custom/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux-gpu/otel.yaml
@@ -885,6 +885,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/linux/otel.yaml
@@ -854,6 +854,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows-2012/otel.yaml
@@ -1256,6 +1256,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchbase/golden/windows/otel.yaml
@@ -1256,6 +1256,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_couchdb/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux-gpu/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/linux/otel.yaml
@@ -710,6 +710,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_custom_collection_interval/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux-gpu/otel.yaml
@@ -868,6 +868,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm/golden/linux/otel.yaml
@@ -837,6 +837,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux-gpu/otel.yaml
@@ -813,6 +813,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_dcgm_v2/golden/linux/otel.yaml
@@ -782,6 +782,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux-gpu/otel.yaml
@@ -815,6 +815,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/linux/otel.yaml
@@ -784,6 +784,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows-2012/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch/golden/windows/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux-gpu/otel.yaml
@@ -815,6 +815,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/linux/otel.yaml
@@ -784,6 +784,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows-2012/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_credentials/golden/windows/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux-gpu/otel.yaml
@@ -815,6 +815,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/linux/otel.yaml
@@ -784,6 +784,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows-2012/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_custom_endpoint_http/golden/windows/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux-gpu/otel.yaml
@@ -815,6 +815,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/linux/otel.yaml
@@ -784,6 +784,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows-2012/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_disable_cluster_metrics/golden/windows/otel.yaml
@@ -1186,6 +1186,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux-gpu/otel.yaml
@@ -837,6 +837,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/linux/otel.yaml
@@ -806,6 +806,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows-2012/otel.yaml
@@ -1208,6 +1208,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_no_jvm/golden/windows/otel.yaml
@@ -1208,6 +1208,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux-gpu/otel.yaml
@@ -817,6 +817,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/linux/otel.yaml
@@ -786,6 +786,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows-2012/otel.yaml
@@ -1188,6 +1188,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_elasticsearch_tls_credentials/golden/windows/otel.yaml
@@ -1188,6 +1188,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux-gpu/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_nvml_from_hostmetrics/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux-gpu/otel.yaml
@@ -743,6 +743,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_exclude_subset_of_nvml_metrics/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux-gpu/otel.yaml
@@ -807,6 +807,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/linux/otel.yaml
@@ -776,6 +776,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows-2012/otel.yaml
@@ -1178,6 +1178,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_flink/golden/windows/otel.yaml
@@ -1178,6 +1178,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hadoop_no_jvm/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux-gpu/otel.yaml
@@ -786,6 +786,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/linux/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows-2012/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase/golden/windows/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux-gpu/otel.yaml
@@ -786,6 +786,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/linux/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows-2012/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_hbase_no_jvm/golden/windows/otel.yaml
@@ -1157,6 +1157,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jetty_no_jvm/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_auth/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_jvm_with_endpoint/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux-gpu/otel.yaml
@@ -794,6 +794,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/linux/otel.yaml
@@ -763,6 +763,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows-2012/otel.yaml
@@ -1165,6 +1165,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka/golden/windows/otel.yaml
@@ -1165,6 +1165,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux-gpu/otel.yaml
@@ -794,6 +794,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/linux/otel.yaml
@@ -763,6 +763,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows-2012/otel.yaml
@@ -1165,6 +1165,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_kafka_no_jvm/golden/windows/otel.yaml
@@ -1165,6 +1165,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux-gpu/otel.yaml
@@ -782,6 +782,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/linux/otel.yaml
@@ -751,6 +751,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows-2012/otel.yaml
@@ -1153,6 +1153,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_memcached/golden/windows/otel.yaml
@@ -1153,6 +1153,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux-gpu/otel.yaml
@@ -781,6 +781,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/linux/otel.yaml
@@ -750,6 +750,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows-2012/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb/golden/windows/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mongodb_unix_socket/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux-gpu/otel.yaml
@@ -821,6 +821,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/linux/otel.yaml
@@ -790,6 +790,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows-2012/otel.yaml
@@ -1192,6 +1192,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql/golden/windows/otel.yaml
@@ -1192,6 +1192,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -821,6 +821,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/linux/otel.yaml
@@ -790,6 +790,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows-2012/otel.yaml
@@ -1192,6 +1192,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_mysql_missing_endpoint/golden/windows/otel.yaml
@@ -1192,6 +1192,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux-gpu/otel.yaml
@@ -775,6 +775,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/linux/otel.yaml
@@ -744,6 +744,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows-2012/otel.yaml
@@ -1146,6 +1146,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx/golden/windows/otel.yaml
@@ -1146,6 +1146,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux-gpu/otel.yaml
@@ -775,6 +775,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/linux/otel.yaml
@@ -744,6 +744,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows-2012/otel.yaml
@@ -1146,6 +1146,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_nginx_custom/golden/windows/otel.yaml
@@ -1146,6 +1146,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux-gpu/otel.yaml
@@ -797,6 +797,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/linux/otel.yaml
@@ -766,6 +766,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows-2012/otel.yaml
@@ -1168,6 +1168,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb/golden/windows/otel.yaml
@@ -1168,6 +1168,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux-gpu/otel.yaml
@@ -797,6 +797,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/linux/otel.yaml
@@ -766,6 +766,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows-2012/otel.yaml
@@ -1168,6 +1168,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_all_params/golden/windows/otel.yaml
@@ -1168,6 +1168,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux-gpu/otel.yaml
@@ -797,6 +797,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/linux/otel.yaml
@@ -766,6 +766,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows-2012/otel.yaml
@@ -1168,6 +1168,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_oracledb_unix_socket/golden/windows/otel.yaml
@@ -1168,6 +1168,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux-gpu/otel.yaml
@@ -783,6 +783,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 60s
     endpoint: var/run/postgresql/:5432

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/linux/otel.yaml
@@ -752,6 +752,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 60s
     endpoint: var/run/postgresql/:5432

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows-2012/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 60s
     endpoint: var/run/postgresql/:5432

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql/golden/windows/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 60s
     endpoint: var/run/postgresql/:5432

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux-gpu/otel.yaml
@@ -783,6 +783,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/linux/otel.yaml
@@ -752,6 +752,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows-2012/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls/golden/windows/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -783,6 +783,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/linux/otel.yaml
@@ -752,6 +752,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows-2012/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_no_sni/golden/windows/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -783,6 +783,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/linux/otel.yaml
@@ -752,6 +752,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows-2012/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_postgresql_tls_with_certs/golden/windows/otel.yaml
@@ -1154,6 +1154,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   postgresql/postgresql:
     collection_interval: 30s
     endpoint: localhost:3306

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_basic_auth/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_complex/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_default_replacement/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_multi_replacement_regex/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_node_exporter/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_relabel/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_replace_using_capture_groups/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_scrape_interval/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux-gpu/otel.yaml
@@ -755,6 +755,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/linux/otel.yaml
@@ -724,6 +724,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows-2012/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_prometheus_tlx_with_certs/golden/windows/otel.yaml
@@ -1126,6 +1126,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_no_sni/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_rabbitmq_tls_with_certs/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_redis_custom/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux-gpu/otel.yaml
@@ -781,6 +781,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/linux/otel.yaml
@@ -750,6 +750,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows-2012/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_saphana/golden/windows/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_solr/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux-gpu/otel.yaml
@@ -779,6 +779,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/linux/otel.yaml
@@ -748,6 +748,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows-2012/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_tomcat_custom/golden/windows/otel.yaml
@@ -1150,6 +1150,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux-gpu/otel.yaml
@@ -772,6 +772,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/linux/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows-2012/otel.yaml
@@ -1143,6 +1143,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_varnish/golden/windows/otel.yaml
@@ -1143,6 +1143,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux-gpu/otel.yaml
@@ -1448,6 +1448,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/linux/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows-2012/otel.yaml
@@ -1819,6 +1819,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault/golden/windows/otel.yaml
@@ -1819,6 +1819,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux-gpu/otel.yaml
@@ -1448,6 +1448,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/linux/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows-2012/otel.yaml
@@ -1819,6 +1819,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_tls/golden/windows/otel.yaml
@@ -1819,6 +1819,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux-gpu/otel.yaml
@@ -1448,6 +1448,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/linux/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows-2012/otel.yaml
@@ -1819,6 +1819,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_vault_with_token/golden/windows/otel.yaml
@@ -1819,6 +1819,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux-gpu/otel.yaml
@@ -781,6 +781,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/linux/otel.yaml
@@ -750,6 +750,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows-2012/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly/golden/windows/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux-gpu/otel.yaml
@@ -781,6 +781,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/linux/otel.yaml
@@ -750,6 +750,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows-2012/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_wildfly_with_host_port/golden/windows/otel.yaml
@@ -1152,6 +1152,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux-gpu/otel.yaml
@@ -772,6 +772,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/linux/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows-2012/otel.yaml
@@ -1143,6 +1143,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper/golden/windows/otel.yaml
@@ -1143,6 +1143,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux-gpu/otel.yaml
@@ -772,6 +772,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/linux/otel.yaml
@@ -741,6 +741,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows-2012/otel.yaml
@@ -1143,6 +1143,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/metrics-receiver_zookeeper_endpoint/golden/windows/otel.yaml
@@ -1143,6 +1143,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux-gpu/otel.yaml
@@ -1031,6 +1031,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/linux/otel.yaml
@@ -985,6 +985,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows-2012/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/test-otlp-exporter-only/golden/windows/otel.yaml
@@ -1417,6 +1417,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows-2012/otel.yaml
@@ -1097,6 +1097,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-backward_compatible_with_explicit_exporters/golden/windows/otel.yaml
@@ -1097,6 +1097,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-all-custom_use_built_in_receivers/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_iis/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows-2012/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_override_builtin/golden/windows/otel.yaml
@@ -731,6 +731,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows-2012/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-logging-use_ansi/golden/windows/otel.yaml
@@ -1112,6 +1112,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux-gpu/otel.yaml
@@ -743,6 +743,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_iis/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux-gpu/otel.yaml
@@ -743,6 +743,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/linux/otel.yaml
@@ -711,6 +711,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows-2012/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-default_overrides_disable_mssql/golden/windows/otel.yaml
@@ -1115,6 +1115,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows-2012/otel.yaml
@@ -1097,6 +1097,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-pipeline_multiple_pipelines/golden/windows/otel.yaml
@@ -1097,6 +1097,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows-2012/otel.yaml
@@ -1145,6 +1145,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_active_directory_ds/golden/windows/otel.yaml
@@ -1145,6 +1145,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows-2012/otel.yaml
@@ -1164,6 +1164,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_duplicate/golden/windows/otel.yaml
@@ -1164,6 +1164,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows-2012/otel.yaml
@@ -1121,6 +1121,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_iis_v2_override/golden/windows/otel.yaml
@@ -1121,6 +1121,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux-gpu/otel.yaml
@@ -777,6 +777,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/linux/otel.yaml
@@ -746,6 +746,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_jvm_missing_endpoint/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows-2012/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_duplicate/golden/windows/otel.yaml
@@ -1148,6 +1148,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows-2012/otel.yaml
@@ -1127,6 +1127,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-metrics-receiver_mssql_v2_override/golden/windows/otel.yaml
@@ -1127,6 +1127,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel.yaml
@@ -1631,6 +1631,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1922,6 +1922,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel.yaml
@@ -1631,6 +1631,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_new_channels/golden/windows/otel_otlp_exporter.yaml
@@ -1922,6 +1922,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel.yaml
@@ -1236,6 +1236,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows-2012/otel_otlp_exporter.yaml
@@ -1527,6 +1527,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel.yaml
@@ -1236,6 +1236,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:

--- a/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
+++ b/confgenerator/testdata/goldens/windows-otel-logging-receiver_winlog2_xml/golden/windows/otel_otlp_exporter.yaml
@@ -1527,6 +1527,7 @@ receivers:
     - feature_tracking_otlp.json
     poll_interval: 1m0s
     replay_file: true
+    start_at: beginning
   prometheus/agent_prometheus:
     config:
       scrape_configs:


### PR DESCRIPTION
## Description
Fixes `TestDefaultMetrics` flakiness on `master` (and related branches).
The `enabled_receivers_otlp.json` file is written once synchronously at agent startup. The OTel Collector `filelog` receiver tails this file, but without `start_at: beginning`, it defaults to tailing from the end. If the receiver boots up after the payload is fully written, it misses the metric definitions entirely, resulting in missing telemetry labels (`telemetry_type`, `receiver_type`). 

This PR explicitly sets `start_at: beginning` to close this timing race condition during fast startup.


## Related issue
b/548545924

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [X] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
