### PR TITLE
dockerfiles: build el10 packages on Rocky Linux 10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,10 +285,14 @@ COPY --from=rockylinux9-build /google-cloud-ops-agent-plugin*.tar.gz /
 # Build Ops Agent for rockylinux-10
 # ======================================
 
-FROM rockylinux/rockylinux:10 AS rockylinux10-build-base
+FROM rockylinux/rockylinux:10.0 AS rockylinux10-build-base
 ARG OPENJDK_MAJOR_VERSION
 
-RUN set -x; dnf -y update && \
+RUN set -x; \
+		sed -i -e 's|^mirrorlist=|#mirrorlist=|' \
+		  -e 's|^#baseurl=http://dl.rockylinux.org/$contentdir/$releasever|baseurl=https://dl.rockylinux.org/vault/rocky/10.0|' \
+		  /etc/yum.repos.d/rocky*.repo && \
+		dnf -y update && \
 		dnf -y install 'dnf-command(config-manager)' && \
 		dnf config-manager --set-enabled crb && \
 		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -105,6 +105,10 @@ var dockerfileArguments = []templateArguments{
 		// Build against the oldest supported EL10 minor (10.0, OpenSSL 3.2).
 		// RHEL 10.1+ rebased OpenSSL to 3.5; binaries built there depend on
 		// OPENSSL_3.4.0 symbol versions that RHEL 10.0 (EUS) does not provide.
+		// Rocky mirrors only serve the latest 10.x, so the repos below are
+		// pointed at the 10.0 vault; pinning the image tag alone is not enough.
+		// TODO: b/558217946 - Revisit the 10.0 pin once fluent-bit no longer
+		// needs OpenSSL 3.4 symbols or RHEL 10.0 EUS is out of support.
 		from_image:  "rockylinux/rockylinux:10.0",
 		target_name: "rockylinux10",
 		install_packages: `RUN set -x; \

--- a/dockerfiles/compile.go
+++ b/dockerfiles/compile.go
@@ -102,9 +102,16 @@ var dockerfileArguments = []templateArguments{
 		package_extension: "rpm",
 	},
 	{
-		from_image:  "rockylinux/rockylinux:10",
+		// Build against the oldest supported EL10 minor (10.0, OpenSSL 3.2).
+		// RHEL 10.1+ rebased OpenSSL to 3.5; binaries built there depend on
+		// OPENSSL_3.4.0 symbol versions that RHEL 10.0 (EUS) does not provide.
+		from_image:  "rockylinux/rockylinux:10.0",
 		target_name: "rockylinux10",
-		install_packages: `RUN set -x; dnf -y update && \
+		install_packages: `RUN set -x; \
+		sed -i -e 's|^mirrorlist=|#mirrorlist=|' \
+		  -e 's|^#baseurl=http://dl.rockylinux.org/$contentdir/$releasever|baseurl=https://dl.rockylinux.org/vault/rocky/10.0|' \
+		  /etc/yum.repos.d/rocky*.repo && \
+		dnf -y update && \
 		dnf -y install 'dnf-command(config-manager)' && \
 		dnf config-manager --set-enabled crb && \
 		dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \


### PR DESCRIPTION
## Description
The `rockylinux10` build target uses `rockylinux/rockylinux:10` and runs `dnf -y update`,
so it now builds on Rocky 10.2 with OpenSSL 3.5. fluent-bit calls `EVP_MD_CTX_size()`,
which OpenSSL 3.4+ headers define as `EVP_MD_CTX_get_size_ex`, a 3.4-only exported
symbol. Every el10 RPM published since 2.64.0 therefore requires
`libcrypto.so.3(OPENSSL_3.4.0)(64bit)`.

RHEL 10.0 (EUS) ships OpenSSL 3.2.2, which does not provide that symbol version, so on
those hosts `dnf update` fails:

```
Problem: package google-cloud-ops-agent-2.70.0-1.el10.x86_64 from @System requires
libcrypto.so.3(OPENSSL_3.4.0)(64bit), but none of the providers can be installed
```

RHEL 10 rebased OpenSSL from 3.2 to 3.5 in 10.1 (RHEL 9 never rebased it, which is why
the same pattern has been fine for el9). This change pins the el10 build to Rocky 10.0
with its repos pointed at the 10.0 vault, so el10 packages are built against the oldest
supported EL10 minor. `Dockerfile` is regenerated with `go run ./dockerfiles`.

## Related issue
b/558217946

## How has this been tested?
Built the `rockylinux10-build` target locally from this branch with `docker buildx`. The
container resolved `openssl-devel-3.2.2-16.el10_0.4` from the 10.0 vault and produced
`google-cloud-ops-agent-2.71.0-1.el10.x86_64.rpm` with:

```
$ rpm -qp --requires google-cloud-ops-agent-2.71.0-1.el10.x86_64.rpm | grep -i "libcrypto\|libssl"
libcrypto.so.3(OPENSSL_3.0.0)(64bit)
libcrypto.so.3()(64bit)
libssl.so.3(OPENSSL_3.0.0)(64bit)
libssl.so.3()(64bit)
```

Installed that RPM on fresh GCE VMs:

| Image | openssl-libs | install | openssl downgraded? | `dnf check` | `dnf update --assumeno` | agent |
|---|---|---|---|---|---|---|
| rhel-10-0-eus-lvm-v20260811 (10.0) | 3.2.2-16.el10_0.6 | OK | no | clean | resolves (31 upgrades) | active, logs delivered |
| rhel-10-v20260908 (10.2) | 3.5.5-6.el10_2 | OK | no | clean | resolves | active, logs delivered |

`readelf -V` on the built fluent-bit shows only the `OPENSSL_3.0.0` version node and
`ldd -r` reports no unresolved symbols. For comparison, the published 2.70.0-1.el10 on the
same 10.0 EUS image fails `dnf update` with the solver error above, and `ldd -r` reports
`undefined symbol: EVP_MD_CTX_get_size_ex, version OPENSSL_3.4.0`.

`gofmt`, `go vet ./dockerfiles/`, `go test ./dockerfiles/`, `make lint` and `make test`
pass on the branch.

## Checklist:
- Unit tests
  - [x] Unit tests do not apply.
- Integration tests
  - [x] Integration tests do not apply.
- Documentation
  - [x] This PR introduces no user visible changes.
- Minor version bump
  - [x] This PR introduces no new features.
