### PR TITLE
[chore] Update go version to 1.26.x in CI and Dockerfile.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: true
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.x
+        go-version: 1.26.x
         cache: true
     - run: |
         go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/pr_presubmit.yaml
+++ b/.github/workflows/pr_presubmit.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
         cache: true
 
     - id: files

--- a/dev-docs/upgrade-go.md
+++ b/dev-docs/upgrade-go.md
@@ -5,6 +5,7 @@ To upgrade the version of Go that the Ops Agent uses, update the version in the 
 * `go.mod` version restriction
 * The `GO_VERSION` arg in `dockerfiles/template-header`
 * `Dockerfile.windows` in the spot where it downloads and runs the Go MSI
+* The test runner container used in Kokoro tests, following the instructions at `go/sdi-integ-test#updating-the-test-runner-container`
 
 Once you have updated the Go version in the following places, verify the new version works:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/ops-agent
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/kokoro/scripts/test/go_test.Dockerfile
+++ b/kokoro/scripts/test/go_test.Dockerfile
@@ -14,7 +14,7 @@
 
 # To edit this file, follow these instructions: go/sdi-integ-test#updating-the-test-runner-container.
 
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 


### PR DESCRIPTION
## Description
Update go version to 1.26.x in CI and Dockerfile. Followup to https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/pull/625.

## Related issue
<!--- Add a link to the issue (follow the b/XXX format for internal issues) -->

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
