### PR TITLE
integration_test: add retry loop to GetStatus query in testWindowsStandaloneAgentConflict

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -4468,7 +4468,19 @@ func testWindowsStandaloneAgentConflict(t *testing.T, installStandalone func(ctx
 
 		// 3. Check the error log for a message about Ops Agent conflicting with standalone agent.
 		if gce.IsOpsAgentUAPPlugin() {
-			cmdOut, err := gce.RunRemotely(ctx, logger, vm, agents.GetUAPPluginStatusForImage(vm.ImageSpec))
+			var cmdOut gce.CommandOutput
+			b := backoff.WithContext(
+				backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 30),
+				ctx,
+			)
+			err := backoff.Retry(func() error {
+				out, err := gce.RunRemotely(ctx, logger, vm, agents.GetUAPPluginStatusForImage(vm.ImageSpec))
+				if err != nil {
+					return err
+				}
+				cmdOut = out
+				return nil
+			}, b)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
## Description
In UAP mode, start-uap-plugin-server.ps1 starts the plugin server asynchronously via Windows Task Scheduler. Adding a retry loop gives the background process time to bind port 1234 before grpcurl connects.

## Related issue
Fixes: b/551943932

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
