### PR TITLE
chore(deps): update gce-testing-internal to extend early-boot SSH transport retry window

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	buf.build/go/protoyaml v0.3.1
 	cloud.google.com/go/secretmanager v1.16.0
 	github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260904140452-23f028dc7797
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260905181209-a08a8acea05d
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0
 	go.opentelemetry.io/collector/pdata v1.48.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1v
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228 h1:K6GHKAI+PB91Fm+KEwX4q6s6xzZ/+BkOi8Kjxh0tJ6U=
 github.com/GoogleCloudPlatform/google-guest-agent v0.0.0-20250924181420-23412fbd6228/go.mod h1:31SvkAl6ORtir1odRpTl92XpTtn52GnBAHPtCKDSePo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260904140452-23f028dc7797 h1:QI6wOZCFdreLbNkMrEVSmbVv+/rXLC6V7rD5AstbJ7I=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260904140452-23f028dc7797/go.mod h1:w+hALN4HKl6g1hzn0eY8jBpOn2qNOoEtVrmnEyVyCHs=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260905181209-a08a8acea05d h1:3dozloDOwECdD/vWdo/moLjyr34r4DPVvm+p/j04mOs=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260905181209-a08a8acea05d/go.mod h1:To1auBRtiRCp5wQxkfEt+b2YlkXngNTfdofBwvqDd/o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 h1:l7+6kwRMJNwdCvYdDl7Eax+wzEYHSnNY7zrrfbhDdTA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0/go.mod h1:pJTkW8hEUIIi3Pf65lPZOnn4Y81yCllX6IWk2jNXdkM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 h1:owcC2UnmsZycprQ5RfRgjydWhuoxg71LUfyiQdijZuM=


### PR DESCRIPTION
## Description
Updates `github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal` to `v0.0.0-20260905181209-a08a8acea05d` (from GoogleCloudPlatform/opentelemetry-operations-collector#642).

### Background & Root Cause
In Ops Agent CI, early-boot SSH connection failures (`Connection refused` / `Connection reset by peer` / `kex_exchange_identification: read: Connection reset by peer`, exit code 255) were the single largest source of infrastructure test flakes (~31.6% of all CI flakes), concentrated on fast-booting ARM64 (Tau T2A) instances.
Empirical benchmarking across 330 VM initializations (`VM_initialization.txt`) spanning 17 Linux distribution targets revealed:
- **ARM64 instances boot 1.5x–2.1x faster than x86_64 instances** (`Boot -> SSH First OK` median is `20.0s–30.0s` on ARM64 vs `34.5s–51.0s` on x86_64).
- Because ARM64 reaches `systemctl is-system-running == "running"` in `20s–45s`, `SetupVM()` returns control to the test runner right as `google-guest-agent` executes its late-boot network manager handover (`nmcli conn reload`).
- This handover temporarily deactivates the primary interface (`ens4`) and renegotiates DHCP for **10s–16s** (max observed refusal window: `16.0s` on Ubuntu 22.04 ARM64 and `15.0s` on Debian 12 ARM64).
- Previously, `RunRemotelyStdin` retried SSH transport errors only 3 times at 3-second intervals (`~9.15s` total window), giving up 1–7 seconds before `ens4` and `sshd` finished reconnecting.

## Related issue
b/557287367

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [ ] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [ ] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [ ] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [ ] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
