### PR TITLE
[Testing] Update NVIDIA driver pinning to 595 and CUDA toolkit to 13.2 for Ubuntu/Debian

### DIFF
--- a/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgm/debian_ubuntu/install
@@ -81,9 +81,9 @@ else
                 # cuda-12-6 is the latest version that supports Debian 11
                 sudo apt -y install cuda-12-6
             else
-                sudo apt -y install nvidia-driver-pinning-590.48.01
+                sudo apt -y install nvidia-driver-pinning-595
                 sudo apt -y install cuda-drivers
-                sudo apt -y install cuda-toolkit-13-1
+                sudo apt -y install cuda-toolkit-13-2
             fi
             ;;
     esac

--- a/integration_test/third_party_apps_test/applications/dcgmv1/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/dcgmv1/debian_ubuntu/install
@@ -80,9 +80,9 @@ else
                 # cuda-12-6 is the latest version that supports Debian 11
                 sudo apt -y install cuda-12-6
             else
-                sudo apt -y install nvidia-driver-pinning-590.48.01
+                sudo apt -y install nvidia-driver-pinning-595
                 sudo apt -y install cuda-drivers
-                sudo apt -y install cuda-toolkit-13-1
+                sudo apt -y install cuda-toolkit-13-2
             fi
             ;;
     esac

--- a/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
+++ b/integration_test/third_party_apps_test/applications/nvml/debian_ubuntu/install
@@ -86,9 +86,9 @@ case $DEVICE_CODE in
             # cuda-12-6 is the latest version that supports Debian 11
             sudo apt -y install cuda-12-6
         else
-            sudo apt -y install nvidia-driver-pinning-590.48.01
+            sudo apt -y install nvidia-driver-pinning-595
             sudo apt -y install cuda-drivers
-            sudo apt -y install cuda-toolkit-13-1
+            sudo apt -y install cuda-toolkit-13-2
         fi
         ;;
 esac


### PR DESCRIPTION
## Description

The latest Ubuntu 24.04 image (`ubuntu-2404-noble-amd64-v20260906`) upgraded the GCP kernel to `7.0.0-1011-gcp`. The previously pinned NVIDIA driver (`nvidia-driver-pinning-590.48.01`) fails DKMS module compilation against this kernel with:
```
ERROR: Kernel configuration is invalid.
include/generated/autoconf.h or include/config/auto.conf are missing.
Run 'make oldconfig && make prepare' on kernel src to fix it.
```
This is a known issue where NVIDIA driver series 590 DKMS source does not support Linux kernel 7.0+.

Updating the driver pinning to `nvidia-driver-pinning-595` (which installs driver 595.91.07+ with Linux kernel 7.0+ compatibility) and updating CUDA toolkit to `cuda-toolkit-13-2` across Debian/Ubuntu third-party app test install scripts (`dcgm`, `dcgmv1`, `nvml`) resolves the DKMS build failure.

## Related issue

b/559883082 http://b/559883082

## How has this been tested?

Modifying `integration_test/third_party_apps_test/applications/{dcgm,dcgmv1,nvml}` marks these applications as `impactedApps` in `main_test.go`, which enables them to run under `-test.short` in the `noble_x86_64` Kokoro GitHub presubmit suite.

## Checklist:

- [x] Unit tests do not apply.
- [ ] Unit tests have been added/modified and passed for this PR.
- [ ] Integration tests do not apply.
- [x] Integration tests have been added/modified and passed for this PR.
- [x] This PR introduces no user visible changes.
- [ ] This PR introduces user visible changes and the corresponding documentation change has been made.
- [x] This PR introduces no new features.
- [ ] This PR introduces new features, and there is a separate PR to bump the minor version https://github.com/GoogleCloudPlatform/ops-agent/blob/master/VERSION since the last release https://github.com/GoogleCloudPlatform/ops-agent/releases already.
- [ ] This PR bumps the version.
