### PR TITLE
test(ops_agent_test): deflake TestFileOffset log verification

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5305,8 +5305,10 @@ func TestFileOffset(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Wait 1 min for all logs to be ingested after first start.
-		time.Sleep(1 * time.Minute)
+		// Wait for the first line to be ingested before stopping the agent.
+		if err := gce.WaitForLog(ctx, logger, vm, "files_1", time.Hour, `jsonPayload.message="first line"`); err != nil {
+			t.Fatalf("Failed waiting for initial log ingestion: %v", err)
+		}
 
 		if _, err := gce.RunRemotely(ctx, logger, vm, agents.StopCommandForImage(vm.ImageSpec)); err != nil {
 			t.Fatal(err)
@@ -5321,20 +5323,34 @@ func TestFileOffset(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Wait 1 min for logs to be ingested after restart.
-		time.Sleep(1 * time.Minute)
+		// Verify second log was ingested after restart.
+		if err := gce.WaitForLog(ctx, logger, vm, "files_1", time.Hour, `jsonPayload.message="second line"`); err != nil {
+			t.Fatalf("Failed waiting for log ingestion after restart: %v", err)
+		}
 
-		// We should only observe one instance of the "first line" log.
-		matchingLogs, err := gce.QueryAllLogs(ctx, logger, vm, "files_1", time.Hour, `jsonPayload.message="first line"`, gce.LogQueryMaxAttempts)
+		// We should only observe one instance of the "first line" log (offset was preserved).
+		// QueryAllLogs returns immediately on attempt 1 with an empty slice if err == nil (intended for AssertLogMissing).
+		// To account for Cloud Logging query index propagation, retry until at least one log is returned.
+		queryCtx, queryCancel := context.WithTimeout(ctx, 3*time.Minute)
+		defer queryCancel()
+
+		var matchingLogs []*cloudlogging.Entry
+		err := backoff.Retry(func() error {
+			var qErr error
+			matchingLogs, qErr = gce.QueryAllLogs(queryCtx, logger, vm, "files_1", time.Hour, `jsonPayload.message="first line"`, 1)
+			if qErr != nil {
+				return qErr
+			}
+			if len(matchingLogs) == 0 {
+				return errors.New("matching logs is empty")
+			}
+			return nil
+		}, backoff.WithContext(backoff.NewConstantBackOff(10*time.Second), queryCtx))
 		if err != nil {
-			t.Error(err)
+			logger.Printf("Failed waiting for 'first line' query matches: %v", err)
 		}
 		if len(matchingLogs) != 1 {
 			t.Errorf(`Expected to find exactly one instance of "first line" log in the backend. Found %d instances.`, len(matchingLogs))
-		}
-		// Verify second log was ingested.
-		if err := gce.WaitForLog(ctx, logger, vm, "files_1", time.Hour, `jsonPayload.message="second line"`); err != nil {
-			t.Error(err)
 		}
 	})
 }


### PR DESCRIPTION
## Description
In TestFileOffset, the test was sleeping for a fixed 1 minute before stopping the agent and checking log ingestion. When querying for the "first line" log count via QueryAllLogs, the query would occasionally return 0 entries due to Cloud Logging search index propagation delay, causing immediate test failure without retries.

This change:
1. Replaces the blind sleep before stopping the agent with WaitForLog to ensure "first line" is ingested before shutting down the agent.
2. Waits for "second line" immediately after restart to confirm agent resumption.
3. Retries QueryAllLogs until matches appear to tolerate Cloud Logging query indexing delays before asserting exactly 1 instance was received.

## Related issue
Fixes: b/557196420

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
