### PR TITLE
test(ops_agent_test): add clock skew buffer to TestDisableSelfLogCollection startTime

### DIFF
--- a/integration_test/ops_agent_test/main_test.go
+++ b/integration_test/ops_agent_test/main_test.go
@@ -5009,7 +5009,8 @@ func TestDisableSelfLogCollection(t *testing.T) {
 
 		time.Sleep(2 * time.Minute)
 
-		startTime := time.Now()
+		// Subtract 10s to account for slight clock skew between the Kokoro runner and GCE VM.
+		startTime := time.Now().Add(-10 * time.Second)
 		if _, err := gce.RunRemotely(ctx, logger.ToMainLog(), vm, agents.StartCommandForImage(vm.ImageSpec)); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description
Adds a 10-second negative offset (`startTime := time.Now().Add(-10 * time.Second)`) to `startTime` in `TestDisableSelfLogCollection` to prevent 1–2s clock skew between the Kokoro runner and fast-booting ARM64 GCE VMs from dropping the startup `ops-agent-health` log.
### Root Cause
In #2415, `TestDisableSelfLogCollection` was updated to anchor the `WaitForLog` query filter to `startTime := time.Now()` (evaluated on the Kokoro runner immediately before restarting the Ops Agent). On fast-booting ARM64 GCE instances (e.g., `rockylinux10-aarch64`), a 1–2 second clock skew where the VM clock is slightly behind the Kokoro runner clock causes the initial `ops-agent-health` log timestamp to be 1–2s earlier than `startTime`. As a result, the `timestamp >= startTime` query filter excludes the log and times out after 3 minutes (`QUERY_LOG_TIMEOUT`).

### Why `-10s` is Safe Against Cross-Session Log Leakage
Immediately before capturing `startTime`, the test stops the first Ops Agent session and executes a `time.Sleep(2 * time.Minute)` (120 seconds) while the agent is completely stopped. Subtracting 10 seconds from `startTime` still leaves a **110-second gap** after the first session stopped during which no `ops-agent-health` logs were emitted, making cross-session log contamination impossible while comfortably absorbing any runner-to-VM clock skew.

## Related issue
Bug: b/555828971

## How has this been tested?
<!--- Please describe how you tested the changes besides the automatically triggered unit tests when applicable. -->
<!--- Must include sample output logs or metrics and/or screenshots of key results when applicable. -->

## Checklist:
- Unit tests
  - [X] Unit tests do not apply.
  - [ ] Unit tests have been added/modified and passed for this PR.
- Integration tests
  - [ ] Integration tests do not apply.
  - [X] Integration tests have been added/modified and passed for this PR.
- Documentation
  - [X] This PR introduces no user visible changes.
  - [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- Minor version bump
  - [X] This PR introduces no new features.
  - [ ] This PR introduces new features, and there is a separate PR to bump the [minor version](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION) since the last [release](https://github.com/GoogleCloudPlatform/ops-agent/releases) already.
  - [ ] This PR bumps the version.

<!--- To edit this template, go to https://github.com/GoogleCloudPlatform/ops-agent/edit/master/.github/PULL_REQUEST_TEMPLATE.md -->
