### PR TITLE
integration_test: add retry loop to fetchPIDAndProcessName to prevent UAP subagent startup race

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -843,7 +843,7 @@ func TestPluginGetStatusReturnsRPCErrorOnSubAgentTerminationWithNonZeroCode(t *t
 			t.Errorf("expected the plugin GetStatus() call to return an error, got nil")
 		}
 
-		pid, _, err := fetchPIDAndProcessName(ctx, logger, vm, []string{"fluent-bit"})
+		pid, _ := fetchPID(ctx, logger, vm, "fluent-bit")
 		if pid != "" {
 			t.Error("expected the plugin to terminate the other subagent when one crashes")
 		}
@@ -886,12 +886,14 @@ func TestKillChildJobsWhenPluginServerProcessTerminates(t *testing.T) {
 
 		time.Sleep(10 * time.Second)
 
-		pid, _, err := fetchPIDAndProcessName(ctx, logger, vm, metricsAgentProcessNamesForImage(vm.ImageSpec))
-		if pid != "" {
-			t.Error("expected the plugin to terminate otel subagent process when the parent gRPC server process terminates")
+		for _, pn := range metricsAgentProcessNamesForImage(vm.ImageSpec) {
+			pid, _ := fetchPID(ctx, logger, vm, pn)
+			if pid != "" {
+				t.Errorf("expected the plugin to terminate %s subagent process when the parent gRPC server process terminates", pn)
+			}
 		}
 
-		pid, err = fetchPID(ctx, logger, vm, "fluent-bit")
+		pid, _ := fetchPID(ctx, logger, vm, "fluent-bit")
 		if pid != "" {
 			t.Error("expected the plugin to terminate fluent-bit subagent process when the parent gRPC server process terminates")
 		}
@@ -4276,17 +4278,31 @@ func fetchPID(ctx context.Context, logger *log.Logger, vm *gce.VM, processName s
 }
 
 // fetchPIDAndProcessName returns the process ID and name of the first matching process from a given list of names on the given VM.
+// It retries for up to 30 seconds to allow asynchronously spawned subagents time to register in the process table.
 func fetchPIDAndProcessName(ctx context.Context, logger *log.Logger, vm *gce.VM, processNames []string) (string, string, error) {
-	var errors error
-	for _, pn := range processNames {
-		output, err := fetchPID(ctx, logger, vm, pn)
-		if err != nil {
-			errors = multierr.Append(errors, err)
-		} else {
-			return output, pn, nil
+	b := backoff.WithContext(
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 15),
+		ctx,
+	)
+	var output, matchedName string
+	err := backoff.Retry(func() error {
+		var errors error
+		for _, pn := range processNames {
+			out, err := fetchPID(ctx, logger, vm, pn)
+			if err != nil {
+				errors = multierr.Append(errors, err)
+			} else if out != "" {
+				output = out
+				matchedName = pn
+				return nil
+			}
 		}
+		return errors
+	}, b)
+	if err != nil {
+		return "", "", err
 	}
-	return "", "", errors
+	return output, matchedName, nil
 }
 
 func terminateProcess(ctx context.Context, logger *log.Logger, vm *gce.VM, processName string) error {


### PR DESCRIPTION



## Description
On Windows, UAP plugin starts subagent processes asynchronously inside a Job object. Retrying fetchPIDAndProcessName for up to 30 seconds allows the process to spawn and appear in the OS process table without failing immediately.

## Related issue
Fixes: b/551908579

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
