### PR TITLE
build: Temporarily remove _LOUHI_CHANGED_FILES during gcloud upload

### DIFF
--- a/kokoro/scripts/build/build.ps1
+++ b/kokoro/scripts/build/build.ps1
@@ -121,7 +121,15 @@ if ($env:_LOUHI_TAG_NAME -ne $null) {
   $target=$louhi_tag_components[3]
   $arch=$louhi_tag_components[4]
   $gcs_bucket="gs://${env:_STAGING_ARTIFACTS_PROJECT_ID}-ops-agent-releases/${ver}/${ref}/${target}/${arch}/"
+  # Temporarily remove _LOUHI_CHANGED_FILES to avoid breaking gcloud (Python) env var char limit
+  $cachedLouhiChangedFiles = $env:_LOUHI_CHANGED_FILES
+  Remove-Item -Path "Env:\_LOUHI_CHANGED_FILES" -ErrorAction SilentlyContinue
+
   gcloud storage cp "$env:KOKORO_ARTIFACTS_DIR/result/*.goo"  "${gcs_bucket}"
   gcloud storage cp "$env:KOKORO_ARTIFACTS_DIR/result/google-cloud-ops-agent-plugin*.tar.gz"  "${gcs_bucket}"
   gcloud storage cp "$env:KOKORO_ARTIFACTS_DIR/result/google-cloud-ops-agent-plugin-sha256.txt"  "${gcs_bucket}"
+
+  if ($cachedLouhiChangedFiles) {
+      $env:_LOUHI_CHANGED_FILES = $cachedLouhiChangedFiles
+  }
 }

--- a/kokoro/scripts/build/packaging/package.ps1
+++ b/kokoro/scripts/build/packaging/package.ps1
@@ -141,6 +141,10 @@ Write-Host "Copying artifacts to $GcsBucket"
 
 # Upload .goo files
 $GooFiles = Join-Path $OutputDir "*.goo"
+# Temporarily remove _LOUHI_CHANGED_FILES to avoid breaking gcloud (Python) env var char limit
+$cachedLouhiChangedFiles = $env:_LOUHI_CHANGED_FILES
+Remove-Item -Path "Env:\_LOUHI_CHANGED_FILES" -ErrorAction SilentlyContinue
+
 gcloud storage cp $GooFiles "$GcsBucket"
 
 # Upload tar.gz plugin files
@@ -150,5 +154,9 @@ gcloud storage cp $PluginTar "$GcsBucket"
 # Upload SHA256 text file
 $ShaFile = Join-Path $InputDir "result\google-cloud-ops-agent-plugin-sha256.txt"
 gcloud storage cp $ShaFile "$GcsBucket"
+
+if ($cachedLouhiChangedFiles) {
+    $env:_LOUHI_CHANGED_FILES = $cachedLouhiChangedFiles
+}
 
 Write-Host "Script finished successfully."


### PR DESCRIPTION
## Description
The Kokoro Windows pipeline fails during artifact upload when _LOUHI_CHANGED_FILES exceeds the 32767 char limit in Python. This commit temporarily clears the Env variable in PowerShell to avoid breaking gcloud.

## Related issue
b/550326277

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [X] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
